### PR TITLE
Extended support for multiple `score_fn` + added performance script for PaySim

### DIFF
--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -36,6 +36,72 @@ class ValidatePopulationMetrics(TypedDict):
 
 
 class BooleanGP:
+    """
+    Boolean Genetic Programming algorithm for evolving rule-based classifiers.
+
+    This class implements a genetic programming algorithm that evolves a population of
+    boolean rules to optimize a fitness function. Each generation applies crossover and
+    mutation operations, evaluates the population, and selects the best individuals.
+
+    The algorithm tracks both the current best rule (best in the current run) and the
+    real best rule (all-time best across regenerations). When enabled, regeneration
+    resets the population if no improvement is observed for a specified number of epochs.
+
+    Args:
+        score_fn (Callable[[ndarray, ndarray], float]):
+            Function that computes fitness scores. Signature: `score_fn(predictions, labels) -> float`.
+            Higher scores indicate better fitness. Must accept boolean predictions and integer labels.
+        population_generator (PopulationGenerator):
+            Generator that creates the initial population of rules.
+        mutation_executor (MutationExecutor):
+            Executor that applies mutations to the population.
+        crossover_executor (CrossoverExecutor | None, optional):
+            Executor that applies crossover operations. If `None`, a default `CrossoverExecutor`
+            is created. Default: `None`.
+        selection (BaseSelection | None, optional):
+            Selection strategy for choosing individuals for the next generation. If `None`,
+            a default `RouletteSelection` is created. Default: `None`.
+        regeneration (bool, optional):
+            Whether to regenerate the population when no improvement is observed.
+            Default: `False`.
+        regeneration_patience (int, optional):
+            Number of epochs without improvement before regenerating the population.
+            Must be positive when `regeneration=True`. Default: `100`.
+
+    Examples:
+        >>> import numpy as np
+        >>> from hgp_lib.algorithms import BooleanGP
+        >>> from hgp_lib.mutations import (
+        ...     MutationExecutor, create_standard_literal_mutations, create_standard_operator_mutations
+        ... )
+        >>> from hgp_lib.populations import PopulationGenerator, RandomStrategy
+        >>> from hgp_lib.rules import Literal
+        >>>
+        >>> def accuracy(predictions, labels):
+        ...     return np.mean(predictions == labels)
+        >>>
+        >>> generator = PopulationGenerator(
+        ...     strategies=[RandomStrategy(num_literals=4)],
+        ...     population_size=10
+        ... )
+        >>> mutation_executor = MutationExecutor(
+        ...     literal_mutations=create_standard_literal_mutations(4),
+        ...     operator_mutations=create_standard_operator_mutations(4)
+        ... )
+        >>>
+        >>> gp = BooleanGP(
+        ...     score_fn=accuracy,
+        ...     population_generator=generator,
+        ...     mutation_executor=mutation_executor
+        ... )
+        >>>
+        >>> train_data = np.array([[True, False, True, False], [False, True, False, True]])
+        >>> train_labels = np.array([1, 0])
+        >>> metrics = gp.step(train_data, train_labels)
+        >>> metrics['epoch']
+        0
+    """
+
     def __init__(
         self,
         score_fn: Callable[[ndarray, ndarray], float],
@@ -83,6 +149,67 @@ class BooleanGP:
         self._epoch = -1
 
     def step(self, train_data: ndarray, train_labels: ndarray) -> StepMetrics:
+        """
+        Performs one training step (generation) of the genetic programming algorithm.
+
+        Each step applies crossover to create offspring, mutates the population,
+        evaluates all rules, updates the best rule, and selects individuals for
+        the next generation. If regeneration is enabled and no improvement has
+        been observed for `regeneration_patience` epochs, the population is
+        regenerated.
+
+        Args:
+            train_data (ndarray):
+                Training data as a 2D boolean array with instances on rows and features on columns.
+            train_labels (ndarray):
+                Training labels as a 1D integer array (0 or 1 for binary classification).
+
+        Returns:
+            StepMetrics: Dictionary containing:
+                - `best` (float): Best fitness score in current run.
+                - `best_rule` (Rule): Best rule in current run.
+                - `real_best` (float): All-time best fitness score.
+                - `real_best_rule` (Rule): All-time best rule.
+                - `current_best` (float): Best score in current generation.
+                - `population_scores` (ndarray): Fitness scores for all rules.
+                - `epoch` (int): Current epoch number (0-indexed).
+                - `best_not_improved_epochs` (int): Epochs since last improvement.
+                - `regenerated` (bool): Whether population was regenerated this step.
+
+        Examples:
+            >>> import numpy as np
+            >>> from hgp_lib.algorithms import BooleanGP
+            >>> from hgp_lib.mutations import (
+            ...     MutationExecutor, create_standard_literal_mutations, create_standard_operator_mutations
+            ... )
+            >>> from hgp_lib.populations import PopulationGenerator, RandomStrategy
+            >>>
+            >>> def accuracy(predictions, labels):
+            ...     return np.mean(predictions == labels)
+            >>>
+            >>> generator = PopulationGenerator(
+            ...     strategies=[RandomStrategy(num_literals=4)],
+            ...     population_size=5
+            ... )
+            >>> mutation_executor = MutationExecutor(
+            ...     literal_mutations=create_standard_literal_mutations(4),
+            ...     operator_mutations=create_standard_operator_mutations(4)
+            ... )
+            >>>
+            >>> gp = BooleanGP(
+            ...     score_fn=accuracy,
+            ...     population_generator=generator,
+            ...     mutation_executor=mutation_executor
+            ... )
+            >>>
+            >>> train_data = np.array([[True, False, True, False], [False, True, False, True]])
+            >>> train_labels = np.array([1, 0])
+            >>> metrics = gp.step(train_data, train_labels)
+            >>> 'best' in metrics
+            True
+            >>> metrics['epoch']
+            0
+        """
         self._epoch += 1
         self.population += self.crossover_executor.apply(self.population)
         self.mutation_executor.apply(self.population)
@@ -156,6 +283,72 @@ class BooleanGP:
         score_fn: Callable[[ndarray, ndarray], float] | None = None,
         all_time_best: bool = False,
     ) -> ValidateBestMetrics:
