### PR TITLE
Added binarization step in bechmarking. Closes #41.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,13 @@ For more information about binarization and custom configurations, see TODO (cre
 Label aware binarization is usually employed to create class-aware bins for numerical columns.
 The binarizer must be fit only on the training data to prevent data leakage!
 
-Depending on usage, data preparation may very (i.e. when doing k-fold cross-validation).
+Depending on usage, data preparation may vary (i.e. when doing k-fold cross-validation).
+
+> **Note:** If you are using the **GPBenchmarker**, you do **not** need to binarize manually.
+> The benchmarker handles per-fold binarization internally to prevent data leakage.
+> See [Benchmarking Boolean GP](#benchmarking-boolean-gp) for details.
+
+For manual training (GPTrainer / BooleanGP), binarize the data yourself:
 
 ```python
 from hgp_lib.preprocessing import StandardBinarizer
@@ -227,10 +233,36 @@ test_metrics = trainer.score(test_data, test_labels)
 
 The benchmarker runs multiple full runs (default 30), each with a stratified train/test split and k-fold CV on the training set. Results are aggregated across runs. Runs execute in parallel by default. The benchmarker accepts a `BenchmarkerConfig` containing a `TrainerConfig` template.
 
+**Automatic binarization**: Pass raw (non-binarized) data as a `pandas.DataFrame` in `BenchmarkerConfig.data`. The benchmarker binarizes internally: for each fold, a fresh copy of the binarizer is fitted on the training fold (with labels for supervised binning) and used to transform the validation fold. The best fold's binarizer is then used to transform the held-out test set. This prevents data leakage across folds and between train/test splits.
+
+By default a `StandardBinarizer()` is used. You can pass a custom binarizer (unfitted) via the `binarizer` parameter:
+
+```python
+from hgp_lib.preprocessing import StandardBinarizer
+
+binarizer = StandardBinarizer(num_bins=10)  # must be unfitted
+config = BenchmarkerConfig(
+    data=data,
+    labels=labels,
+    trainer_config=trainer_config,
+    binarizer=binarizer,  # None -> default StandardBinarizer(num_bins=5)
+)
+```
+
+**Feature names**: The `BenchmarkResult` includes `feature_names_per_run`, a list of `Dict[int, str]` mappings (one per run) from literal indices to the binarized column names. Use this to display rules in human-readable form:
+
+```python
+best_idx = np.argmax(result.all_test_scores)
+print(result.all_best_rules[best_idx].to_str(result.feature_names_per_run[best_idx]))
+```
+
 **Scorer Optimization**: The benchmarker can automatically optimize scorers per fold by deduplicating data and using sample weights. This significantly speeds up scoring for datasets with many duplicate rows. To use this feature, pass a base scorer (not pre-optimized) that accepts a `sample_weight` parameter, and set `optimize_scorer=True` in `BooleanGPConfig` (this is the default).
+
+**Full example**:
 
 ```python
 import numpy as np
+import pandas as pd
 from hgp_lib import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.benchmarkers import GPBenchmarker
 
@@ -246,9 +278,12 @@ def f1_score(predictions, labels, sample_weight=None):
         return 1.0 if pred_sum == label_sum == 0 else 0.0
     return 2 * tp / (pred_sum + label_sum)
 
+data = pd.DataFrame(...)  # raw features as a DataFrame (bool / categorical / numeric)
+labels = np.array(...)    # 1-D target array
+
 # Create nested configs: BooleanGPConfig -> TrainerConfig -> BenchmarkerConfig
 # Note: train_data/train_labels are not needed in gp_config here;
-# the benchmarker will set them per fold from the full dataset.
+# the benchmarker will binarize and set them per fold.
 gp_config = BooleanGPConfig(
     score_fn=f1_score,
     optimize_scorer=True,  # Default; enables scorer optimization per fold
@@ -269,8 +304,13 @@ config = BenchmarkerConfig(
 )
 benchmarker = GPBenchmarker(config)
 result = benchmarker.fit()
-# result.run_metrics, result.mean_test_score, result.std_test_score,
-# result.mean_best_val_score, result.std_best_val_score, result.all_test_scores, result.all_best_rules
+
+# Aggregated metrics
+print(f"Test score: {result.mean_test_score:.4f} ± {result.std_test_score:.4f}")
+
+# Human-readable best rule
+best_idx = np.argmax(result.all_test_scores)
+print(result.all_best_rules[best_idx].to_str(result.feature_names_per_run[best_idx]))
 ```
 
 **Important**: Do NOT pass pre-optimized scorers (e.g., from `optimize_scorer_for_data`) when using the benchmarker. Pre-optimized scorers have sample weights bound to the original data, which become invalid after train/test/fold splits. Either pass a base scorer with `optimize_scorer=True` (default), or use `optimize_scorer=False` for scorers without `sample_weight` support.

--- a/hgp_lib/benchmarkers/gp_benchmarker.py
+++ b/hgp_lib/benchmarkers/gp_benchmarker.py
@@ -10,27 +10,45 @@ from ..metrics import BenchmarkResult, RunMetrics
 from .progress import ProgressConfig, ProgressListener
 from .results import aggregate_results
 from .runner import execute_single_run, single_run_wrapper
+from ..preprocessing import StandardBinarizer
 
 
 class GPBenchmarker:
     """
-    Benchmarker for Boolean GP: runs multiple full runs with stratified train/test
-    split and k-fold CV per run, then aggregates results.
+    Benchmarker for Boolean GP: runs multiple independent experiments with
+    stratified train/test split and k-fold CV per run, then aggregates results.
 
-    Accepts a BenchmarkerConfig containing the full dataset, a TrainerConfig template,
-    and benchmarker-specific settings. Each run uses a different random seed.
-    Within each run, k-fold cross-validation is performed on the training set;
-    the best rule is selected from the fold with the best validation score and
-    evaluated on the held-out test set.
+    Data flow per run:
+
+    1. Stratified train/test split (using `test_size`).
+    2. For each of the `n_folds` folds:
+
+       a. A fresh copy of the `binarizer` is fitted on the training fold.
+       b. The validation fold is transformed using the same fitted binarizer.
+       c. Binarized data is converted to boolean numpy arrays and used for GP
+          training.
+
+    3. The best fold (highest validation score) is selected. Its binarizer is
+       used to transform the held-out test set for final evaluation.
+
+    Raw (non-binarized) data should be passed as a
+    `pandas.DataFrame` in `BenchmarkerConfig.data`. Binarization happens
+    internally per fold to prevent data leakage.
+
+    The `BenchmarkResult` includes `feature_names_per_run`, a mapping from
+    literal indices to the binarized column names, enabling human-readable
+    rule display via `rule.to_str(feature_names)`.
 
     Args:
-        config (BenchmarkerConfig): Configuration with data, labels, trainer_config
-            template, and benchmarker-specific options (num_runs, n_folds, etc.).
+        config (BenchmarkerConfig): Configuration with data,
+            labels, binarizer, trainer_config template, and benchmarker-specific
+            options. See `BenchmarkerConfig` for more details.
 
     Examples:
         Basic usage with scorer optimization::
 
             import numpy as np
+            import pandas as pd
             from hgp_lib.configs import BooleanGPConfig, TrainerConfig, BenchmarkerConfig
             from hgp_lib.benchmarkers import GPBenchmarker
 
@@ -46,11 +64,14 @@ class GPBenchmarker:
                     return 1.0 if pred_sum == label_sum == 0 else 0.0
                 return 2 * tp / (pred_sum + label_sum)
 
-            # Create template configs (data will be set per fold)
+            data = pd.DataFrame(...)  # raw features (bool / categorical / numeric)
+            labels = np.array(...)    # 1-D target array
+
+            # Create template configs (data will be binarized and set per fold)
             gp_config = BooleanGPConfig(score_fn=f1_score, optimize_scorer=True)
             trainer_config = TrainerConfig(gp_config=gp_config, num_epochs=100)
 
-            # Create benchmarker config
+            # Create benchmarker config (binarizer=None -> default StandardBinarizer)
             config = BenchmarkerConfig(
                 data=data,
                 labels=labels,
@@ -58,12 +79,20 @@ class GPBenchmarker:
             )
             benchmarker = GPBenchmarker(config)
             result = benchmarker.fit()
+
+            # Display the best rule in human-readable form
+            best_idx = np.argmax(result.all_test_scores)
+            print(result.all_best_rules[best_idx].to_str(
+                result.feature_names_per_run[best_idx]
+            ))
     """
 
     # TODO: This should be a doctest instead of an example.
     def __init__(self, config: BenchmarkerConfig):
         validate_benchmarker_config(config)
         self.config = config
+        if self.config.binarizer is None:
+            self.config.binarizer = StandardBinarizer()
         self._run_metrics: List[RunMetrics] | None = None
 
     def _effective_n_jobs(self) -> int:
@@ -141,9 +170,16 @@ class GPBenchmarker:
         """
         Run all benchmark runs (parallel or sequential) and aggregate results.
 
+        Each run performs a stratified train/test split, k-fold CV with per-fold
+        binarization, and test-set evaluation. Results across runs are aggregated
+        into mean/std statistics.
+
         Returns:
-            BenchmarkResult: run_metrics, mean_test_score, std_test_score,
-                mean_best_val_score, std_best_val_score, all_test_scores, all_best_rules.
+            BenchmarkResult: Contains `run_metrics`, `mean_test_score`,
+                `std_test_score`, `mean_best_val_score`, `std_best_val_score`,
+                `all_test_scores`, `all_best_rules`, and
+                `feature_names_per_run`.
+                See `BenchmarkResult` for detailed field descriptions.
         """
         effective_n_jobs = self._effective_n_jobs()
 

--- a/hgp_lib/benchmarkers/results.py
+++ b/hgp_lib/benchmarkers/results.py
@@ -23,9 +23,9 @@ def aggregate_results(run_metrics: List[RunMetrics]) -> BenchmarkResult:
         >>> rule = Literal(value=0)
         >>> metrics = [
         ...     RunMetrics(run_id=0, seed=0, fold_train_scores=[0.7], fold_val_scores=[0.75],
-        ...                best_fold_idx=0, test_score=0.8, best_fold_val_score=0.75, best_rule=rule),
+        ...                best_fold_idx=0, test_score=0.8, best_fold_val_score=0.75, best_rule=rule, feature_names={}),
         ...     RunMetrics(run_id=1, seed=1, fold_train_scores=[0.8], fold_val_scores=[0.85],
-        ...                best_fold_idx=0, test_score=0.9, best_fold_val_score=0.85, best_rule=rule),
+        ...                best_fold_idx=0, test_score=0.9, best_fold_val_score=0.85, best_rule=rule, feature_names={}),
         ... ]
         >>> result = aggregate_results(metrics)
         >>> round(result.mean_test_score, 2)
@@ -36,6 +36,7 @@ def aggregate_results(run_metrics: List[RunMetrics]) -> BenchmarkResult:
     test_scores = [m.test_score for m in run_metrics]
     best_val_scores = [m.best_fold_val_score for m in run_metrics]
     all_best_rules = [m.best_rule for m in run_metrics]
+    feature_names_per_run = [m.feature_names for m in run_metrics]
 
     return BenchmarkResult(
         run_metrics=run_metrics,
@@ -45,4 +46,5 @@ def aggregate_results(run_metrics: List[RunMetrics]) -> BenchmarkResult:
         std_best_val_score=float(np.std(best_val_scores)),
         all_test_scores=test_scores,
         all_best_rules=all_best_rules,
+        feature_names_per_run=feature_names_per_run,
     )

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -1,4 +1,5 @@
 import random
+from copy import deepcopy
 from dataclasses import replace
 from functools import partial
 from multiprocessing import Queue
@@ -24,20 +25,34 @@ def execute_single_run(
     progress_queue: Optional[Queue] = None,
 ) -> RunMetrics:
     """
-    Execute one benchmark run: stratified train/test split, k-fold CV, select best fold, test.
+    Execute one benchmark run: stratified train/test split, per-fold binarization,
+    k-fold CV training, best-fold selection, and test-set evaluation.
 
-    This is a module-level function so it can be pickled for process_map.
+    This is a module-level function so it can be pickled for `multiprocessing`.
+
+    **Per-fold binarization:** For each fold a fresh `deepcopy` of the configured
+    binarizer is fitted on the training fold (with labels, enabling supervised
+    binning for numerical features) and used to transform the validation fold.
+    After selecting the best fold, its binarizer transforms the held-out test
+    data. This prevents data leakage across folds and between train/test sets.
+
+    The resulting `RunMetrics` includes `feature_names`, a `Dict[int, str]`
+    mapping literal indices to binarized column names for the best fold's
+    binarizer. This enables human-readable display of the best rule.
 
     Args:
         run_id (int): Index of the run (0-based).
         seed (int): Random seed for stratified split and k-fold.
-        config (BenchmarkerConfig): Configuration for the benchmark run.
+        config (BenchmarkerConfig): Configuration for the benchmark run. See `BenchmarkerConfig` for more details.
         progress_queue (Queue | None): Optional queue for sending progress updates
             to the main process. When provided, local progress bars are disabled
             and progress is sent via the queue instead. Default: `None`.
 
     Returns:
-        RunMetrics: Metrics for the run including fold scores, best rule, and validation score.
+        RunMetrics: Contains `run_id`, `seed`, `fold_train_scores`,
+            `fold_val_scores`, `best_fold_idx`, `best_fold_val_score`,
+            `test_score`, `best_rule`, and `feature_names`.
+            See `RunMetrics` for detailed field descriptions.
 
     Raises:
         RuntimeError: If no best rule is available after training a fold.
@@ -77,11 +92,22 @@ def execute_single_run(
     epoch_callback = (
         partial(send_progress, progress_queue, "epoch") if use_queue else None
     )
+    binarizers = []
+    feature_names_per_binarizer = []
 
     for train_idx, val_idx in fold_splits:
-        fold_train = train_data[train_idx]
-        fold_val = train_data[val_idx]
+        fold_train = train_data.iloc[train_idx]
         fold_train_labels = train_labels[train_idx]
+
+        binarizer = deepcopy(config.binarizer)
+        fold_train = binarizer.fit_transform(fold_train, fold_train_labels)
+        binarizers.append(binarizer)
+        feature_names_per_binarizer.append(
+            {i: col for i, col in enumerate(fold_train.columns)}
+        )
+        fold_train = fold_train.to_numpy(dtype=bool)
+
+        fold_val = binarizer.transform(train_data.iloc[val_idx]).to_numpy(dtype=bool)
         fold_val_labels = train_labels[val_idx]
 
         fold_gp_config = replace(
@@ -129,6 +155,11 @@ def execute_single_run(
     best_fold_idx = int(np.argmax(fold_val_scores))
     best_fold_val_score = fold_val_scores[best_fold_idx]
     best_rule = fold_best_rules[best_fold_idx]
+    del train_data, train_labels
+
+    binarizer_here = binarizers[best_fold_idx]
+    feature_names = feature_names_per_binarizer[best_fold_idx]
+    test_data = binarizer_here.transform(test_data).to_numpy(dtype=bool)
 
     if gp_template.optimize_scorer:
         test_score_fn, test_data_opt, test_labels_opt = optimize_scorer_for_data(
@@ -153,6 +184,7 @@ def execute_single_run(
         best_fold_val_score=best_fold_val_score,
         test_score=test_score,
         best_rule=best_rule,
+        feature_names=feature_names,
     )
 
 

--- a/hgp_lib/configs/benchmarker_config.py
+++ b/hgp_lib/configs/benchmarker_config.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 
 from numpy import ndarray
+from pandas import DataFrame
+from sklearn.preprocessing import KBinsDiscretizer
 
+from ..preprocessing import StandardBinarizer
 from ..utils.validation import check_isinstance, check_X_y
 from .trainer_config import TrainerConfig, validate_trainer_config
 
@@ -15,24 +18,48 @@ class BenchmarkerConfig:
     will create TrainerConfig instances for each fold, replacing the data with fold-specific
     train/validation splits.
 
+    The benchmarker handles binarization internally: for each fold, it fits a fresh copy
+    of the binarizer on the training fold and transforms validation/test data with it.
+    This avoids data leakage (the binarizer never sees validation or test data during fitting).
+    Pass raw (non-binarized) data as a `pandas.DataFrame`.
+
     Attributes:
-        data (ndarray): Full dataset to be split into train/test and k-fold CV.
-        labels (ndarray): Labels for the full dataset.
+        data (DataFrame): Full dataset as a `pandas.DataFrame`. The benchmarker will
+            binarize it per-fold using the configured `binarizer`, then convert to a
+            boolean numpy array for the GP algorithm. Columns can be boolean, categorical,
+            or numeric.
+        labels (ndarray): Labels for the full dataset (1-D numpy array).
         trainer_config (TrainerConfig): Template configuration for training. The nested
-            gp_config does not need train_data/train_labels (they will be set per fold).
-        num_runs (int): Number of benchmark runs with different random seeds.
-        test_size (float): Fraction of data to hold out for testing.
-        n_folds (int): Number of folds for k-fold cross-validation.
-        n_jobs (int): Number of parallel jobs (-1 = all CPUs, 1 = sequential).
-        base_seed (int): Base random seed; each run uses base_seed + run_id.
-        show_run_progress (bool): Show progress bar for runs.
+            `gp_config` does not need `train_data`/`train_labels` (they will be set
+            per fold by the benchmarker).
+        binarizer (StandardBinarizer | KBinsDiscretizer | None): Binarizer to transform
+            features into boolean columns. A fresh `deepcopy` is fitted per fold so
+            the original stays unfitted. When `None` (default), a
+            `StandardBinarizer()` with default settings is used, which applies
+            one-hot-encoding to categorical features and decision-tree-based binarization
+            (5 bins) to numerical features. The binarizer must **not** be already fitted.
+            Default: `None`.
+        num_runs (int): Number of benchmark runs with different random seeds. Default: `30`.
+        test_size (float): Fraction of data to hold out for testing. Default: `0.2`.
+        n_folds (int): Number of folds for k-fold cross-validation. Default: `5`.
+        n_jobs (int): Number of parallel jobs (`-1` = all CPUs, `1` = sequential).
+            Default: `-1`.
+        base_seed (int): Base random seed; each run uses `base_seed + run_id`.
+            Default: `0`.
+        show_run_progress (bool): Show progress bar for runs. Default: `True`.
         show_fold_progress (bool): Show progress bar for folds within each run.
+            Default: `True`.
         show_epoch_progress (bool): Show progress bar for epochs within each fold.
+            Default: `True`.
 
     Examples:
         >>> import numpy as np
+        >>> import pandas as pd
         >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig, BenchmarkerConfig
-        >>> data = np.array([[True, False], [False, True], [True, True], [False, False]])
+        >>> data = pd.DataFrame({
+        ...     'feature1': [True, False, True, False],
+        ...     'feature2': [False, True, True, False],
+        ... })
         >>> labels = np.array([1, 0, 1, 0])
         >>> def accuracy(p, l): return float((p == l).mean())
         >>> gp_config = BooleanGPConfig(score_fn=accuracy)
@@ -46,9 +73,10 @@ class BenchmarkerConfig:
         2
     """
 
-    data: ndarray
+    data: DataFrame
     labels: ndarray
     trainer_config: TrainerConfig
+    binarizer: StandardBinarizer | KBinsDiscretizer | None = None
     num_runs: int = 30
     test_size: float = 0.2
     n_folds: int = 5
@@ -76,9 +104,13 @@ def validate_benchmarker_config(config: BenchmarkerConfig) -> None:
 
     Examples:
         >>> import numpy as np
+        >>> import pandas as pd
         >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig, BenchmarkerConfig
         >>> from hgp_lib.configs.benchmarker_config import validate_benchmarker_config
-        >>> data = np.array([[True, False], [False, True], [True, True], [False, False]])
+        >>> data = pd.DataFrame({
+        ...     'feature1': [True, False, True, False],
+        ...     'feature2': [False, True, True, False],
+        ... })
         >>> labels = np.array([1, 0, 1, 0])
         >>> def accuracy(p, l): return float((p == l).mean())
         >>> gp_config = BooleanGPConfig(score_fn=accuracy)
@@ -88,13 +120,21 @@ def validate_benchmarker_config(config: BenchmarkerConfig) -> None:
         ... )
         >>> validate_benchmarker_config(config)  # No error
     """
-    # Validate full dataset
-    check_X_y(config.data, config.labels)
+    check_X_y(config.data, config.labels, x_type=DataFrame)
 
     # Validate trainer config (without requiring data in gp_config)
     validate_trainer_config(config.trainer_config, require_data=False)
 
-    # Validate benchmarker-specific parameters
+    # TODO: Test that KBinsDiscretizer works end-to-end with the benchmarker runner.
+    #       The runner currently calls binarizer.fit_transform(X, y) and .transform(X)
+    #       and expects DataFrame outputs with .columns and .to_numpy(). KBinsDiscretizer
+    #       returns numpy arrays, so an adapter or protocol may be needed.
+    if config.binarizer is not None:
+        check_isinstance(config.binarizer, (StandardBinarizer, KBinsDiscretizer))
+        if hasattr(config.binarizer, "_is_fitted") and config.binarizer._is_fitted:
+            raise ValueError(
+                "binarizer must not be fitted before passing to BenchmarkerConfig"
+            )
     check_isinstance(config.num_runs, int)
     if config.num_runs < 1:
         raise ValueError("num_runs must be a positive integer")

--- a/hgp_lib/metrics/__init__.py
+++ b/hgp_lib/metrics/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict
 
 from numpy import ndarray
 
@@ -147,6 +147,7 @@ class TrainerResult:
 class RunMetrics:
     """
     Metrics returned by a single benchmark run.
+
     Attributes:
         run_id (int): Index of the run (0-based).
         seed (int): Random seed used for this run.
@@ -156,6 +157,9 @@ class RunMetrics:
         best_fold_val_score (float): Best validation score across folds.
         test_score (float): Test set score of the selected best rule.
         best_rule (Rule): The best rule selected from the best fold.
+        feature_names (Dict[int, str]): Mapping from literal indices to the
+            binarized column names produced by the best fold's binarizer.
+            Use with `rule.to_str(feature_names)` for human-readable output.
     """
 
     run_id: int
@@ -166,12 +170,14 @@ class RunMetrics:
     best_fold_val_score: float
     test_score: float
     best_rule: Rule
+    feature_names: Dict[int, str]
 
 
 @dataclass
 class BenchmarkResult:
     """
     Metrics returned by the benchmarker after fitting.
+
     Attributes:
         run_metrics (List[RunMetrics]): Per-run details.
         mean_test_score (float): Mean test score across runs.
@@ -180,6 +186,10 @@ class BenchmarkResult:
         std_best_val_score (float): Standard deviation of best validation scores.
         all_test_scores (List[float]): Test score for each run.
         all_best_rules (List[Rule]): Best rule from each run.
+        feature_names_per_run (List[Dict[int, str]]): Literal-index-to-column-name
+            mapping for each run's best rule. Use
+            `result.all_best_rules[i].to_str(result.feature_names_per_run[i])`
+            to display the *i*-th run's rule in human-readable form.
     """
 
     run_metrics: List[RunMetrics]
@@ -189,6 +199,7 @@ class BenchmarkResult:
     std_best_val_score: float
     all_test_scores: List[float]
     all_best_rules: List[Rule]
+    feature_names_per_run: List[Dict[int, str]]
 
 
 __all__ = [

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -79,6 +79,7 @@ class StandardBinarizer:
         self.column_precision = {}
         self.categorical_values_ = {}
         self.numerical_bins_ = {}
+        self._is_fitted = False
 
     def _validate_params(
         self, num_bins: int, column_strategy: Optional[dict[str, int]], precision: int
@@ -228,6 +229,7 @@ class StandardBinarizer:
                     f"Unsupported column type for column {column} of type {X[column].dtype}"
                 )
 
+        self._is_fitted = True
         return result
 
     def _format_numeric_bin_name(self, column: str, left: float, right: float) -> str:
@@ -272,7 +274,7 @@ class StandardBinarizer:
         """
         check_isinstance(X, pd.DataFrame)
 
-        if not self.categorical_values_ or not self.numerical_bins_:
+        if not self._is_fitted:
             raise ValueError("Binarizer must be fitted before calling transform")
 
         result = pd.DataFrame(index=X.index)

--- a/hgp_lib/utils/validation.py
+++ b/hgp_lib/utils/validation.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Sequence, Tuple, Type, Callable, Any
 import numpy as np
+import pandas as pd
 
 from ..rules import Rule
 
@@ -91,27 +92,34 @@ def validate_operator_types(operator_types: Sequence[Type[Rule]]):
             )
 
 
-def check_X_y(X: np.ndarray, y: np.ndarray):
+def check_X_y(
+    X: np.ndarray | pd.DataFrame,
+    y: np.ndarray,
+    x_type: Type[np.ndarray] | Type[pd.DataFrame] = np.ndarray,
+):
     """
     Validate input data and labels.
 
-    Checks that X and y are numpy arrays, have compatible shapes (same number of samples),
-    and are not None.
+    Checks that X is an instance of `x_type`, y is a numpy array, both are
+    non-None, non-empty, 2-D/1-D respectively, and have the same number of
+    samples.
 
     Args:
-        X (np.ndarray): Input data.
-        y (np.ndarray): Target labels.
+        X (np.ndarray | pd.DataFrame): Input data.
+        y (np.ndarray): Target labels (1-D).
+        x_type (Type[np.ndarray] | Type[pd.DataFrame]): Expected type for X.
+            Default: `np.ndarray`.
 
     Raises:
         ValueError: If X or y is None, empty, or have mismatched lengths.
-        TypeError: If X or y is not a numpy array.
+        TypeError: If X is not an instance of `x_type` or y is not an ndarray.
     """
     if X is None:
         raise ValueError("X (data) cannot be None")
     if y is None:
         raise ValueError("y (labels) cannot be None")
 
-    check_isinstance(X, np.ndarray)
+    check_isinstance(X, x_type)
     check_isinstance(y, np.ndarray)
 
     if len(X) != len(y):

--- a/scripts/paysim_benchmark.py
+++ b/scripts/paysim_benchmark.py
@@ -49,7 +49,6 @@ Requires preprocessed PaySim data in HDF format at data/PaySim.hdf
 
 import argparse
 from functools import partial
-import gc
 
 import numpy as np
 import pandas as pd
@@ -108,21 +107,7 @@ def f1_score(y_pred, y_true, sample_weight=None):
 # ==============================================================================
 
 
-def load_and_binarize_paysim(hdf_path: str, num_bins: int = 5):
-    """
-    Load PaySim data and binarize features.
-
-    The binarization converts continuous features into boolean features using
-    dt-based binning. Each original feature becomes `num_bins` boolean
-    features indicating which bin the value falls into.
-
-    Args:
-        hdf_path: Path to the preprocessed PaySim HDF file
-        num_bins: Number of bins for binarization
-
-    Returns:
-        Tuple of (data, labels, feature_names)
-    """
+def load_paysim(hdf_path: str):
     print(f"Loading data from {hdf_path}...")
     df: pd.DataFrame = pd.read_hdf(hdf_path)
 
@@ -141,19 +126,7 @@ def load_and_binarize_paysim(hdf_path: str, num_bins: int = 5):
     print(f"Loaded {len(data)} samples, {len(data.columns)} features")
     print(f"Fraud rate: {labels.mean():.4f} ({labels.sum()} fraud cases)")
 
-    # Binarize features using quantile-based binning
-    print(f"\nBinarizing features (num_bins={num_bins})...")
-    binarizer = StandardBinarizer(num_bins=num_bins)
-    data_bin = binarizer.fit_transform(data, labels)
-    feature_names = {i: col for i, col in enumerate(data_bin.columns)}
-
-    print(f"Binarized: {data_bin.shape[1]} features (from {data.shape[1]})")
-
-    data_bin = data_bin.values
-    del data
-    gc.collect()
-
-    return data_bin, labels, feature_names
+    return data, labels
 
 
 def is_valid(rule: Rule, max_rule_size: int) -> bool:
@@ -196,9 +169,7 @@ def main(args: argparse.Namespace):
     5. Print results with statistics
     """
     # Load data
-    data, labels, feature_names = load_and_binarize_paysim(
-        args.data_path, num_bins=args.num_bins
-    )
+    data, labels = load_paysim(args.data_path)
 
     # Create validity checker
     is_valid = create_validity_checker(args.max_rule_size)
@@ -256,10 +227,13 @@ def main(args: argparse.Namespace):
     print("BENCHMARK CONFIGURATION")
     print("=" * 60)
 
+    binarizer = StandardBinarizer(num_bins=args.num_bins)
+
     config = BenchmarkerConfig(
         data=data,
         labels=labels,
         trainer_config=trainer_config,
+        binarizer=binarizer,
         num_runs=args.num_runs,
         n_folds=args.n_folds,
         test_size=args.test_size,
@@ -335,7 +309,7 @@ def main(args: argparse.Namespace):
     print(f"\nBest rule (from run {best_run_idx}, score={scores[best_run_idx]:.4f}):")
     print(f"  {best_rule}")
     print("\nReadable form:")
-    print(f"  {best_rule.to_str(feature_names)}")
+    print(f"  {best_rule.to_str(result.feature_names_per_run[best_run_idx])}")
 
     print("\n" + "=" * 60)
     print("Benchmark completed!")

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,283 @@
+"""Tests for all config modules: BooleanGPConfig, TrainerConfig, BenchmarkerConfig."""
+
+import doctest
+import unittest
+
+import numpy as np
+import pandas as pd
+
+import hgp_lib.configs.boolean_gp_config
+import hgp_lib.configs.trainer_config
+import hgp_lib.configs.benchmarker_config
+from hgp_lib.configs import (
+    BenchmarkerConfig,
+    BooleanGPConfig,
+    TrainerConfig,
+    validate_benchmarker_config,
+    validate_gp_config,
+    validate_trainer_config,
+)
+from hgp_lib.preprocessing import StandardBinarizer
+
+
+def accuracy(predictions, labels):
+    """Module-level score function."""
+    return float((predictions == labels).mean())
+
+
+class TestBooleanGPConfig(unittest.TestCase):
+    """Tests for BooleanGPConfig and validate_gp_config."""
+
+    def setUp(self):
+        self.data = np.array(
+            [[True, False], [False, True], [True, True], [False, False]]
+        )
+        self.labels = np.array([1, 0, 1, 0])
+
+    def test_valid_config(self):
+        config = BooleanGPConfig(
+            score_fn=accuracy, train_data=self.data, train_labels=self.labels
+        )
+        validate_gp_config(config)  # Should not raise
+
+    def test_valid_config_without_data(self):
+        """Template config for benchmarker (no data required)."""
+        config = BooleanGPConfig(score_fn=accuracy)
+        validate_gp_config(config, require_data=False)  # Should not raise
+
+    def test_missing_data_raises(self):
+        config = BooleanGPConfig(score_fn=accuracy)
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=True)
+
+    def test_score_fn_must_be_callable(self):
+        with self.assertRaises(TypeError):
+            config = BooleanGPConfig(score_fn="not callable")
+            validate_gp_config(config, require_data=False)
+
+    def test_regeneration_patience_must_be_positive(self):
+        config = BooleanGPConfig(
+            score_fn=accuracy, regeneration=True, regeneration_patience=0
+        )
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=False)
+
+    def test_max_depth_requires_sampling_strategy(self):
+        config = BooleanGPConfig(
+            score_fn=accuracy, max_depth=1, num_child_populations=3
+        )
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=False)
+
+    def test_max_depth_requires_child_populations(self):
+        config = BooleanGPConfig(
+            score_fn=accuracy, max_depth=1, num_child_populations=0
+        )
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=False)
+
+    def test_feedback_type_invalid(self):
+        config = BooleanGPConfig(score_fn=accuracy, feedback_type="invalid")
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=False)
+
+    def test_feedback_strength_must_be_positive(self):
+        config = BooleanGPConfig(score_fn=accuracy, feedback_strength=0)
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=False)
+
+    def test_top_k_transfer_must_be_at_least_1(self):
+        config = BooleanGPConfig(score_fn=accuracy, top_k_transfer=0)
+        with self.assertRaises(ValueError):
+            validate_gp_config(config, require_data=False)
+
+    def test_defaults(self):
+        config = BooleanGPConfig(score_fn=accuracy)
+        self.assertTrue(config.optimize_scorer)
+        self.assertFalse(config.regeneration)
+        self.assertEqual(config.regeneration_patience, 100)
+        self.assertEqual(config.max_depth, 0)
+        self.assertEqual(config.num_child_populations, 0)
+        self.assertIsNone(config.population_generator)
+        self.assertIsNone(config.mutation_executor)
+        self.assertIsNone(config.crossover_executor)
+        self.assertIsNone(config.selection)
+
+
+class TestTrainerConfig(unittest.TestCase):
+    """Tests for TrainerConfig and validate_trainer_config."""
+
+    def setUp(self):
+        self.data = np.array(
+            [[True, False], [False, True], [True, True], [False, False]]
+        )
+        self.labels = np.array([1, 0, 1, 0])
+        self.gp_config = BooleanGPConfig(
+            score_fn=accuracy, train_data=self.data, train_labels=self.labels
+        )
+
+    def test_valid_config(self):
+        config = TrainerConfig(gp_config=self.gp_config, num_epochs=10)
+        validate_trainer_config(config)  # Should not raise
+
+    def test_valid_config_without_data(self):
+        gp_config = BooleanGPConfig(score_fn=accuracy)
+        config = TrainerConfig(gp_config=gp_config, num_epochs=10)
+        validate_trainer_config(config, require_data=False)  # Should not raise
+
+    def test_num_epochs_must_be_int(self):
+        config = TrainerConfig(gp_config=self.gp_config, num_epochs=5.0)
+        with self.assertRaises(TypeError):
+            validate_trainer_config(config)
+
+    def test_num_epochs_must_be_positive(self):
+        config = TrainerConfig(gp_config=self.gp_config, num_epochs=0)
+        with self.assertRaises(ValueError):
+            validate_trainer_config(config)
+
+    def test_val_every_must_be_positive(self):
+        config = TrainerConfig(gp_config=self.gp_config, num_epochs=10, val_every=0)
+        with self.assertRaises(ValueError):
+            validate_trainer_config(config)
+
+    def test_val_data_and_labels_must_both_be_provided(self):
+        config = TrainerConfig(
+            gp_config=self.gp_config,
+            num_epochs=10,
+            val_data=self.data,
+            val_labels=None,
+        )
+        with self.assertRaises(ValueError):
+            validate_trainer_config(config)
+
+    def test_valid_with_validation_data(self):
+        config = TrainerConfig(
+            gp_config=self.gp_config,
+            num_epochs=10,
+            val_data=self.data,
+            val_labels=self.labels,
+        )
+        validate_trainer_config(config)  # Should not raise
+
+    def test_defaults(self):
+        config = TrainerConfig(gp_config=self.gp_config, num_epochs=10)
+        self.assertEqual(config.val_every, 100)
+        self.assertTrue(config.progress_bar)
+        self.assertTrue(config.leave_progress_bar)
+        self.assertIsNone(config.progress_callback)
+        self.assertEqual(config.progress_update_interval, 100)
+
+
+class TestBenchmarkerConfig(unittest.TestCase):
+    """Tests for BenchmarkerConfig and validate_benchmarker_config."""
+
+    def setUp(self):
+        self.data = pd.DataFrame(
+            {
+                "feature1": [True, False, True, False, True, False, True, False],
+                "feature2": [False, True, True, False, False, True, True, False],
+            }
+        )
+        self.labels = np.array([1, 0, 1, 0, 1, 0, 1, 0])
+        self.gp_config = BooleanGPConfig(score_fn=accuracy)
+        self.trainer_config = TrainerConfig(gp_config=self.gp_config, num_epochs=5)
+
+    def _make_config(self, **kwargs):
+        defaults = dict(
+            data=self.data,
+            labels=self.labels,
+            trainer_config=self.trainer_config,
+            n_folds=2,
+        )
+        defaults.update(kwargs)
+        return BenchmarkerConfig(**defaults)
+
+    def test_valid_config(self):
+        config = self._make_config()
+        validate_benchmarker_config(config)  # Should not raise
+
+    def test_data_must_be_dataframe(self):
+        with self.assertRaises(TypeError):
+            config = self._make_config(data=self.data.to_numpy())
+            validate_benchmarker_config(config)
+
+    def test_data_string_rejected(self):
+        with self.assertRaises(TypeError):
+            config = self._make_config(data="not a dataframe")
+            validate_benchmarker_config(config)
+
+    def test_labels_must_be_ndarray(self):
+        with self.assertRaises(TypeError):
+            config = self._make_config(labels="not array")
+            validate_benchmarker_config(config)
+
+    def test_labels_length_must_match(self):
+        with self.assertRaises(ValueError):
+            config = self._make_config(labels=np.array([1, 0]))
+            validate_benchmarker_config(config)
+
+    def test_num_runs_must_be_positive(self):
+        with self.assertRaises(ValueError):
+            config = self._make_config(num_runs=0)
+            validate_benchmarker_config(config)
+
+    def test_test_size_must_be_in_range(self):
+        with self.assertRaises(ValueError):
+            config = self._make_config(test_size=0.0)
+            validate_benchmarker_config(config)
+        with self.assertRaises(ValueError):
+            config = self._make_config(test_size=1.0)
+            validate_benchmarker_config(config)
+
+    def test_n_folds_must_be_at_least_2(self):
+        with self.assertRaises(ValueError):
+            config = self._make_config(n_folds=1)
+            validate_benchmarker_config(config)
+
+    def test_fitted_binarizer_rejected(self):
+        binarizer = StandardBinarizer(num_bins=2)
+        binarizer.fit_transform(self.data)
+        with self.assertRaises(ValueError):
+            config = self._make_config(binarizer=binarizer)
+            validate_benchmarker_config(config)
+
+    def test_custom_binarizer_accepted(self):
+        binarizer = StandardBinarizer(num_bins=3)
+        config = self._make_config(binarizer=binarizer)
+        validate_benchmarker_config(config)  # Should not raise
+
+    def test_invalid_binarizer_type(self):
+        with self.assertRaises(TypeError):
+            config = self._make_config(binarizer="not a binarizer")
+            validate_benchmarker_config(config)
+
+    def test_defaults(self):
+        config = self._make_config()
+        self.assertEqual(config.num_runs, 30)
+        self.assertEqual(config.test_size, 0.2)
+        self.assertEqual(config.n_jobs, -1)
+        self.assertEqual(config.base_seed, 0)
+        self.assertTrue(config.show_run_progress)
+        self.assertTrue(config.show_fold_progress)
+        self.assertTrue(config.show_epoch_progress)
+        self.assertIsNone(config.binarizer)
+
+
+class TestConfigDoctests(unittest.TestCase):
+    """Run doctests for all config modules."""
+
+    def test_boolean_gp_config_doctests(self):
+        result = doctest.testmod(hgp_lib.configs.boolean_gp_config, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+
+    def test_trainer_config_doctests(self):
+        result = doctest.testmod(hgp_lib.configs.trainer_config, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+
+    def test_benchmarker_config_doctests(self):
+        result = doctest.testmod(hgp_lib.configs.benchmarker_config, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -3,6 +3,7 @@ import unittest
 import random
 
 import numpy as np
+import pandas as pd
 
 import hgp_lib
 from hgp_lib.benchmarkers import GPBenchmarker
@@ -14,6 +15,7 @@ from hgp_lib.mutations import (
     create_standard_operator_mutations,
 )
 from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule
 from hgp_lib.selections import RouletteSelection
 
@@ -36,17 +38,20 @@ class TestGPBenchmarker(unittest.TestCase):
         random.seed(42)
         np.random.seed(42)
 
-        self.data = np.array(
-            [
-                [True, False, True, False],
-                [False, True, False, True],
-                [True, True, False, False],
-                [False, False, True, True],
-                [True, False, False, True],
-                [False, True, True, False],
-                [True, True, True, False],
-                [False, False, False, True],
-            ]
+        self.data = pd.DataFrame(
+            np.array(
+                [
+                    [True, False, True, False],
+                    [False, True, False, True],
+                    [True, True, False, False],
+                    [False, False, True, True],
+                    [True, False, False, True],
+                    [False, True, True, False],
+                    [True, True, True, False],
+                    [False, False, False, True],
+                ]
+            ),
+            columns=["0", "1", "2", "3"],
         )
         self.labels = np.array([1, 0, 1, 0, 1, 0, 1, 0])
         self.num_features = 4
@@ -110,9 +115,9 @@ class TestGPBenchmarker(unittest.TestCase):
                 config = self._make_config(trainer_config=trainer_config)
                 GPBenchmarker(config)
 
-        with self.subTest("data must be ndarray"):
+        with self.subTest("data must be a DataFrame"):
             with self.assertRaises(TypeError):
-                config = self._make_config(data="not array")
+                config = self._make_config(data="not a dataframe")
                 GPBenchmarker(config)
 
         with self.subTest("labels must be ndarray"):
@@ -152,7 +157,7 @@ class TestGPBenchmarker(unittest.TestCase):
 
         with self.subTest("data must be 2D"):
             with self.assertRaises(ValueError):
-                config = self._make_config(data=np.array([1, 2, 3]))
+                config = self._make_config(data=pd.DataFrame(np.array([1, 2, 3])))
                 GPBenchmarker(config)
 
         with self.subTest("labels must be 1D"):
@@ -224,6 +229,12 @@ class TestGPBenchmarker(unittest.TestCase):
         self.assertEqual(len(result.run_metrics), 2)
         self.assertEqual(len(result.all_test_scores), 2)
 
+        # feature_names_per_run should have one entry per run
+        self.assertEqual(len(result.feature_names_per_run), 2)
+        for fn_map in result.feature_names_per_run:
+            self.assertIsInstance(fn_map, dict)
+            self.assertTrue(len(fn_map) > 0)
+
     def test_fit_run_metrics_structure(self):
         trainer_config = self._make_trainer_config(num_epochs=3)
         config = self._make_config(trainer_config=trainer_config, num_runs=1, n_jobs=1)
@@ -243,6 +254,13 @@ class TestGPBenchmarker(unittest.TestCase):
         self.assertEqual(len(run_metrics.fold_train_scores), 2)
         self.assertEqual(len(run_metrics.fold_val_scores), 2)
         self.assertIsInstance(run_metrics.best_rule, Rule)
+
+        # feature_names should map literal indices to column names
+        self.assertIsInstance(run_metrics.feature_names, dict)
+        self.assertTrue(len(run_metrics.feature_names) > 0)
+        for idx, name in run_metrics.feature_names.items():
+            self.assertIsInstance(idx, int)
+            self.assertIsInstance(name, str)
 
     def test_fit_aggregation(self):
         trainer_config = self._make_trainer_config(num_epochs=3)
@@ -379,6 +397,61 @@ class TestGPBenchmarker(unittest.TestCase):
         """Test that optimize_scorer defaults to True in BooleanGPConfig."""
         gp_config = BooleanGPConfig(score_fn=accuracy_with_sample_weight)
         self.assertTrue(gp_config.optimize_scorer)
+
+    def test_default_binarizer_is_set(self):
+        """Test that a default StandardBinarizer is created when binarizer=None."""
+        config = self._make_config()
+        benchmarker = GPBenchmarker(config)
+        self.assertIsInstance(benchmarker.config.binarizer, StandardBinarizer)
+
+    def test_custom_binarizer(self):
+        """Test that a custom StandardBinarizer with non-default bins is used."""
+        binarizer = StandardBinarizer(num_bins=3)
+        config = self._make_config(binarizer=binarizer)
+        benchmarker = GPBenchmarker(config)
+        self.assertIs(benchmarker.config.binarizer, binarizer)
+        result = benchmarker.fit()
+        self.assertEqual(len(result.run_metrics), 2)
+
+    def test_fitted_binarizer_rejected(self):
+        """Test that a pre-fitted binarizer is rejected during validation."""
+        binarizer = StandardBinarizer(num_bins=2)
+        binarizer.fit_transform(self.data)
+        self.assertTrue(binarizer._is_fitted)
+        with self.assertRaises(ValueError):
+            config = self._make_config(binarizer=binarizer)
+            GPBenchmarker(config)
+
+    def test_data_must_be_dataframe(self):
+        """Test that passing a numpy array as data raises TypeError."""
+        with self.assertRaises(TypeError):
+            config = self._make_config(data=self.data.to_numpy())
+            GPBenchmarker(config)
+
+    def test_feature_names_enable_readable_rules(self):
+        """Test that feature_names can be used with rule.to_str() for readable output."""
+        trainer_config = self._make_trainer_config(num_epochs=3)
+        config = self._make_config(trainer_config=trainer_config, num_runs=1, n_jobs=1)
+        benchmarker = GPBenchmarker(config)
+        result = benchmarker.fit()
+
+        best_rule = result.all_best_rules[0]
+        feature_names = result.feature_names_per_run[0]
+
+        # to_str should succeed and return a non-empty string
+        readable = best_rule.to_str(feature_names)
+        self.assertIsInstance(readable, str)
+        self.assertTrue(len(readable) > 0)
+
+    def test_feature_names_consistent_across_result(self):
+        """Test that feature_names in RunMetrics matches feature_names_per_run in BenchmarkResult."""
+        trainer_config = self._make_trainer_config(num_epochs=2)
+        config = self._make_config(trainer_config=trainer_config, num_runs=2, n_jobs=1)
+        benchmarker = GPBenchmarker(config)
+        result = benchmarker.fit()
+
+        for i, run_metrics in enumerate(result.run_metrics):
+            self.assertEqual(run_metrics.feature_names, result.feature_names_per_run[i])
 
     def test_doctests(self):
         result = doctest.testmod(hgp_lib.benchmarkers.gp_benchmarker, verbose=False)


### PR DESCRIPTION
* Fixes #41. 
* Binarization is now part of the benchmarker. Binarization is fitted on the train data, and transforms the validation and test data using the train set's configuration.
* Updated documentation, docstrings and tests.
* Added `_is_fitted` attribute to binarizer.
* Fixed scripts. 