### PR TITLE
Documentation + doctest update for rules

### DIFF
--- a/hgp_lib/rules/literals.py
+++ b/hgp_lib/rules/literals.py
@@ -31,16 +31,18 @@ class Literal(Rule):
 
     def evaluate(self, data):
         """
-        Evaluates this literal on the given data array.
+        Evaluates this literal on the given data array, based on the `self.value` feature.
 
         Args:
-            data: A 2D array where each column represents a feature.
+            data (np.ndarray):
+                Input data passed to subrules. Must be a 2D ndarray, with instances on rows and features on columns.
+                Not checked at runtime for performance reasons.
 
         Returns:
-            xp.ndarray: Boolean array corresponding to this literal’s value
-                        (negated if `self.negated` is True).
+            np.ndarray:
+                The boolean result of evaluating this rule vectorized across all instances.
 
-        Example:
+        Examples:
             >>> import torch
             >>> data = torch.tensor([[True, False], [False, True]])
             >>> Literal(value=0).evaluate(data)

--- a/hgp_lib/rules/low_memory_operators.py
+++ b/hgp_lib/rules/low_memory_operators.py
@@ -8,23 +8,22 @@ from .rules import Rule
 
 class And(Rule):
     """
-    Logical conjunction (`AND`) operator node for rule trees.
-
-    The `And` class represents the logical AND operation. It evaluates to `True` only if every subrule evaluates to
+    Logical conjunction (`AND`) operator node for rule trees. It evaluates to `True` only if every subrule evaluates to
     `True`.
 
     Attributes:
         subrules (List[Rule]):
-            A list of child rules combined with logical AND. Must be a list longer than 1 element, but this is
-            not checked at runtime.
+            A list of child rules combined with logical AND. Must be a list longer than 1 element. Not checked at
+            runtime for performance reasons. Default: `None`.
         parent (Optional[Rule]):
-            A reference to the parent rule, if part of a larger tree.
+            A reference to the parent rule, if part of a larger tree. Default: `None`.
         value (None):
-            Always `None` for operator nodes (non-literals).
+            Always `None` for operator nodes (non-literals). Not checked at runtime for performance reasons. Default:
+            `None`.
         negated (bool):
-            Whether the entire conjunction is logically negated (`~And(...)`).
+            Whether the entire conjunction is logically negated (`~And(...)`). Default: `False`.
 