+        """
+        Evaluates the best rule on validation or test data.
+
+        Computes the fitness score of either the current best rule or the all-time
+        best rule on the provided data. This is useful for validation during training
+        or final evaluation on test sets.
+
+        Args:
+            data (ndarray):
+                Validation/test data as a 2D boolean array with instances on rows
+                and features on columns.
+            labels (ndarray):
+                Validation/test labels as a 1D integer array (0 or 1 for binary classification).
+            score_fn (Callable[[ndarray, ndarray], float] | None, optional):
+                Optional custom scoring function. If `None`, uses the instance's `score_fn`.
+                Default: `None`.
+            all_time_best (bool, optional):
+                If `True`, evaluates the all-time best rule. If `False`, evaluates
+                the current run's best rule. Default: `False`.
+
+        Returns:
+            ValidateBestMetrics: Dictionary containing:
+                - `best` (float): Fitness score of the best rule on the data.
+                - `best_rule` (Rule): The evaluated rule.
+
+        Raises:
+            RuntimeError:
+                If no best rule is available (algorithm hasn't run any steps yet).
+
+        Examples:
+            >>> import numpy as np
+            >>> from hgp_lib.algorithms import BooleanGP
+            >>> from hgp_lib.mutations import (
+            ...     MutationExecutor, create_standard_literal_mutations, create_standard_operator_mutations
+            ... )
+            >>> from hgp_lib.populations import PopulationGenerator, RandomStrategy
+            >>>
+            >>> def accuracy(predictions, labels):
+            ...     return np.mean(predictions == labels)
+            >>>
+            >>> generator = PopulationGenerator(
+            ...     strategies=[RandomStrategy(num_literals=4)],
+            ...     population_size=5
+            ... )
+            >>> mutation_executor = MutationExecutor(
+            ...     literal_mutations=create_standard_literal_mutations(4),
+            ...     operator_mutations=create_standard_operator_mutations(4)
+            ... )
+            >>>
+            >>> gp = BooleanGP(
+            ...     score_fn=accuracy,
+            ...     population_generator=generator,
+            ...     mutation_executor=mutation_executor
+            ... )
+            >>>
+            >>> train_data = np.array([[True, False, True, False], [False, True, False, True]])
+            >>> train_labels = np.array([1, 0])
+            >>> _ = gp.step(train_data, train_labels)
+            >>> val_data = np.array([[True, True, False, False]])
+            >>> val_labels = np.array([1])
+            >>> metrics = gp.validate_best(val_data, val_labels)
+            >>> 'best' in metrics
+            True
+            >>> 'best_rule' in metrics
+            True
+        """
         if self.real_best_rule is None or self.best_rule is None:
             raise RuntimeError("No best rule available. Run at least one step first.")
 
@@ -172,6 +365,76 @@ class BooleanGP:
         score_fn: Callable[[ndarray, ndarray], float] | None = None,
         all_time_best: bool = False,
     ) -> ValidatePopulationMetrics:
+        """
+        Evaluates the best rule and entire population on validation or test data.
+
+        Computes fitness scores for both the best rule and all rules in the current
+        population. This provides insight into both the best individual's performance
+        and the overall population quality.
+
+        Args:
+            data (ndarray):
+                Validation/test data as a 2D boolean array with instances on rows
+                and features on columns.
+            labels (ndarray):
+                Validation/test labels as a 1D integer array (0 or 1 for binary classification).
+            score_fn (Callable[[ndarray, ndarray], float] | None, optional):
+                Optional custom scoring function. If `None`, uses the instance's `score_fn`.
+                Default: `None`.
+            all_time_best (bool, optional):
+                If `True`, evaluates the all-time best rule. If `False`, evaluates
+                the current run's best rule. Default: `False`.
+
+        Returns:
+            ValidatePopulationMetrics: Dictionary containing:
+                - `best` (float): Fitness score of the best rule on the data.
+                - `best_rule` (Rule): The evaluated best rule.
+                - `population_scores` (ndarray): Fitness scores for all rules in the population.
+
+        Raises:
+            RuntimeError:
+                If no best rule is available (algorithm hasn't run any steps yet).
+
+        Examples:
+            >>> import numpy as np
+            >>> from hgp_lib.algorithms import BooleanGP
+            >>> from hgp_lib.mutations import (
+            ...     MutationExecutor, create_standard_literal_mutations, create_standard_operator_mutations
+            ... )
+            >>> from hgp_lib.populations import PopulationGenerator, RandomStrategy
+            >>>
+            >>> def accuracy(predictions, labels):
+            ...     return np.mean(predictions == labels)
+            >>>
+            >>> generator = PopulationGenerator(
+            ...     strategies=[RandomStrategy(num_literals=4)],
+            ...     population_size=5
+            ... )
+            >>> mutation_executor = MutationExecutor(
+            ...     literal_mutations=create_standard_literal_mutations(4),
+            ...     operator_mutations=create_standard_operator_mutations(4)
+            ... )
+            >>>
+            >>> gp = BooleanGP(
+            ...     score_fn=accuracy,
+            ...     population_generator=generator,
+            ...     mutation_executor=mutation_executor
+            ... )
+            >>>
+            >>> train_data = np.array([[True, False, True, False], [False, True, False, True]])
+            >>> train_labels = np.array([1, 0])
+            >>> _ = gp.step(train_data, train_labels)
+            >>>
+            >>> val_data = np.array([[True, True, False, False]])
+            >>> val_labels = np.array([1])
+            >>> metrics = gp.validate_population(val_data, val_labels)
+            >>> 'best' in metrics
+            True
+            >>> 'population_scores' in metrics
+            True
+            >>> len(metrics['population_scores']) == len(gp.population)
+            True
+        """
         if self.real_best_rule is None or self.best_rule is None:
             raise RuntimeError("No best rule available. Run at least one step first.")
         best_rule = self.real_best_rule if all_time_best else self.best_rule

--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -46,6 +46,7 @@ class BooleanGP:
         regeneration: bool = False,
         regeneration_patience: int = 100,
     ):
+        # TODO: We should reconsider the ordering of the arguments for score fn. Pred, GT or GT, Pred?
         validate_callable(score_fn)
         check_isinstance(population_generator, PopulationGenerator)
         check_isinstance(mutation_executor, MutationExecutor)
@@ -85,7 +86,7 @@ class BooleanGP:
         self._epoch += 1
         self.population += self.crossover_executor.apply(self.population)
         self.mutation_executor.apply(self.population)
-        scores = self._evaluate_population(train_data, train_labels)
+        scores = self._evaluate_population(train_data, train_labels, self.score_fn)
         return self._new_generation(scores)
 
     def _new_generation(self, scores: ndarray) -> StepMetrics:
@@ -124,12 +125,17 @@ class BooleanGP:
             )
         return metrics
 
-    def _evaluate_population(self, data: ndarray, labels: ndarray) -> ndarray:
+    def _evaluate_population(
+        self,
+        data: ndarray,
+        labels: ndarray,
+        score_fn: Callable[[ndarray, ndarray], float],
+    ) -> ndarray:
         # TODO: we should also support batched evaluation or free-threaded evaluation
         n = len(self.population)
         scores = np.zeros(n)
         for i in range(n):
-            scores[i] = self.score_fn(self.population[i].evaluate(data), labels)
+            scores[i] = score_fn(self.population[i].evaluate(data), labels)
         return scores
 
     def _update_best(self, current_best: float, current_best_rule: Rule):
@@ -144,25 +150,34 @@ class BooleanGP:
             self.best_not_improved_epochs += 1
 
     def validate_best(
-        self, data: ndarray, labels: ndarray, all_time_best: bool = False
+        self,
+        data: ndarray,
+        labels: ndarray,
+        score_fn: Callable[[ndarray, ndarray], float] | None = None,
+        all_time_best: bool = False,
     ) -> ValidateBestMetrics:
         if self.real_best_rule is None or self.best_rule is None:
             raise RuntimeError("No best rule available. Run at least one step first.")
 
         best_rule = self.real_best_rule if all_time_best else self.best_rule
+        score_fn = self.score_fn if score_fn is None else score_fn
         return ValidateBestMetrics(
-            best=self.score_fn(best_rule.evaluate(data), labels), best_rule=best_rule
+            best=score_fn(best_rule.evaluate(data), labels), best_rule=best_rule
         )
 
     def validate_population(
-        self, data: ndarray, labels: ndarray, all_time_best: bool = False
+        self,
+        data: ndarray,
+        labels: ndarray,
+        score_fn: Callable[[ndarray, ndarray], float] | None = None,
+        all_time_best: bool = False,
     ) -> ValidatePopulationMetrics:
         if self.real_best_rule is None or self.best_rule is None:
             raise RuntimeError("No best rule available. Run at least one step first.")
         best_rule = self.real_best_rule if all_time_best else self.best_rule
-
+        score_fn = self.score_fn if score_fn is None else score_fn
         return ValidatePopulationMetrics(
-            best=self.score_fn(best_rule.evaluate(data), labels),
+            best=score_fn(best_rule.evaluate(data), labels),
             best_rule=best_rule,
-            population_scores=self._evaluate_population(data, labels),
+            population_scores=self._evaluate_population(data, labels, score_fn),
         )

--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -217,6 +217,22 @@ class BooleanGP:
         return self._new_generation(scores)
 
     def _new_generation(self, scores: ndarray) -> StepMetrics:
+        """
+        Creates a new generation by selecting individuals and optionally regenerating the population.
+
+        Updates the best rule tracking, checks if regeneration is needed, and selects the next
+        generation using the configured selection strategy. If regeneration is triggered,
+        the population is completely regenerated and best tracking is reset.
+
+        Args:
+            scores (ndarray):
+                Fitness scores for all rules in the current population. Must have the same
+                length as `self.population`.
+
+        Returns:
+            StepMetrics: Dictionary containing metrics about the generation step, including
+                whether regeneration occurred and the current best scores.
+        """
         best_idx = np.argmax(scores)
         current_best = scores[best_idx]
 
@@ -258,7 +274,27 @@ class BooleanGP:
         labels: ndarray,
         score_fn: Callable[[ndarray, ndarray], float],
     ) -> ndarray:
-        # TODO: we should also support batched evaluation or free-threaded evaluation
+        """
+        Evaluates all rules in the population against the given data.
+
+        Computes fitness scores for each rule by evaluating it on the data and applying
+        the scoring function. This is done sequentially for each rule in the population.
+
+        Args:
+            data (ndarray):
+                Data to evaluate rules on. A 2D boolean array with instances on rows
+                and features on columns.
+            labels (ndarray):
+                True labels for the data. A 1D integer array (0 or 1 for binary classification).
+            score_fn (Callable[[ndarray, ndarray], float]):
+                Function to compute fitness scores. Signature: `score_fn(predictions, labels) -> float`.
+
+        Returns:
+            ndarray: Array of fitness scores, one for each rule in the population.
+
+        Note:
+            TODO: we should also support batched evaluation or free-threaded evaluation
+        """
         n = len(self.population)
         scores = np.zeros(n)
         for i in range(n):