-    Example:
+    Examples:
         >>> from hgp_lib.rules.low_memory_operators import And, Or
         >>> from hgp_lib.rules import Literal
         >>> rule = And([
@@ -36,29 +35,35 @@ class And(Rule):
         And(0, Or(~1, 2), 3)
     """
 
-    def evaluate(self, data):
+    def evaluate(self, data: np.ndarray) -> np.ndarray:
         """
-        Evaluates this `And` rule against input data or context.
-
         All subrules are recursively evaluated, and their results are combined using logical conjunction. The final
         result is optionally negated if `self.negated` is `True`.
 
         Args:
             data (np.ndarray):
-                Input data passed to subrules, a matrix of instances and features.
+                Input data passed to subrules. Must be a 2D ndarray, with instances on rows and features on columns.
+                Not checked at runtime for performance reasons.
 
         Returns:
             np.ndarray:
-                The logical AND of all subrule evaluations, optionally negated.
+                The boolean result of evaluating this rule vectorized across all instances.
 
-        Example:
+        Examples:
             >>> from hgp_lib.rules.low_memory_operators import And
             >>> from hgp_lib.rules import Literal
             >>> import numpy as np
-            >>> data = np.array([True, False, True])
+            >>> data = np.array([
+            ...     [True, False],
+            ...     [False, False],
+            ...     [False, False]
+            ... ])
             >>> rule = And([Literal(value=0), Literal(value=1, negated=True)])
             >>> rule.evaluate(data)
-            array([False,  True, False])
+            array([ True, False, False])
+
+        Notes:
+            This implementation is efficient and allocates as little memory as possible.
         """
         rez = self.subrules[0].evaluate(data)
         if self.subrules[0].value is not None and not self.subrules[0].negated:
@@ -72,22 +77,21 @@ class And(Rule):
 
 class Or(Rule):
     """
-    Logical disjunction (`OR`) operator node for rule trees.
-
-    The `Or` class represents a logical OR operation. It evaluates to `True` if any subrule evaluates to `True`.
+    Logical disjunction (`OR`) operator node for rule trees. It evaluates to `True` if any subrule evaluates to `True`.
 
     Attributes:
         subrules (List[Rule]):
-            A list of child rules combined with logical OR.  Must be a list longer than 1 element, but this is
-            not checked at runtime.
+            A list of child rules combined with logical AND. Must be a list longer than 1 element. Not checked at
+            runtime for performance reasons. Default: `None`.
         parent (Optional[Rule]):
-            A reference to the parent rule, if part of a larger tree.
+            A reference to the parent rule, if part of a larger tree. Default: `None`.
         value (None):
-            Always `None` for operator nodes (non-literals).
+            Always `None` for operator nodes (non-literals). Not checked at runtime for performance reasons. Default:
+            `None`.
         negated (bool):
-            Whether the entire disjunction is logically negated (`~Or(...)`).
+            Whether the entire conjunction is logically negated (`~And(...)`). Default: `False`.
 
-    Example:
+    Examples:
         >>> from hgp_lib.rules.low_memory_operators import And
         >>> from hgp_lib.rules import Literal
         >>> rule = Or([Literal(value=0), Literal(value=1, negated=True)])
@@ -95,29 +99,34 @@ class Or(Rule):
         Or(0, ~1)
     """
 
-    def evaluate(self, data):
+    def evaluate(self, data: np.ndarray) -> np.ndarray:
         """
-        Evaluates this `Or` rule against input data or context.
-
         All subrules are recursively evaluated, and their results are combined using logical disjunction. The final
         result is optionally negated if `self.negated` is `True`.
 
         Args:
             data (np.ndarray):
-                Input data passed to subrules, a matrix of instances and features.
+                Input data passed to subrules. Must be a 2D ndarray, with instances on rows and features on columns.
+                Not checked at runtime for performance reasons.
 
         Returns:
             np.ndarray:
-                The logical OR of all subrule evaluations, optionally negated.
+                The boolean result of evaluating this rule vectorized across all instances.
 
-        Example:
+        Examples:
             >>> from hgp_lib.rules.low_memory_operators import And
             >>> from hgp_lib.rules import Literal
             >>> import numpy as np
-            >>> data = np.array([True, False, True])
-            >>> rule = And([Literal(value=0), Literal(value=1, negated=True)])
+            >>> data = np.array([
+            ...     [True, False, True],
+            ...     [False, False, True]
+            ... ])
+            >>> rule = Or([Literal(value=0), Literal(value=1)])
             >>> rule.evaluate(data)
-            array([False,  True, False])
+            array([ True, False])
+
+        Notes:
+            This implementation is efficient and allocates as little memory as possible.
         """
         rez = self.subrules[0].evaluate(data)
         if self.subrules[0].value is not None and not self.subrules[0].negated:

--- a/hgp_lib/rules/operators.py
+++ b/hgp_lib/rules/operators.py
@@ -3,11 +3,65 @@ import numpy as np
 from .rules import Rule
 
 
-# TODO: Write documentation and add doctests
-
-
 class And(Rule):
-    def evaluate(self, data):
+    """
+    Logical conjunction (`AND`) operator node for rule trees. It evaluates to `True` only if every subrule evaluates to
+    `True`.
+
+    Attributes:
+        subrules (List[Rule]):
+            A list of child rules combined with logical AND. Must be a list longer than 1 element. Not checked at
+            runtime for performance reasons. Default: `None`.
+        parent (Optional[Rule]):
+            A reference to the parent rule, if part of a larger tree. Default: `None`.
+        value (None):
+            Always `None` for operator nodes (non-literals). Not checked at runtime for performance reasons. Default:
+            `None`.
+        negated (bool):
+            Whether the entire conjunction is logically negated (`~And(...)`). Default: `False`.
+
+    Examples:
+        >>> from hgp_lib.rules.operators import And, Or
+        >>> from hgp_lib.rules import Literal
+        >>> rule = And([
+        ...     Literal(value=0),
+        ...     Or([Literal(value=1, negated=True), Literal(value=2)]),
+        ...     Literal(value=3)
+        ... ])
+        >>> rule
+        And(0, Or(~1, 2), 3)
+    """
+
+    def evaluate(self, data: np.ndarray) -> np.ndarray:
+        """
+        All subrules are recursively evaluated, and their results are combined using logical conjunction. The final
+        result is optionally negated if `self.negated` is `True`.
+
+        Args:
+            data (np.ndarray):
+                Input data passed to subrules. Must be a 2D ndarray, with instances on rows and features on columns.
+                Not checked at runtime for performance reasons.
+
+        Returns:
+            np.ndarray:
+                The boolean result of evaluating this rule vectorized across all instances.
+
+        Examples:
+            >>> from hgp_lib.rules.operators import And
+            >>> from hgp_lib.rules import Literal
+            >>> import numpy as np
+            >>> data = np.array([
+            ...     [True, False],
+            ...     [False, False],
+            ...     [False, False]
+            ... ])
+            >>> rule = And([Literal(value=0), Literal(value=1, negated=True)])
+            >>> rule.evaluate(data)
+            array([ True, False, False])
+
+        Notes:
+            This implementation does as few operations as possible, at the expense of more memory usage.
+        """
         cols = []
         neg_mask = []
         sub_operators = []
@@ -34,7 +88,58 @@ class And(Rule):
 
 
 class Or(Rule):
-    def evaluate(self, data):
+    """
+    Logical disjunction (`OR`) operator node for rule trees. It evaluates to `True` if any subrule evaluates to `True`.
+
+    Attributes:
+        subrules (List[Rule]):
+            A list of child rules combined with logical AND. Must be a list longer than 1 element. Not checked at
+            runtime for performance reasons. Default: `None`.
+        parent (Optional[Rule]):
+            A reference to the parent rule, if part of a larger tree. Default: `None`.
+        value (None):
+            Always `None` for operator nodes (non-literals). Not checked at runtime for performance reasons. Default:
+            `None`.
+        negated (bool):
+            Whether the entire conjunction is logically negated (`~And(...)`). Default: `False`.
+
+    Examples:
+        >>> from hgp_lib.rules.operators import And
+        >>> from hgp_lib.rules import Literal
+        >>> rule = Or([Literal(value=0), Literal(value=1, negated=True)])
+        >>> rule
+        Or(0, ~1)
+    """
+
+    def evaluate(self, data: np.ndarray) -> np.ndarray:
+        """
+        All subrules are recursively evaluated, and their results are combined using logical disjunction. The final
+        result is optionally negated if `self.negated` is `True`.
+
+        Args:
+            data (np.ndarray):
+                Input data passed to subrules. Must be a 2D ndarray, with instances on rows and features on columns.
+                Not checked at runtime for performance reasons.
+
+        Returns:
+            np.ndarray:
+                The boolean result of evaluating this rule vectorized across all instances.
+
+        Examples:
+            >>> from hgp_lib.rules.operators import And
+            >>> from hgp_lib.rules import Literal
+            >>> import numpy as np
+            >>> data = np.array([
+            ...     [True, False, True],
+            ...     [False, False, True]
+            ... ])
+            >>> rule = Or([Literal(value=0), Literal(value=1)])
+            >>> rule.evaluate(data)
+            array([ True, False])
+
+        Notes:
+            This implementation does as few operations as possible, at the expense of more memory usage.
+        """
         cols = []
         neg_mask = []
         sub_operators = []

--- a/hgp_lib/rules/rules.py
+++ b/hgp_lib/rules/rules.py
@@ -2,6 +2,8 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional
 
+import numpy as np
+
 
 class Rule(ABC):
     """
@@ -28,7 +30,7 @@ class Rule(ABC):
         - `__slots__` are used for performance optimization to reduce memory overhead.
         - No runtime validation is performed for speed; incorrect usage may cause undefined behavior.
 
-    Example:
+    Examples:
         >>> from hgp_lib.rules import And, Or, Literal
         >>> rule = And([
         ...     Literal(value=0),
@@ -136,15 +138,16 @@ class Rule(ABC):
         return self.__class__(self.subrules, self.parent if parent is None else parent, self.value, self.negated)
 
     @abstractmethod
-    def evaluate(self, data):
+    def evaluate(self, data: np.ndarray) -> np.ndarray:
         """
-        Abstract method to evaluate this rule against a given context.
+        Abstract method to evaluate this rule against the given data, in a vectorized manner.
 
         Args:
-            data: The input data or environment against which the rule is evaluated.
+            data (np.ndarray): The input data. Must be a 2D ndarray, with instances on rows and features on columns.
 
         Returns:
-            bool: The result of evaluating this rule.
+            np.ndarray:
+                The boolean result of evaluating this rule vectorized across all instances.
 
         Notes:
             Concrete subclasses (`And`, `Or`, `Literal`, etc.) must implement this.

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -178,10 +178,13 @@ class TestRules(unittest.TestCase):
         self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
         result = doctest.testmod(hgp_lib.rules.literals, verbose=False)
         self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+        result = doctest.testmod(hgp_lib.rules.operators, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+        result = doctest.testmod(hgp_lib.rules.low_memory_operators, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
 
 
 if __name__ == "__main__":
     unittest.main()
     # TODO: Add performance test that should execute both operator types and measure
     # Use np.testing.measure
-


### PR DESCRIPTION
* Added explicit `np.ndarray` type to Rule.evaluate
* Replaced docstring Example: with Examples:, using the Google docstring standard.
* Updated the docstring for the low_memory_operators. Removed irrelevant information and added notes about implementation and missing runtime checks.
* Added documentation for the operators (docstring is similar to low_memory_operators).
* Added doctests to the unittest module