@@ -266,13 +302,27 @@ class BooleanGP:
         return scores
 
     def _update_best(self, current_best: float, current_best_rule: Rule):
+        """
+        Updates the best rule tracking based on the current generation's best.
+
+        If the current best score is greater than or equal to the stored best score,
+        updates both the current run's best and the all-time best (if it's a new record).
+        Otherwise, increments the counter for epochs without improvement.
+
+        Args:
+            current_best (float):
+                The best fitness score from the current generation.
+            current_best_rule (Rule):
+                The rule that achieved the best score in the current generation.
+                This rule will be copied when stored.
+        """
         if current_best >= self.best_score:
             self.best_not_improved_epochs = 0
             self.best_score = current_best
             self.best_rule = current_best_rule.copy()
             if self.best_score > self.real_best_score:
                 self.real_best_score = self.best_score
-                self.real_best_rule = self.best_rule
+                self.real_best_rule = self.best_rule.copy()
         else:
             self.best_not_improved_epochs += 1
 

--- a/hgp_lib/rules/__init__.py
+++ b/hgp_lib/rules/__init__.py
@@ -10,3 +10,4 @@ else:
     from .operators import Or, And
 
 __all__ = ["Literal", "Rule", "Or", "And", "utils", "operators", "low_memory_operators"]
+# TODO: Provide support for both torch and numpy

--- a/scripts/paysim_latency.py
+++ b/scripts/paysim_latency.py
@@ -1,0 +1,280 @@
+"""
+PaySim Fraud Detection Training Script
+
+This script trains a Boolean GP model on PaySim transaction data to detect fraud.
+This script does not work with the original dataset file and needs preprocessing before.
+TODO: We should add docs example with how to run on paysim
+"""
+
+import gc
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from tqdm import tqdm
+from timed_decorator.builder import create_timed_decorator, get_timed_decorator
+
+from hgp_lib.algorithms import BooleanGP
+from hgp_lib.crossover import CrossoverExecutor
+from hgp_lib.mutations import (
+    MutationExecutor,
+    create_standard_literal_mutations,
+    create_standard_operator_mutations,
+)
+from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.preprocessing import StandardBinarizer
+from hgp_lib.rules import Rule, Literal, And, Or
+from functools import partial
+
+
+def fast_f1_score(y_pred, y_true, sample_weight=None):
+    if sample_weight is None:
+        y_pred_sum = y_pred.sum()
+        y_true_sum = y_true.sum()
+    else:
+        y_pred_sum = np.dot(y_pred, sample_weight)
+        y_true_sum = np.dot(y_true, sample_weight)
+
+    if y_pred_sum == 0 or y_true_sum == 0:
+        if y_pred_sum == 0 and y_true_sum == 0:
+            return 1.0
+        return 0.0
+
+    if sample_weight is None:
+        return 2 * (y_pred & y_true).sum() / (y_pred_sum + y_true_sum)
+    return 2 * np.dot((y_pred & y_true), sample_weight) / (y_pred_sum + y_true_sum)
+
+
+def preprocess_paysim_data(hdf_path: str):
+    print(f"Loading data from {hdf_path}...")
+
+    feature_columns = [
+        "type",
+        "amount",
+        "oldbalanceOrg",
+        "newbalanceOrig",
+        "oldbalanceDest",
+        "newbalanceDest",
+    ]
+    df: pd.DataFrame = pd.read_hdf(hdf_path)
+    if "isFraud" in df.columns:
+        target_column = "isFraud"
+    elif "target" in df.columns:
+        target_column = "target"
+    else:
+        raise RuntimeError(df.columns)
+
+    data = df[feature_columns].copy()
+    labels = df[target_column].values.copy()
+
+    del df
+
+    print(f"Loaded {len(data)} samples with {len(feature_columns)} features")
+    print(f"Fraud rate: {labels.mean():.4f} ({labels.sum()} fraud cases)")
+
+    print("\nSplitting data...")
+    train_data, test_data, train_labels, test_labels = train_test_split(
+        data, labels, test_size=0.2, random_state=42, stratify=labels
+    )
+    del data, labels
+
+    train_data, val_data, train_labels, val_labels = train_test_split(
+        train_data,
+        train_labels,
+        test_size=0.2,
+        random_state=42,
+        stratify=train_labels,
+    )
+
+    print(f"Train: {len(train_data)} samples")
+    print(f"Val: {len(val_data)} samples")
+    print(f"Test: {len(test_data)} samples")
+
+    print("\nBinarizing data...")
+    binarizer = StandardBinarizer(num_bins=5)
+    train_data_bin = binarizer.fit_transform(train_data, train_labels)
+    val_data_bin = binarizer.transform(val_data)
+    test_data_bin = binarizer.transform(test_data)
+
+    print(f"Binarized features: {train_data_bin.shape[1]} (from {train_data.shape[1]})")
+
+    train_data_bin = train_data_bin.values
+    val_data_bin = val_data_bin.values
+    test_data_bin = test_data_bin.values
+
+    del train_data, val_data, test_data
+    gc.collect()
+
+    return (
+        train_data_bin,
+        train_labels,
+        val_data_bin,
+        val_labels,
+        test_data_bin,
+        test_labels,
+    )
+
+
+def setup_timing():
+    measurements = {}
+    create_timed_decorator(
+        "GPTimer",
+        nested=True,
+        collect_gc=False,
+        disable_gc=True,
+        stdout=False,
+        out=measurements,
+    )
+    return measurements
+
+
+def apply_timing_decorators(gp_algo: BooleanGP, score_fn):
+    decorator = get_timed_decorator("GPTimer")
+
+    Literal.evaluate = decorator(Literal.evaluate)
+    And.evaluate = decorator(And.evaluate)
+    Or.evaluate = decorator(Or.evaluate)
+
+    score_fn = decorator(score_fn)
+
+    gp_algo.step = decorator(gp_algo.step)
+    gp_algo._new_generation = decorator(gp_algo._new_generation)
+    gp_algo._evaluate_population = decorator(gp_algo._evaluate_population)
+    gp_algo._update_best = decorator(gp_algo._update_best)
+    gp_algo.validate_population = decorator(gp_algo.validate_population)
+
+    gp_algo.crossover_executor.apply = decorator(gp_algo.crossover_executor.apply)
+    gp_algo.mutation_executor.apply = decorator(gp_algo.mutation_executor.apply)
+    gp_algo.selection.select = decorator(gp_algo.selection.select)
+
+    return score_fn
+
+
+def print_timing_results(measurements: dict):
+    print("\n" + "=" * 60)
+    print("Timing Results:")
+    print("=" * 60)
+
+    for key, (counts, elapsed, own_time) in measurements.items():
+        own_time /= 1e9
+        elapsed /= 1e9
+        print(
+            f"Function {key} was called {counts} time(s) and took {own_time:.4f}s/{elapsed:.4f}s "
+            f"({own_time / counts}/{elapsed / counts} per call)"
+        )
+
+    print()
+
+
+def remove_duplicates(data, labels):
+    Xy = np.hstack((data, labels[:, None]))
+    Xy_unique, sample_weight = np.unique(Xy, axis=0, return_counts=True)
+    return Xy_unique[:, :-1], Xy_unique[:, -1], sample_weight
+
+
+def main():
+    measurements = setup_timing()
+
+    hdf_path = "data/PaySim.hdf"
+    num_epochs = 2000
+    population_size = 100
+    max_rule_size = 50
+    mutation_p = 0.1
+    crossover_p = 0.7
+
+    (
+        train_data_bin,
+        train_labels,
+        val_data_bin,
+        val_labels,
+        test_data_bin,
+        test_labels,
+    ) = preprocess_paysim_data(hdf_path)
+    train_data_bin, train_labels, sample_weight = remove_duplicates(
+        train_data_bin, train_labels
+    )
+    val_data_bin, val_labels, sample_weight_val = remove_duplicates(
+        train_data_bin, train_labels
+    )
+
+    train_score_fn = partial(fast_f1_score, sample_weight=sample_weight)
+    val_score_fn = partial(fast_f1_score, sample_weight=sample_weight_val)
+    test_score_fn = fast_f1_score
+
+    def is_rule_valid(rule: Rule) -> bool:
+        if len(rule) > max_rule_size:
+            return False
+        return True
+
+    num_features = train_data_bin.shape[1]
+    literal_mutations = create_standard_literal_mutations(num_features)
+    operator_mutations = create_standard_operator_mutations(num_features)
+
+    random_strategy = RandomStrategy(num_literals=num_features)
+    population_generator = PopulationGenerator(
+        strategies=[random_strategy],
+        population_size=population_size,
+    )
+
+    mutation_executor = MutationExecutor(
+        literal_mutations=literal_mutations,
+        operator_mutations=operator_mutations,
+        mutation_p=mutation_p,
+        check_valid=is_rule_valid,
+        num_tries=5,
+    )
+
+    crossover_executor = CrossoverExecutor(
+        crossover_p=crossover_p,
+        check_valid=is_rule_valid,
+        num_tries=2,
+    )
+
+    print("\nInitializing Boolean GP...")
+    gp_algo = BooleanGP(
+        score_fn=train_score_fn,
+        population_generator=population_generator,
+        mutation_executor=mutation_executor,
+        crossover_executor=crossover_executor,
+        regeneration=True,
+        regeneration_patience=200,
+    )
+
+    train_score_fn = apply_timing_decorators(gp_algo, train_score_fn)
+    gp_algo.train_score_fn = train_score_fn
+
+    print(f"\nStarting training for {num_epochs} epochs...")
+
+    val_best = 0
+    val_avg = 0
+    with tqdm(range(num_epochs), desc="Training") as tbar:
+        for epoch in tbar:
+            train_metrics = gp_algo.step(train_data_bin, train_labels)
+
+            if (epoch + 1) % 10 == 0:
+                val_metrics = gp_algo.validate_population(
+                    val_data_bin, val_labels, val_score_fn
+                )
+                val_best = val_metrics["best"]
+                val_avg = val_metrics["population_scores"].mean()
+            tbar.set_postfix(
+                {
+                    "train_best": f"{train_metrics['best']:.4f}",
+                    "val_best": f"{val_best:.4f}",
+                    "val_avg": f"{val_avg:.4f}",
+                }
+            )
+
+    print("\n" + "-" * 60)
+    print("Final evaluation on test set...")
+    test_metrics = gp_algo.validate_population(
+        test_data_bin, test_labels, test_score_fn, all_time_best=True
+    )
+    print(f"Test best: {test_metrics['best']:.4f}")
+    print(f"Test population average: {test_metrics['population_scores'].mean():.4f}")
+
+    print_timing_results(measurements)
+    print("\nTraining completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/paysim_profile.py
+++ b/scripts/paysim_profile.py
@@ -153,13 +153,14 @@ def print_timing_results(measurements: dict):
     print("\n" + "=" * 60)
     print("Timing Results:")
     print("=" * 60)
+    sorted_measurements = sorted(measurements.items(), key=lambda x: x[1][2])
 
-    for key, (counts, elapsed, own_time) in measurements.items():
+    for key, (counts, elapsed, own_time) in sorted_measurements:
         own_time /= 1e9
         elapsed /= 1e9
         print(
             f"Function {key} was called {counts} time(s) and took {own_time:.4f}s/{elapsed:.4f}s "
-            f"({own_time / counts}/{elapsed / counts} per call)"
+            f"({own_time / counts:.4f}/{elapsed / counts:.4f} per call)"
         )
 
     print()
@@ -175,10 +176,10 @@ def main():
     measurements = setup_timing()
 
     hdf_path = "data/PaySim.hdf"
-    num_epochs = 2000
+    num_epochs = 5000
     population_size = 100
     max_rule_size = 50
-    mutation_p = 0.1
+    mutation_p = 0.05
     crossover_p = 0.7
 
     (

--- a/scripts/paysim_profile.py
+++ b/scripts/paysim_profile.py
@@ -259,7 +259,9 @@ def main():
                 val_avg = val_metrics["population_scores"].mean()
             tbar.set_postfix(
                 {
+                    "current_best": f"{train_metrics['current_best']:.4f}",
                     "train_best": f"{train_metrics['best']:.4f}",
+                    "real_best": f"{train_metrics['real_best']:.4f}",
                     "val_best": f"{val_best:.4f}",
                     "val_avg": f"{val_avg:.4f}",
                 }

--- a/scripts/paysim_profile.py
+++ b/scripts/paysim_profile.py
@@ -25,6 +25,8 @@ from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule, Literal, And, Or
 from functools import partial
 
+from hgp_lib.selections import BaseSelection
+
 
 def fast_f1_score(y_pred, y_true, sample_weight=None):
     if sample_weight is None:
@@ -127,26 +129,27 @@ def setup_timing():
     return measurements
 
 
-def apply_timing_decorators(gp_algo: BooleanGP, score_fn):
+def apply_timing_decorators():
     decorator = get_timed_decorator("GPTimer")
 
     Literal.evaluate = decorator(Literal.evaluate)
     And.evaluate = decorator(And.evaluate)
     Or.evaluate = decorator(Or.evaluate)
 
-    score_fn = decorator(score_fn)
+    global fast_f1_score
+    fast_f1_score = decorator(fast_f1_score)
 
-    gp_algo.step = decorator(gp_algo.step)
-    gp_algo._new_generation = decorator(gp_algo._new_generation)
-    gp_algo._evaluate_population = decorator(gp_algo._evaluate_population)
-    gp_algo._update_best = decorator(gp_algo._update_best)
-    gp_algo.validate_population = decorator(gp_algo.validate_population)
+    BooleanGP.step = decorator(BooleanGP.step)
+    BooleanGP._new_generation = decorator(BooleanGP._new_generation)
+    BooleanGP._evaluate_population = decorator(BooleanGP._evaluate_population)
+    BooleanGP._update_best = decorator(BooleanGP._update_best)
+    BooleanGP.validate_population = decorator(BooleanGP.validate_population)
 
-    gp_algo.crossover_executor.apply = decorator(gp_algo.crossover_executor.apply)
-    gp_algo.mutation_executor.apply = decorator(gp_algo.mutation_executor.apply)
-    gp_algo.selection.select = decorator(gp_algo.selection.select)
+    CrossoverExecutor.apply = decorator(CrossoverExecutor.apply)
 
-    return score_fn
+    MutationExecutor.apply = decorator(MutationExecutor.apply)
+
+    BaseSelection.select = decorator(BaseSelection.select)
 
 
 def print_timing_results(measurements: dict):
@@ -174,6 +177,7 @@ def remove_duplicates(data, labels):
 
 def main():
     measurements = setup_timing()
+    apply_timing_decorators()
 
     hdf_path = "data/PaySim.hdf"
     num_epochs = 5000
@@ -239,9 +243,6 @@ def main():
         regeneration=True,
         regeneration_patience=200,
     )
-
-    train_score_fn = apply_timing_decorators(gp_algo, train_score_fn)
-    gp_algo.train_score_fn = train_score_fn
 
     print(f"\nStarting training for {num_epochs} epochs...")
 

--- a/scripts/paysim_profile.py
+++ b/scripts/paysim_profile.py
@@ -180,7 +180,7 @@ def main():
     apply_timing_decorators()
 
     hdf_path = "data/PaySim.hdf"
-    num_epochs = 5000
+    num_epochs = 1000
     population_size = 100
     max_rule_size = 50
     mutation_p = 0.05
@@ -198,7 +198,7 @@ def main():
         train_data_bin, train_labels
     )
     val_data_bin, val_labels, sample_weight_val = remove_duplicates(
-        train_data_bin, train_labels
+        val_data_bin, val_labels
     )
 
     train_score_fn = partial(fast_f1_score, sample_weight=sample_weight)
@@ -246,6 +246,8 @@ def main():
 
     print(f"\nStarting training for {num_epochs} epochs...")
 
+    with open("debug.txt", "w") as f:
+        pass
     val_best = 0
     val_avg = 0
     with tqdm(range(num_epochs), desc="Training") as tbar:
@@ -258,6 +260,12 @@ def main():
                 )
                 val_best = val_metrics["best"]
                 val_avg = val_metrics["population_scores"].mean()
+                if (epoch + 1) % 50 == 0:
+                    with open("debug.txt", "a") as f:
+                        f.write(str(epoch) + "\n")
+                        for r in gp_algo.population:
+                            f.write(str(r) + "\n")
+                        f.write("\n--------------------\n")
             tbar.set_postfix(
                 {
                     "current_best": f"{train_metrics['current_best']:.4f}",

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -1,0 +1,452 @@
+import doctest
+import unittest
+import random
+
+import numpy as np
+
+import hgp_lib.algorithms.boolean_gp
+from hgp_lib.algorithms import BooleanGP
+from hgp_lib.crossover import CrossoverExecutor
+from hgp_lib.mutations import (
+    MutationExecutor,
+    create_standard_literal_mutations,
+    create_standard_operator_mutations,
+)
+from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.rules import Rule
+
+
+class TestBooleanGP(unittest.TestCase):
+    def setUp(self):
+        random.seed(42)
+        np.random.seed(42)
+
+        self.train_data = np.array(
+            [
+                [True, False, True, False],
+                [False, True, False, True],
+                [True, True, False, False],
+                [False, False, True, True],
+            ]
+        )
+        self.train_labels = np.array([1, 0, 1, 0])
+        self.val_data = np.array(
+            [[True, False, False, True], [False, True, True, False]]
+        )
+        self.val_labels = np.array([1, 0])
+        self.num_features = 4
+
+        def accuracy(predictions, labels):
+            return np.mean(predictions == labels)
+
+        self.score_fn = accuracy
+
+        self.generator = PopulationGenerator(
+            strategies=[RandomStrategy(num_literals=self.num_features)],
+            population_size=10,
+        )
+
+        self.mutation_executor = MutationExecutor(
+            literal_mutations=create_standard_literal_mutations(self.num_features),
+            operator_mutations=create_standard_operator_mutations(self.num_features),
+        )
+
+    def test_boolean_gp_validation(self):
+        with self.subTest("score_fn must be callable"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn="not callable",
+                    population_generator=self.generator,
+                    mutation_executor=self.mutation_executor,
+                )
+
+        with self.subTest("population_generator must be PopulationGenerator"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator="not generator",
+                    mutation_executor=self.mutation_executor,
+                )
+
+        with self.subTest("mutation_executor must be MutationExecutor"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator=self.generator,
+                    mutation_executor="not executor",
+                )
+
+        with self.subTest("crossover_executor must be CrossoverExecutor"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator=self.generator,
+                    mutation_executor=self.mutation_executor,
+                    crossover_executor="not executor",
+                )
+
+        with self.subTest("selection must be BaseSelection"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator=self.generator,
+                    mutation_executor=self.mutation_executor,
+                    selection="not selection",
+                )
+
+        with self.subTest("regeneration must be bool"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator=self.generator,
+                    mutation_executor=self.mutation_executor,
+                    regeneration=1,
+                )
+
+        with self.subTest("regeneration_patience must be int"):
+            with self.assertRaises(TypeError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator=self.generator,
+                    mutation_executor=self.mutation_executor,
+                    regeneration_patience=1.5,
+                )
+
+        with self.subTest(
+            "regeneration_patience must be positive when regeneration=True"
+        ):
+            with self.assertRaises(ValueError):
+                BooleanGP(
+                    score_fn=self.score_fn,
+                    population_generator=self.generator,
+                    mutation_executor=self.mutation_executor,
+                    regeneration=True,
+                    regeneration_patience=0,
+                )
+
+    def test_boolean_gp_init(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        self.assertIsNotNone(gp.population)
+        self.assertEqual(len(gp.population), 10)
+        self.assertEqual(gp.best_score, -float("inf"))
+        self.assertIsNone(gp.best_rule)
+        self.assertEqual(gp.real_best_score, -float("inf"))
+        self.assertIsNone(gp.real_best_rule)
+        self.assertEqual(gp.best_not_improved_epochs, 0)
+
+    def test_boolean_gp_defaults(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        self.assertIsInstance(gp.crossover_executor, CrossoverExecutor)
+        from hgp_lib.selections import RouletteSelection
+
+        self.assertIsInstance(gp.selection, RouletteSelection)
+
+    def test_step_returns_metrics(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        metrics = gp.step(self.train_data, self.train_labels)
+
+        self.assertIn("best", metrics)
+        self.assertIn("best_rule", metrics)
+        self.assertIn("real_best", metrics)
+        self.assertIn("real_best_rule", metrics)
+        self.assertIn("current_best", metrics)
+        self.assertIn("population_scores", metrics)
+        self.assertIn("epoch", metrics)
+        self.assertIn("best_not_improved_epochs", metrics)
+        self.assertIn("regenerated", metrics)
+
+        self.assertEqual(metrics["epoch"], 0)
+        self.assertIsInstance(metrics["best_rule"], Rule)
+        self.assertIsInstance(metrics["real_best_rule"], Rule)
+        self.assertIsInstance(metrics["population_scores"], np.ndarray)
+        self.assertGreater(len(metrics["population_scores"]), 0)
+
+    def test_step_updates_best_rule(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        initial_best = gp.best_score
+        metrics = gp.step(self.train_data, self.train_labels)
+
+        self.assertGreaterEqual(metrics["best"], initial_best)
+        self.assertIsNotNone(gp.best_rule)
+        self.assertIsNotNone(gp.real_best_rule)
+
+    def test_step_increments_epoch(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        metrics1 = gp.step(self.train_data, self.train_labels)
+        self.assertEqual(metrics1["epoch"], 0)
+
+        metrics2 = gp.step(self.train_data, self.train_labels)
+        self.assertEqual(metrics2["epoch"], 1)
+
+    def test_step_updates_population_size(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        initial_size = len(gp.population)
+        gp.step(self.train_data, self.train_labels)
+
+        self.assertEqual(len(gp.population), initial_size)
+
+    def test_validate_best_raises_without_steps(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        with self.assertRaises(RuntimeError) as context:
+            gp.validate_best(self.val_data, self.val_labels)
+
+        self.assertIn("No best rule available", str(context.exception))
+
+    def test_validate_best_returns_metrics(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+        metrics = gp.validate_best(self.val_data, self.val_labels)
+
+        self.assertIn("best", metrics)
+        self.assertIn("best_rule", metrics)
+        self.assertIsInstance(metrics["best"], float)
+        self.assertIsInstance(metrics["best_rule"], Rule)
+
+    def test_validate_best_all_time_best(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+        current_metrics = gp.validate_best(
+            self.val_data, self.val_labels, all_time_best=False
+        )
+        all_time_metrics = gp.validate_best(
+            self.val_data, self.val_labels, all_time_best=True
+        )
+
+        self.assertIsInstance(current_metrics["best_rule"], Rule)
+        self.assertIsInstance(all_time_metrics["best_rule"], Rule)
+
+    def test_validate_best_custom_score_fn(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+
+        def custom_score(predictions, labels):
+            return np.sum(predictions & labels)
+
+        metrics = gp.validate_best(
+            self.val_data, self.val_labels, score_fn=custom_score
+        )
+        self.assertIn("best", metrics)
+
+    def test_validate_population_raises_without_steps(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        with self.assertRaises(RuntimeError) as context:
+            gp.validate_population(self.val_data, self.val_labels)
+
+        self.assertIn("No best rule available", str(context.exception))
+
+    def test_validate_population_returns_metrics(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+        metrics = gp.validate_population(self.val_data, self.val_labels)
+
+        self.assertIn("best", metrics)
+        self.assertIn("best_rule", metrics)
+        self.assertIn("population_scores", metrics)
+        self.assertIsInstance(metrics["best"], float)
+        self.assertIsInstance(metrics["best_rule"], Rule)
+        self.assertEqual(len(metrics["population_scores"]), len(gp.population))
+
+    def test_validate_population_all_time_best(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+        current_metrics = gp.validate_population(
+            self.val_data, self.val_labels, all_time_best=False
+        )
+        all_time_metrics = gp.validate_population(
+            self.val_data, self.val_labels, all_time_best=True
+        )
+
+        self.assertIsInstance(current_metrics["best_rule"], Rule)
+        self.assertIsInstance(all_time_metrics["best_rule"], Rule)
+
+    def test_validate_population_custom_score_fn(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+
+        def custom_score(predictions, labels):
+            return np.sum(predictions & labels)
+
+        metrics = gp.validate_population(
+            self.val_data, self.val_labels, score_fn=custom_score
+        )
+        self.assertIn("best", metrics)
+        self.assertIn("population_scores", metrics)
+
+    def test_regeneration_disabled(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+            regeneration=False,
+            regeneration_patience=1,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+
+        self.assertFalse(gp.regeneration)
+
+    def test_regeneration_enabled(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+            regeneration=True,
+            regeneration_patience=1,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+
+        metrics = gp.step(self.train_data, self.train_labels)
+
+        if metrics["regenerated"]:
+            self.assertEqual(gp.best_score, -float("inf"))
+            self.assertEqual(gp.best_not_improved_epochs, 0)
+
+    def test_best_not_improved_epochs_tracking(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        metrics1 = gp.step(self.train_data, self.train_labels)
+        initial_epochs = metrics1["best_not_improved_epochs"]
+
+        metrics2 = gp.step(self.train_data, self.train_labels)
+
+        if metrics2["current_best"] < metrics1["best"]:
+            self.assertGreater(metrics2["best_not_improved_epochs"], initial_epochs)
+        else:
+            self.assertEqual(metrics2["best_not_improved_epochs"], 0)
+
+    def test_real_best_tracking(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        gp.step(self.train_data, self.train_labels)
+        initial_real_best = gp.real_best_score
+
+        gp.step(self.train_data, self.train_labels)
+
+        self.assertGreaterEqual(gp.real_best_score, initial_real_best)
+        if gp.best_score > initial_real_best:
+            self.assertEqual(gp.real_best_score, gp.best_score)
+
+    def test_multiple_steps(self):
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+        )
+
+        for i in range(5):
+            metrics = gp.step(self.train_data, self.train_labels)
+            self.assertEqual(metrics["epoch"], i)
+            self.assertIsNotNone(metrics["best_rule"])
+
+    def test_step_with_custom_crossover(self):
+        crossover_executor = CrossoverExecutor(crossover_p=0.5)
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+            crossover_executor=crossover_executor,
+        )
+
+        metrics = gp.step(self.train_data, self.train_labels)
+        self.assertIn("best", metrics)
+
+    def test_step_with_custom_selection(self):
+        from hgp_lib.selections import RouletteSelection
+
+        selection = RouletteSelection()
+        gp = BooleanGP(
+            score_fn=self.score_fn,
+            population_generator=self.generator,
+            mutation_executor=self.mutation_executor,
+            selection=selection,
+        )
+
+        metrics = gp.step(self.train_data, self.train_labels)
+        self.assertIn("best", metrics)
+
+    def test_doctests(self):
+        result = doctest.testmod(hgp_lib.algorithms.boolean_gp, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* A different `score_fn` can be passed for validation or testing. This enables the implementation of faster scoring methods based on unique data (no duplicates) and also the evaluation of multiple metrics
* Included a profiling script on the PaySim dataset
* Added tests and documentation for `BooleanGP`