### PR TITLE
Factory Pattern for PopulationGenerator and MutationExecutor construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ val_data = binarizer.transform(val_data)
 test_data = binarizer.transform(test_data)
 ```
 
-**Config-based API**: The library uses dataclass configs (`BooleanGPConfig`, `TrainerConfig`, `BenchmarkerConfig`) for all main components. When you pass training data in a config, **the number of features is derived from the data** (`train_data.shape[1]`), so you do not need to pass `num_literals` when using default population generator and mutation executor.
+**Config-based API**: The library uses dataclass configs (`BooleanGPConfig`, `TrainerConfig`, `BenchmarkerConfig`) for all main components. When you pass training data in a config, **the number of features is derived from the data** (`train_data.shape[1]`) and passed to the configured `PopulationGeneratorFactory` and `MutationExecutorFactory` at runtime, so you do not need to pass `num_literals` when using the default factories.
 
 ### Simple training
 
@@ -70,12 +70,13 @@ test_metrics = trainer.score(test_data, test_labels)
 
 ### Hyperparameter configuration
 
+The `PopulationGeneratorFactory` and `MutationExecutorFactory` hold config-time parameters and build the actual `PopulationGenerator` / `MutationExecutor` at runtime (when `num_features` is known from the data). Subclass either factory to use custom strategies or mutations.
 
 ```python
-from hgp_lib.mutations import create_mutation_executor
 from hgp_lib.crossover import CrossoverExecutor
+from hgp_lib.mutations import MutationExecutorFactory
+from hgp_lib.populations import PopulationGeneratorFactory, BestLiteralStrategy
 from hgp_lib.selections import TournamentSelection, RouletteSelection, ParetoSelection
-from hgp_lib.populations import PopulationGenerator, RandomStrategy, BestLiteralStrategy
 from hgp_lib.rules import Rule
 
 max_rule_size = 100
@@ -94,29 +95,24 @@ def is_rule_valid(rule: Rule) -> bool:
     return True
 
 
-num_features = train_data.shape[1]  # Derive from data; no need to pass num_literals into config when using defaults
-random_strategy = RandomStrategy(num_literals=num_features)
-best_literal_strategy = BestLiteralStrategy(
-    num_literals=num_features,
-    score_fn=score_fn,
-    train_data=train_data,
-    train_labels=train_labels,
-    sample_size=0.1,  # Use 10% of data for evaluation
-    feature_size=0.5  # Use 50% of features for evaluation
-)
+# Population factory (default uses RandomStrategy)
+population_factory = PopulationGeneratorFactory(population_size=population_size)
 
-population_generator = PopulationGenerator(
-    strategies=[random_strategy, best_literal_strategy],
-    population_size=population_size,
-    weights=[0.8, 0.2]  # 80% Random, 20% Best Literal
-)
+# Subclass to use custom strategies (e.g. BestLiteralStrategy)
+class MyPopulationFactory(PopulationGeneratorFactory):
+    def create_strategies(self, num_literals, score_fn, train_data, train_labels):
+        return [BestLiteralStrategy(
+            num_literals=num_literals,
+            score_fn=score_fn,
+            train_data=train_data,
+            train_labels=train_labels,
+            sample_size=0.1,  # Use 10% of data for evaluation
+            feature_size=0.5, # Use 50% of features for evaluation
+        )]
 
-mutation_executor = create_mutation_executor(
-    num_literals=num_features, # Mandatory
-    mutation_p=mutation_p,  # Optional
-    check_valid=is_rule_valid,  # Optional
-    num_tries=10,  # Optional
-)
+# Mutation factory (default uses standard literal and operator mutations)
+mutation_factory = MutationExecutorFactory(mutation_p=mutation_p)
+
 crossover_executor = CrossoverExecutor(
     crossover_p=crossover_p,  # Optional
     crossover_strategy="best",  # Optional. Default: `"random"`
@@ -135,50 +131,64 @@ selection = TournamentSelection(size=10, selection_probability=0.4)
 
 The `PopulationGenerator` creates the initial set of rules. It uses a strategy pattern to allow for different initialization methods.
 
+When using `BooleanGPConfig`, pass a `PopulationGeneratorFactory` instead of a `PopulationGenerator` directly. The factory defers construction until the number of features is known from the data. Override `create_strategies` to use custom strategies:
+
 ```python
-from hgp_lib.populations import PopulationGenerator, RandomStrategy, BestLiteralStrategy
+from hgp_lib.populations import (
+    PopulationGeneratorFactory, PopulationGenerator,
+    RandomStrategy, BestLiteralStrategy,
+)
 
-# Simple Random Strategy
-# Generates rules with one operator (And/Or) and two random literals
+# Default factory: uses RandomStrategy, constructs the generator at runtime
+factory = PopulationGeneratorFactory(population_size=100)
+
+# Custom factory with BestLiteralStrategy
+class MyFactory(PopulationGeneratorFactory):
+    def create_strategies(self, num_literals, score_fn, train_data, train_labels):
+        random = RandomStrategy(num_literals=num_literals)
+        best = BestLiteralStrategy(
+            num_literals=num_literals,
+            score_fn=score_fn,
+            train_data=train_data,
+            train_labels=train_labels,
+            sample_size=100,    # Evaluate on 100 random samples
+            feature_size=None,  # Evaluate all features
+        )
+        return [random, best]
+
+factory = MyFactory(population_size=100)
+```
+
+You can also create a `PopulationGenerator` directly for standalone use (outside of `BooleanGPConfig`):
+
+```python
 random_strategy = RandomStrategy(num_literals=10)
-
-# Best Literal Strategy
-# Evaluates all single literals on a subset of data and picks the best one
-best_literal_strategy = BestLiteralStrategy(
-    num_literals=10,
-    score_fn=my_score_fn,
-    train_data=X_train,
-    train_labels=y_train,
-    sample_size=100,  # Evaluate on 100 random samples
-    feature_size=None # Evaluate all features
-)
-
-# Combine strategies
 generator = PopulationGenerator(
-    strategies=[random_strategy, best_literal_strategy],
+    strategies=[random_strategy],
     population_size=100,
-    weights=[0.7, 0.3] # 70% of rules from Random, 30% from Best Literal
 )
-
 initial_population = generator.generate()
 ```
 
 ### Low level usage with fine control
 
-Use `BooleanGPConfig` to configure the algorithm. Training data is passed in the config; **the number of features (num_features) is derived from the data shape**, so you do not need to pass `num_literals` separately when using default population generator and mutation executor.
+Use `BooleanGPConfig` to configure the algorithm. Training data is passed in the config; **the number of features (`num_features`) is derived from the data shape** and passed to the configured `population_factory` and `mutation_factory` for runtime construction.
 
 ```python
 from hgp_lib import BooleanGPConfig
 from hgp_lib.algorithms import BooleanGP
+from hgp_lib.mutations import MutationExecutorFactory
+from hgp_lib.populations import PopulationGeneratorFactory
 
 gp_config = BooleanGPConfig(
     train_data=train_data,
     train_labels=train_labels,
     score_fn=score_fn,
-    population_generator=population_generator,  # Optional; default uses num_features from data
-    mutation_executor=mutation_executor,  # Optional; default uses num_features from data
+    population_factory=population_factory,  # Optional; default PopulationGeneratorFactory()
+    mutation_factory=mutation_factory,  # Optional; default MutationExecutorFactory()
     crossover_executor=crossover_executor,
     selection=selection,
+    check_valid=is_rule_valid,
     regeneration=regeneration,
     regeneration_patience=regeneration_patience,
 )
@@ -208,10 +218,11 @@ gp_config = BooleanGPConfig(
     train_data=train_data,
     train_labels=train_labels,
     score_fn=score_fn,
-    population_generator=population_generator,
-    mutation_executor=mutation_executor,
+    population_factory=population_factory,  # Optional; default PopulationGeneratorFactory()
+    mutation_factory=mutation_factory,  # Optional; default MutationExecutorFactory()
     crossover_executor=crossover_executor,
     selection=selection,
+    check_valid=is_rule_valid,
     regeneration=regeneration,
     regeneration_patience=regeneration_patience,
 )

--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -7,10 +7,6 @@ from numpy import ndarray
 from ..configs import BooleanGPConfig, validate_gp_config
 from ..crossover import CrossoverExecutor
 from ..metrics import StepMetrics, ValidateBestMetrics, ValidatePopulationMetrics
-from ..mutations import (
-    create_default_mutation_executor,
-)
-from ..populations.populations_factory import create_default_population_generator
 from ..rules import Rule
 from ..selections import TournamentSelection
 from ..utils.metrics import optimize_scorer_for_data
@@ -28,15 +24,15 @@ class BooleanGP:
     real best rule (all-time best across regenerations). When enabled, regeneration
     resets the population if no improvement is observed for a specified number of epochs.
 
-    Training data and labels are provided via BooleanGPConfig. The number of features
-    (num_features) is derived from the data shape, simplifying PopulationGenerator and
-    MutationExecutor setup when defaults are used.
+    Training data and labels are provided via `BooleanGPConfig`. The number of features
+    (`num_features`) is derived from the data shape and passed to the configured
+    `population_factory` and `mutation_factory` for runtime construction of the
+    `PopulationGenerator` and `MutationExecutor`.
 
     Args:
-        config (BooleanGPConfig): Configuration containing train_data, train_labels,
-            score_fn, and optional components. If population_generator or
-            mutation_executor are None, they are created using num_features derived
-            from config.train_data.shape[1].
+        config (BooleanGPConfig): Configuration containing `train_data`,
+            `train_labels`, `score_fn`, `population_factory`,
+            `mutation_factory`, and optional components.
 
     Examples:
         >>> import numpy as np
@@ -84,20 +80,11 @@ class BooleanGP:
         self.current_depth = current_depth
         num_features = train_data.shape[1]
 
-        population_generator_fn = (
-            config.population_generator_fn or create_default_population_generator
+        population_generator = config.population_factory.create(
+            num_features, score_fn, train_data, train_labels
         )
-        population_generator = population_generator_fn(
-            config.population_size, num_features, score_fn, train_data, train_labels
-        )
-
-        mutation_executor_fn = (
-            config.mutation_executor_fn or create_default_mutation_executor
-        )
-        mutation_executor = mutation_executor_fn(
-            num_literals=num_features,
-            mutation_p=config.mutation_p,
-            check_valid=config.check_valid,
+        mutation_executor = config.mutation_factory.create(
+            num_features, config.check_valid
         )
 
         crossover_executor = config.crossover_executor

--- a/hgp_lib/benchmarkers/results.py
+++ b/hgp_lib/benchmarkers/results.py
@@ -23,9 +23,11 @@ def aggregate_results(run_metrics: List[RunMetrics]) -> BenchmarkResult:
         >>> rule = Literal(value=0)
         >>> metrics = [
         ...     RunMetrics(run_id=0, seed=0, fold_train_scores=[0.7], fold_val_scores=[0.75],
-        ...                best_fold_idx=0, test_score=0.8, best_fold_val_score=0.75, best_rule=rule, feature_names={}),
+        ...                best_fold_idx=0, test_score=0.8, best_fold_val_score=0.75, best_rule=rule,
+        ...                feature_names={}, fold_train_histories=None, fold_val_histories=None),
         ...     RunMetrics(run_id=1, seed=1, fold_train_scores=[0.8], fold_val_scores=[0.85],
-        ...                best_fold_idx=0, test_score=0.9, best_fold_val_score=0.85, best_rule=rule, feature_names={}),
+        ...                best_fold_idx=0, test_score=0.9, best_fold_val_score=0.85, best_rule=rule,
+        ...                feature_names={}, fold_train_histories=None, fold_val_histories=None),
         ... ]
         >>> result = aggregate_results(metrics)
         >>> round(result.mean_test_score, 2)

--- a/hgp_lib/configs/boolean_gp_config.py
+++ b/hgp_lib/configs/boolean_gp_config.py
@@ -1,12 +1,12 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable
 
 from numpy import ndarray
 
 from ..crossover import CrossoverExecutor
-from ..mutations.mutation_factory import create_mutation_executor_fn_type
+from ..mutations.mutation_factory import MutationExecutorFactory
 from ..populations import SamplingStrategy
-from ..populations.populations_factory import create_population_generator_fn_type
+from ..populations.populations_factory import PopulationGeneratorFactory
 from ..rules import Rule
 from ..selections import BaseSelection
 from ..utils.validation import check_isinstance, check_X_y, validate_callable
@@ -18,26 +18,44 @@ class BooleanGPConfig:
     Configuration for BooleanGP.
 
     Attributes:
-        score_fn (Callable): Fitness function (predictions, labels) -> float.
-        train_data (ndarray | None): Training data (2D boolean array). Can be None when
-            used as a template in BenchmarkerConfig (data provided at benchmarker level).
-        train_labels (ndarray | None): Training labels (1D integer array). Can be None
-            when used as a template in BenchmarkerConfig.
-        population_generator (PopulationGenerator | None): Optional; default created from num_features.
-        crossover_executor (CrossoverExecutor | None): Optional; default CrossoverExecutor().
-        selection (BaseSelection | None): Optional; default TournamentSelection().
-        optimize_scorer (bool): Whether to optimize scorer via data deduplication and sample weights.
-        regeneration (bool): Whether to regenerate population on plateau.
+        score_fn (Callable): Fitness function `(predictions, labels) -> float`.
+        train_data (ndarray | None): Training data (2-D boolean array). Can be `None` when
+            used as a template in `BenchmarkerConfig` (data provided at benchmarker level).
+            Default: `None`.
+        train_labels (ndarray | None): Training labels (1-D integer array). Can be `None`
+            when used as a template in `BenchmarkerConfig`. Default: `None`.
+        population_factory (PopulationGeneratorFactory): Factory that creates the
+            `PopulationGenerator` at runtime. Override `create_strategies` on the
+            factory to use custom strategies (e.g., `BestLiteralStrategy`).
+            Default: `PopulationGeneratorFactory()` (population_size=100, RandomStrategy).
+        mutation_factory (MutationExecutorFactory): Factory that creates the
+            `MutationExecutor` at runtime. Override `create_literal_mutations` /
+            `create_operator_mutations` on the factory to use custom mutations.
+            Default: `MutationExecutorFactory()` (mutation_p=0.1, standard mutations).
+        crossover_executor (CrossoverExecutor | None): Optional; default `CrossoverExecutor()`.
+            Default: `None`.
+        selection (BaseSelection | None): Optional; default `TournamentSelection()`.
+            Default: `None`.
+        optimize_scorer (bool): Whether to optimize scorer via data deduplication and
+            sample weights. Default: `True`.
+        regeneration (bool): Whether to regenerate population on plateau. Default: `False`.
         regeneration_patience (int): Epochs without improvement before regeneration.
-        check_valid (Callable[[Rule], bool] | None): Optional rule validator for mutation/crossover.
-        num_child_populations (int): Number of child populations for hierarchical GP. Default: 0.
-        max_depth (int): Maximum hierarchical depth; 0 means no children. Default: 0.
+            Default: `100`.
+        check_valid (Callable[[Rule], bool] | None): Optional rule validator for
+            mutation/crossover. Default: `None`.
+        num_child_populations (int): Number of child populations for hierarchical GP.
+            Default: `0`.
+        max_depth (int): Maximum hierarchical depth; `0` means no children.
             Root population has current_depth=0, its children have current_depth=1, etc.
-        sampling_strategy (SamplingStrategy | None): Strategy for sampling data/features for children.
-            Required when max_depth > 0. Default: None.
-        top_k_transfer (int): Number of top rules to transfer from each child to parent. Default: 10.
-        feedback_type (str): How to apply parent feedback: "additive" or "multiplicative". Default: "multiplicative".
-        feedback_strength (float): Coefficient for feedback signal. Must be > 0. Default: 0.1.
+            Default: `0`.
+        sampling_strategy (SamplingStrategy | None): Strategy for sampling data/features
+            for children. Required when `max_depth > 0`. Default: `None`.
+        top_k_transfer (int): Number of top rules to transfer from each child to parent.
+            Default: `10`.
+        feedback_type (str): How to apply parent feedback: `"additive"` or
+            `"multiplicative"`. Default: `"multiplicative"`.
+        feedback_strength (float): Coefficient for feedback signal. Must be > 0.
+            Default: `0.1`.
 
     Examples:
         >>> import numpy as np
@@ -50,28 +68,28 @@ class BooleanGPConfig:
         (4, 2)
         >>> config.optimize_scorer
         True
+        >>> config.population_factory.population_size
+        100
+        >>> config.mutation_factory.mutation_p
+        0.1
     """
 
     # TODO: We should reconsider the ordering of the arguments for score fn. Pred, GT or GT, Pred?
     score_fn: Callable[[ndarray, ndarray], float]
     train_data: ndarray | None = None
     train_labels: ndarray | None = None
-    population_generator_fn: create_population_generator_fn_type | None = (
-        None  # TODO: Add documentation
+    population_factory: PopulationGeneratorFactory = field(
+        default_factory=PopulationGeneratorFactory
     )
-    population_size: int = 100  # TODO: Add documentation
-    mutation_executor_fn: create_mutation_executor_fn_type | None = (
-        None  # TODO: Add documentation
+    mutation_factory: MutationExecutorFactory = field(
+        default_factory=MutationExecutorFactory
     )
-    mutation_p: float = 0.1  # TODO: Add documentation
-    # TODO: Add tests
     crossover_executor: CrossoverExecutor | None = None
     selection: BaseSelection | None = None
     optimize_scorer: bool = True
     regeneration: bool = False
     regeneration_patience: int = 100
     check_valid: Callable[[Rule], bool] | None = None
-    # Hierarchical GP
     num_child_populations: int = 0
     max_depth: int = 0
     sampling_strategy: SamplingStrategy | None = None
@@ -82,13 +100,14 @@ class BooleanGPConfig:
 
 def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> None:
     """
-    Validate BooleanGPConfig.
+    Validate `BooleanGPConfig`.
 
     Args:
         config (BooleanGPConfig): Configuration to validate.
-        require_data (bool): If True, validates that train_data and train_labels are
-            provided. Set to False when validating a template config (e.g., inside
-            BenchmarkerConfig where data is provided separately). Default: `True`.
+        require_data (bool): If `True`, validates that `train_data` and
+            `train_labels` are provided. Set to `False` when validating a template
+            config (e.g., inside `BenchmarkerConfig` where data is provided
+            separately). Default: `True`.
 
     Raises:
         TypeError: If any field has incorrect type.
@@ -109,20 +128,10 @@ def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> No
             raise ValueError("train_data and train_labels are required")
         check_X_y(config.train_data, config.train_labels)
     validate_callable(config.score_fn)
-    check_isinstance(config.regeneration, bool)
-    check_isinstance(config.regeneration_patience, int)
-    if config.regeneration and config.regeneration_patience < 1:
-        raise ValueError("regeneration_patience must be a positive integer")
-    if config.population_generator_fn is not None:
-        validate_callable(
-            config.population_generator_fn,
-            f"population_generator_fn must be callable, is {type(config.population_generator_fn)}",
-        )
-    if config.mutation_executor_fn is not None:
-        validate_callable(
-            config.mutation_executor_fn,
-            f"mutation_executor_fn must be callable, is {type(config.mutation_executor_fn)}",
-        )
+
+    check_isinstance(config.population_factory, PopulationGeneratorFactory)
+    check_isinstance(config.mutation_factory, MutationExecutorFactory)
+
     if config.crossover_executor is not None:
         check_isinstance(config.crossover_executor, CrossoverExecutor)
     if config.selection is not None:
@@ -130,7 +139,11 @@ def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> No
     if config.check_valid is not None:
         validate_callable(config.check_valid)
 
-    # Hierarchical GP validation
+    check_isinstance(config.regeneration, bool)
+    check_isinstance(config.regeneration_patience, int)
+    if config.regeneration and config.regeneration_patience < 1:
+        raise ValueError("regeneration_patience must be a positive integer")
+
     check_isinstance(config.num_child_populations, int)
     check_isinstance(config.max_depth, int)
     if config.num_child_populations < 0:

--- a/hgp_lib/mutations/__init__.py
+++ b/hgp_lib/mutations/__init__.py
@@ -13,18 +13,17 @@ from .operator_mutations import (
 from .mutation_executor import MutationExecutor
 from .utils import MutationError
 from .mutation_factory import (
-    # TODO: Consider what needs to be imported or not
-    create_default_mutation_executor,
+    MutationExecutorFactory,
     create_standard_literal_mutations,
     create_standard_operator_mutations,
 )
 
 __all__ = [
     "MutationExecutor",
+    "MutationExecutorFactory",
     "Mutation",
     "MutationError",
     # Factory methods
-    "create_default_mutation_executor",
     "create_standard_literal_mutations",
     "create_standard_operator_mutations",
     # Literal and operator mutations

--- a/hgp_lib/mutations/mutation_factory.py
+++ b/hgp_lib/mutations/mutation_factory.py
@@ -1,4 +1,5 @@
 from typing import Callable, Sequence, Tuple, Type
+
 from .base_mutation import Mutation
 from .literal_mutations import (
     DeleteMutation,
@@ -9,6 +10,7 @@ from .literal_mutations import (
 from .operator_mutations import AddLiteral, RemoveIntermediateOperator, ReplaceOperator
 from ..rules import And, Or, Rule
 from .mutation_executor import MutationExecutor
+from ..utils.validation import check_isinstance
 
 
 def create_standard_literal_mutations(
@@ -21,7 +23,8 @@ def create_standard_literal_mutations(
         num_literals (int):
             Total number of available literal values. Must be greater than `1`.
         operator_types (Sequence[Type[Rule]]):
-            Sequence of operator classes (e.g., `(Or, And)`) used by `PromoteLiteral`. Default: `(Or, And)`.
+            Sequence of operator classes (e.g., `(Or, And)`) used by `PromoteLiteral`.
+            Default: `(Or, And)`.
 
     Returns:
         Tuple[Mutation, ...]:
@@ -52,13 +55,12 @@ def create_standard_operator_mutations(
     """
     Creates a standard set of operator-level mutations used for structural modifications of rule trees.
 
-    The returned tuple includes:
-
     Args:
         num_literals (int):
             Total number of available literal values. Must be greater than `1`.
         operator_types (Sequence[Type[Rule]]):
-            Sequence of operator classes (e.g., `(Or, And)`) used by `ReplaceOperator`. Default: `(Or, And)`.
+            Sequence of operator classes (e.g., `(Or, And)`) used by `ReplaceOperator`.
+            Default: `(Or, And)`.
 
     Returns:
         Tuple[Mutation, ...]:
@@ -68,7 +70,6 @@ def create_standard_operator_mutations(
             3. `RemoveIntermediateOperator()` - removes an intermediate operator and promotes its children.
             4. `ReplaceOperator(operator_types)` - replaces an operator with another type (e.g., `And` with `Or`).
             5. `AddLiteral(num_literals)` - adds a new literal subrule to the operator.
-
 
     Examples:
         >>> from hgp_lib.mutations import create_standard_operator_mutations
@@ -86,21 +87,103 @@ def create_standard_operator_mutations(
     )
 
 
-def create_default_mutation_executor(
-    num_literals: int, mutation_p: float, check_valid: Callable[[Rule], bool] | None
-) -> MutationExecutor:
-    literal_mutation_fn = create_standard_literal_mutations
-    operator_mutation_fn = create_standard_operator_mutations
-    num_tries = 1
-    return MutationExecutor(
-        literal_mutations=literal_mutation_fn(num_literals),
-        operator_mutations=operator_mutation_fn(num_literals),
-        mutation_p=mutation_p,
-        check_valid=check_valid,
-        num_tries=num_tries,
-    )
+class MutationExecutorFactory:
+    """
+    Factory for creating `MutationExecutor` instances.
 
+    Stores configuration-time parameters (`mutation_p`, `num_tries`) and defers
+    data-dependent construction to `create`. Override `create_literal_mutations`
+    and/or `create_operator_mutations` to customise which mutations are used.
 
-create_mutation_executor_fn_type = Callable[
-    [int, float, Callable[[Rule], bool] | None], MutationExecutor
-]
+    Attributes:
+        mutation_p (float): Per-node mutation probability. Default: `0.1`.
+        num_tries (int): Maximum number of attempts per mutation node. Must be `1`
+            when no `check_valid` is provided to `create`. Default: `1`.
+
+    Examples:
+        >>> from hgp_lib.mutations import MutationExecutorFactory
+        >>> factory = MutationExecutorFactory(mutation_p=0.05)
+        >>> factory.mutation_p
+        0.05
+        >>> factory.num_tries
+        1
+
+        Subclass to use custom mutations:
+
+        >>> from hgp_lib.mutations import MutationExecutorFactory, NegateMutation
+        >>> class NegateOnlyFactory(MutationExecutorFactory):
+        ...     def create_literal_mutations(self, num_literals):
+        ...         return (NegateMutation(),)
+        ...     def create_operator_mutations(self, num_literals):
+        ...         return (NegateMutation(),)
+        >>> factory = NegateOnlyFactory(mutation_p=1.0)
+        >>> executor = factory.create(num_literals=4)
+        >>> len(executor.literal_mutations)
+        1
+    """
+
+    def __init__(self, mutation_p: float = 0.1, num_tries: int = 1):
+        check_isinstance(mutation_p, float)
+        if mutation_p < 0.0 or mutation_p > 1.0:
+            raise ValueError(
+                f"mutation_p must be between 0.0 and 1.0, got {mutation_p}"
+            )
+        check_isinstance(num_tries, int)
+        if num_tries < 1:
+            raise ValueError(f"num_tries must be at least 1, got {num_tries}")
+        self.mutation_p = mutation_p
+        self.num_tries = num_tries
+
+    def create_literal_mutations(self, num_literals: int) -> Tuple[Mutation, ...]:
+        """
+        Create the set of literal-level mutations.
+
+        Override this method to use custom literal mutations. The default delegates
+        to `create_standard_literal_mutations(num_literals)`.
+
+        Args:
+            num_literals (int): Total number of available literal values.
+
+        Returns:
+            Tuple[Mutation, ...]: Literal mutations for the executor.
+        """
+        return create_standard_literal_mutations(num_literals)
+
+    def create_operator_mutations(self, num_literals: int) -> Tuple[Mutation, ...]:
+        """
+        Create the set of operator-level mutations.
+
+        Override this method to use custom operator mutations. The default delegates
+        to `create_standard_operator_mutations(num_literals)`.
+
+        Args:
+            num_literals (int): Total number of available literal values.
+
+        Returns:
+            Tuple[Mutation, ...]: Operator mutations for the executor.
+        """
+        return create_standard_operator_mutations(num_literals)
+
+    def create(
+        self,
+        num_literals: int,
+        check_valid: Callable[[Rule], bool] | None = None,
+    ) -> MutationExecutor:
+        """
+        Create a `MutationExecutor` with the configured mutations and parameters.
+
+        Args:
+            num_literals (int): Total number of available literal values.
+            check_valid (Callable[[Rule], bool] | None): Optional rule validator.
+                Default: `None`.
+
+        Returns:
+            MutationExecutor: Configured mutation executor.
+        """
+        return MutationExecutor(
+            literal_mutations=self.create_literal_mutations(num_literals),
+            operator_mutations=self.create_operator_mutations(num_literals),
+            mutation_p=self.mutation_p,
+            check_valid=check_valid,
+            num_tries=self.num_tries,
+        )

--- a/hgp_lib/populations/__init__.py
+++ b/hgp_lib/populations/__init__.py
@@ -1,6 +1,7 @@
 from .base_strategy import PopulationStrategy
 from .strategies import RandomStrategy, BestLiteralStrategy
 from .generator import PopulationGenerator
+from .populations_factory import PopulationGeneratorFactory
 from .sampling import (
     SamplingResult,
     SamplingStrategy,
@@ -11,6 +12,7 @@ from .sampling import (
 
 __all__ = [
     "PopulationGenerator",
+    "PopulationGeneratorFactory",
     "PopulationStrategy",
     "RandomStrategy",
     "BestLiteralStrategy",

--- a/hgp_lib/populations/base_strategy.py
+++ b/hgp_lib/populations/base_strategy.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import List
+
 from ..rules import Rule
 
 

--- a/hgp_lib/populations/generator.py
+++ b/hgp_lib/populations/generator.py
@@ -14,7 +14,7 @@ class PopulationGenerator:
     Attributes:
         strategies (Sequence[PopulationStrategy]): The list of strategies to use.
         population_size (int): The total number of rules to generate. Default: `100`.
-        weights (Sequence[float] | np.ndarray| None): Weights for random selection of strategies.
+        weights (Sequence[float] | np.ndarray | None): Weights for random selection of strategies.
             If `None`, all strategies are selected with equal probability. Default: `None`.
 
     Examples:
@@ -37,7 +37,8 @@ class PopulationGenerator:
 
         Args:
             strategies (Sequence[PopulationStrategy]): A non-empty sequence of PopulationStrategy instances.
-            population_size (int): The number of rules to generate. Must be greater than `0`. Default: `100`.
+            population_size (int): The number of rules to generate. Must be greater than `0`.
+                Default: `100`.
             weights (Sequence[float] | np.ndarray | None): Optional weights for each strategy.
                 Must sum to > `0` and be non-negative. Default: `None`.
         """

--- a/hgp_lib/populations/populations_factory.py
+++ b/hgp_lib/populations/populations_factory.py
@@ -5,40 +5,100 @@ import numpy as np
 from .generator import PopulationGenerator
 from .strategies import RandomStrategy
 from .base_strategy import PopulationStrategy
+from ..utils.validation import check_isinstance
 
 
-def create_standard_population_strategies(
-    num_literals: int,
-    score_fn: Callable[[np.ndarray, np.ndarray], float],
-    train_data: np.ndarray,
-    test_data: np.ndarray,
-) -> List[PopulationStrategy]:
-    return [RandomStrategy(num_literals=num_literals)]
+class PopulationGeneratorFactory:
+    """
+    Factory for creating `PopulationGenerator` instances.
 
+    Stores configuration-time parameters (`population_size`) and defers
+    data-dependent construction to `create`. Override `create_strategies`
+    to customise which strategies are instantiated.
 
-create_population_strategies_fn_type = Callable[
-    [int, Callable[[np.ndarray, np.ndarray], float], np.ndarray, np.ndarray],
-    List[PopulationStrategy],
-]
+    Attributes:
+        population_size (int): Number of rules the generator will produce.
+            Default: `100`.
 
+    Examples:
+        >>> from hgp_lib.populations import PopulationGeneratorFactory
+        >>> factory = PopulationGeneratorFactory(population_size=50)
+        >>> factory.population_size
+        50
 
-def create_default_population_generator(
-    population_size: int,
-    num_literals: int,
-    score_fn: Callable[[np.ndarray, np.ndarray], float],
-    train_data: np.ndarray,
-    test_data: np.ndarray,
-) -> PopulationGenerator:
-    strategies = create_standard_population_strategies(
-        num_literals=num_literals,
-        score_fn=score_fn,
-        train_data=train_data,
-        test_data=test_data,
-    )
-    return PopulationGenerator(strategies=strategies, population_size=population_size)
+        Subclass to use custom strategies:
 
+        >>> import numpy as np
+        >>> from hgp_lib.populations import PopulationGeneratorFactory, BestLiteralStrategy
+        >>> class MyFactory(PopulationGeneratorFactory):
+        ...     def create_strategies(self, num_literals, score_fn, train_data, train_labels):
+        ...         return [BestLiteralStrategy(
+        ...             num_literals=num_literals, score_fn=score_fn,
+        ...             train_data=train_data, train_labels=train_labels,
+        ...         )]
+        >>> factory = MyFactory(population_size=20)
+        >>> data = np.array([[True, False], [False, True]])
+        >>> labels = np.array([1, 0])
+        >>> def acc(p, l): return float((p == l).mean())
+        >>> gen = factory.create(2, acc, data, labels)
+        >>> len(gen.generate())
+        20
+    """
 
-create_population_generator_fn_type = Callable[
-    [int, int, Callable[[np.ndarray, np.ndarray], float], np.ndarray, np.ndarray],
-    PopulationGenerator,
-]
+    def __init__(self, population_size: int = 100):
+        check_isinstance(population_size, int)
+        if population_size <= 0:
+            raise ValueError(
+                f"population_size must be a positive integer, got {population_size}"
+            )
+        self.population_size = population_size
+
+    def create_strategies(
+        self,
+        num_literals: int,
+        score_fn: Callable[[np.ndarray, np.ndarray], float],
+        train_data: np.ndarray,
+        train_labels: np.ndarray,
+    ) -> List[PopulationStrategy]:
+        """
+        Create the list of strategies for the generator.
+
+        Override this method to use custom strategies. The default creates
+        a single `RandomStrategy(num_literals=num_literals)`.
+
+        Args:
+            num_literals (int): Number of boolean features (columns in train_data).
+            score_fn (Callable): Fitness function `(predictions, labels) -> float`.
+            train_data (np.ndarray): Training data (2-D boolean array).
+            train_labels (np.ndarray): Training labels (1-D array).
+
+        Returns:
+            List[PopulationStrategy]: Strategies to pass to `PopulationGenerator`.
+        """
+        return [RandomStrategy(num_literals=num_literals)]
+
+    def create(
+        self,
+        num_literals: int,
+        score_fn: Callable[[np.ndarray, np.ndarray], float],
+        train_data: np.ndarray,
+        train_labels: np.ndarray,
+    ) -> PopulationGenerator:
+        """
+        Create a `PopulationGenerator` with data-dependent strategies.
+
+        Args:
+            num_literals (int): Number of boolean features (columns in train_data).
+            score_fn (Callable): Fitness function `(predictions, labels) -> float`.
+            train_data (np.ndarray): Training data (2-D boolean array).
+            train_labels (np.ndarray): Training labels (1-D array).
+
+        Returns:
+            PopulationGenerator: A generator ready to produce the initial population.
+        """
+        strategies = self.create_strategies(
+            num_literals, score_fn, train_data, train_labels
+        )
+        return PopulationGenerator(
+            strategies=strategies, population_size=self.population_size
+        )

--- a/hgp_lib/populations/sampling.py
+++ b/hgp_lib/populations/sampling.py
@@ -15,9 +15,6 @@ from numpy import ndarray
 from hgp_lib.utils.validation import check_isinstance
 
 
-# TODO: Add tests for this module
-
-
 @dataclass
 class SamplingResult:
     """Result of a sampling operation containing sampled data and index mappings.
@@ -56,10 +53,13 @@ class SamplingStrategy(ABC):
     Sampling strategies define how to select subsets of data and/or features
     for child populations in hierarchical GP.
 
-    Args:
-        # TODO: Write documentation about feature_fraction, sample_fraction, and replace
-
     Attributes:
+        feature_fraction (float): Fraction of features to sample per child.
+            Default: `1.0`.
+        sample_fraction (float): Fraction of instances to sample per child.
+            Default: `1.0`.
+        replace (bool): Whether to allow overlap between children.
+            Default: `False`.
         MIN_FEATURES: Minimum number of features required in sampled result.
         MIN_INSTANCES: Minimum number of instances required in sampled result.
     """
@@ -88,19 +88,27 @@ class SamplingStrategy(ABC):
         self.sample_fraction = sample_fraction
         self.replace = replace
 
-        self.add_feature_mapping = feature_fraction != 1.0
-
     def allocate_indices_to_children(self, k: int, n: int, num_children: int):
-        # TODO: Write documentation
-        if self.replace:
-            return [
-                np.random.choice(n, size=k, replace=False) for _ in range(num_children)
-            ]
-        if k * num_children > n:
-            raise RuntimeError(
-                f"Can't allocate {k} indices to {num_children} children from total {n} when replace is False"
-            )
-        return np.random.permutation(n)[: k * num_children].reshape(num_children, k)
+        """Allocate `k` indices out of `n` to each of `num_children` children.
+
+        When `k >= n`, every child receives all `n` indices. When
+        `replace=False` and `k * num_children <= n`, indices are partitioned
+        without overlap. Otherwise each child receives an independent random
+        sample of `k` unique indices (overlap between children is possible).
+
+        Args:
+            k (int): Number of indices each child receives.
+            n (int): Total number of available indices.
+            num_children (int): Number of children to allocate to.
+
+        Returns:
+            List of ndarray, one per child, each containing `min(k, n)` indices.
+        """
+        if k >= n:
+            return [np.arange(n) for _ in range(num_children)]
+        if not self.replace and k * num_children <= n:
+            return np.random.permutation(n)[: k * num_children].reshape(num_children, k)
+        return [np.random.choice(n, size=k, replace=False) for _ in range(num_children)]
 
     @staticmethod
     def create_sampling_result(
@@ -146,14 +154,22 @@ class SamplingStrategy(ABC):
 class FeatureSamplingStrategy(SamplingStrategy):
     """Samples a subset of features from the training data.
 
-    # TODO: Write documentation
+    Each child population receives a subset of the parent's feature columns.
+    The number of features per child is `ceil(num_features * feature_fraction)`.
 
     Overlap behavior (controlled by `replace` parameter):
-        - replace=False: No overlap between children (partitioning) - each feature
-          appears in at most one child population
-        - replace=True: Overlap allowed - features can appear in multiple children
+        - `replace=False`: No overlap between children (partitioning) — each feature
+          appears in at most one child population.
+        - `replace=True`: Overlap allowed — features can appear in multiple children.
+
+    When `feature_fraction=1.0`, all children receive all features regardless of
+    `replace`.
 
     Within each child, features are always unique (no duplicates within a single child).
+
+    Attributes:
+        feature_fraction (float): Fraction of features per child. Default: `1.0`.
+        replace (bool): Allow feature overlap between children. Default: `False`.
 
     Examples:
         >>> import numpy as np
@@ -161,7 +177,7 @@ class FeatureSamplingStrategy(SamplingStrategy):
         >>> strategy = FeatureSamplingStrategy(feature_fraction=0.5)
         >>> data = np.random.rand(100, 10) > 0.5
         >>> labels = np.random.randint(0, 2, 100)
-        >>> results = strategy.sample(data, labels, num_features=10, num_children=3)
+        >>> results = strategy.sample(data, labels, num_children=3)
         >>> len(results)
         3
         >>> len(results[0].feature_indices)
@@ -208,7 +224,20 @@ class FeatureSamplingStrategy(SamplingStrategy):
 class InstanceSamplingStrategy(SamplingStrategy):
     """Samples a subset of instances from the training data.
 
-    # TODO: Write documentation
+    Each child population receives a subset of the parent's rows. All features
+    are preserved. The number of instances per child is
+    `ceil(num_instances * instance_fraction)`.
+
+    Overlap behavior (controlled by `replace` parameter):
+        - `replace=False`: No overlap between children (partitioning).
+        - `replace=True`: Overlap allowed.
+
+    When `instance_fraction=1.0`, all children receive all instances regardless of
+    `replace`.
+
+    Attributes:
+        instance_fraction (float): Fraction of instances per child. Default: `1.0`.
+        replace (bool): Allow instance overlap between children. Default: `False`.
 
     Examples:
         >>> import numpy as np
@@ -216,15 +245,20 @@ class InstanceSamplingStrategy(SamplingStrategy):
         >>> strategy = InstanceSamplingStrategy(instance_fraction=0.8)
         >>> data = np.random.rand(100, 10) > 0.5
         >>> labels = np.random.randint(0, 2, 100)
-        >>> results = strategy.sample(data, labels, num_features=10, num_children=3)
+        >>> results = strategy.sample(data, labels, num_children=3)
         >>> len(results)
         3
         >>> len(results[0].instance_indices)
         80
     """
 
-    def __init__(self, sample_fraction: float = 1.0, replace: bool = False):
-        super().__init__(sample_fraction=sample_fraction, replace=replace)
+    def __init__(self, instance_fraction: float = 1.0, replace: bool = False):
+        super().__init__(sample_fraction=instance_fraction, replace=replace)
+
+    @property
+    def instance_fraction(self) -> float:
+        """Alias for `sample_fraction` for readability."""
+        return self.sample_fraction
 
     def sample(
         self,
@@ -266,11 +300,10 @@ class CombinedSamplingStrategy(SamplingStrategy):
     Applies both feature sampling and instance sampling to create
     child populations with reduced feature and instance sets.
 
-    Args:
-        feature_fraction: Multiplier for feature sample count. Default: 1.0.
-        instance_fraction: Multiplier for instance sample count. Default: 1.0.
-        replace: Whether to allow overlap between children when fractions <= 1.0.
-            Default: False. Ignored for a dimension when its fraction > 1.0 (always True).
+    Attributes:
+        feature_fraction (float): Fraction of features per child. Default: `1.0`.
+        instance_fraction (float): Fraction of instances per child. Default: `1.0`.
+        replace (bool): Whether to allow overlap between children. Default: `False`.
 
     Examples:
         >>> import numpy as np
@@ -282,12 +315,29 @@ class CombinedSamplingStrategy(SamplingStrategy):
         ... )
         >>> data = np.random.rand(100, 10) > 0.5
         >>> labels = np.random.randint(0, 2, 100)
-        >>> results = strategy.sample(data, labels, num_features=10, num_children=3)
+        >>> results = strategy.sample(data, labels, num_children=3)
         >>> len(results)
         3
         >>> results[0].data.shape
         (50, 5)
     """
+
+    def __init__(
+        self,
+        feature_fraction: float = 1.0,
+        instance_fraction: float = 1.0,
+        replace: bool = False,
+    ):
+        super().__init__(
+            feature_fraction=feature_fraction,
+            sample_fraction=instance_fraction,
+            replace=replace,
+        )
+
+    @property
+    def instance_fraction(self) -> float:
+        """Alias for `sample_fraction` for readability."""
+        return self.sample_fraction
 
     def sample(
         self,

--- a/hgp_lib/populations/sampling.py
+++ b/hgp_lib/populations/sampling.py
@@ -226,23 +226,19 @@ class InstanceSamplingStrategy(SamplingStrategy):
 
     Each child population receives a subset of the parent's rows. All features
     are preserved. The number of instances per child is
-    `ceil(num_instances * instance_fraction)`.
+    `ceil(num_instances * sample_fraction)`.
 
     Overlap behavior (controlled by `replace` parameter):
         - `replace=False`: No overlap between children (partitioning).
         - `replace=True`: Overlap allowed.
 
-    When `instance_fraction=1.0`, all children receive all instances regardless of
+    When `sample_fraction=1.0`, all children receive all instances regardless of
     `replace`.
-
-    Attributes:
-        instance_fraction (float): Fraction of instances per child. Default: `1.0`.
-        replace (bool): Allow instance overlap between children. Default: `False`.
 
     Examples:
         >>> import numpy as np
         >>> np.random.seed(42)
-        >>> strategy = InstanceSamplingStrategy(instance_fraction=0.8)
+        >>> strategy = InstanceSamplingStrategy(sample_fraction=0.8)
         >>> data = np.random.rand(100, 10) > 0.5
         >>> labels = np.random.randint(0, 2, 100)
         >>> results = strategy.sample(data, labels, num_children=3)
@@ -252,13 +248,8 @@ class InstanceSamplingStrategy(SamplingStrategy):
         80
     """
 
-    def __init__(self, instance_fraction: float = 1.0, replace: bool = False):
-        super().__init__(sample_fraction=instance_fraction, replace=replace)
-
-    @property
-    def instance_fraction(self) -> float:
-        """Alias for `sample_fraction` for readability."""
-        return self.sample_fraction
+    def __init__(self, sample_fraction: float = 1.0, replace: bool = False):
+        super().__init__(sample_fraction=sample_fraction, replace=replace)
 
     def sample(
         self,
@@ -302,7 +293,7 @@ class CombinedSamplingStrategy(SamplingStrategy):
 
     Attributes:
         feature_fraction (float): Fraction of features per child. Default: `1.0`.
-        instance_fraction (float): Fraction of instances per child. Default: `1.0`.
+        sample_fraction (float): Fraction of instances per child. Default: `1.0`.
         replace (bool): Whether to allow overlap between children. Default: `False`.
 
     Examples:
@@ -310,7 +301,7 @@ class CombinedSamplingStrategy(SamplingStrategy):
         >>> np.random.seed(42)
         >>> strategy = CombinedSamplingStrategy(
         ...     feature_fraction=0.5,
-        ...     instance_fraction=0.5,
+        ...     sample_fraction=0.5,
         ...     replace=False
         ... )
         >>> data = np.random.rand(100, 10) > 0.5
@@ -325,19 +316,14 @@ class CombinedSamplingStrategy(SamplingStrategy):
     def __init__(
         self,
         feature_fraction: float = 1.0,
-        instance_fraction: float = 1.0,
+        sample_fraction: float = 1.0,
         replace: bool = False,
     ):
         super().__init__(
             feature_fraction=feature_fraction,
-            sample_fraction=instance_fraction,
+            sample_fraction=sample_fraction,
             replace=replace,
         )
-
-    @property
-    def instance_fraction(self) -> float:
-        """Alias for `sample_fraction` for readability."""
-        return self.sample_fraction
 
     def sample(
         self,

--- a/hgp_lib/populations/strategies.py
+++ b/hgp_lib/populations/strategies.py
@@ -18,7 +18,8 @@ class RandomStrategy(PopulationStrategy):
 
     Attributes:
         num_literals (int): The total number of available literals.
-        operator_types (Sequence[Type[Rule]]): A sequence of allowed operator types (e.g., `(Or, And)`). Default: `(Or, And)`.
+        operator_types (Sequence[Type[Rule]]): A sequence of allowed operator types
+            (e.g., `(Or, And)`). Default: `(Or, And)`.
 
     Examples:
         >>> from hgp_lib.populations import RandomStrategy
@@ -137,6 +138,12 @@ class BestLiteralStrategy(PopulationStrategy):
         validate_callable(score_fn)
         check_X_y(train_data, train_labels)
 
+        if len(train_data[0]) != num_literals:
+            raise ValueError(
+                f"Number of features in train_data must be equal to num_literals, "
+                f"got {len(train_data[0])} != {num_literals}"
+            )
+
         self.num_literals = num_literals
         self.score_fn = score_fn
         self.train_data = train_data
@@ -144,11 +151,6 @@ class BestLiteralStrategy(PopulationStrategy):
 
         self._sample_count = self._resolve_size(sample_size, len(train_data))
         self._feature_count = self._resolve_size(feature_size, num_literals)
-
-        if len(train_data[0]) != num_literals:
-            raise ValueError(
-                f"Number of features in train_data must be equal to num_literals, got {len(train_data[0])} != {num_literals}"
-            )
 
     def _resolve_size(self, size: int | float | None, total: int) -> int:
         if size is None:
@@ -200,7 +202,6 @@ class BestLiteralStrategy(PopulationStrategy):
             best_score = -float("inf")
 
             for i in feature_indices:
-                # Optimization: Direct access to column data avoids object creation overhead
                 preds_pos = subset_data[:, i]
                 score_pos = self.score_fn(preds_pos, subset_labels)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "scikit-learn",
     "tqdm",
     "optuna",
-    "optuna-dashboard"
+    "optuna-dashboard",
+    "matplotlib"
 ]
 [tool.setuptools.packages.find]
 include = ["hgp_lib*"]

--- a/scripts/optuna_hypertuning.py
+++ b/scripts/optuna_hypertuning.py
@@ -31,10 +31,12 @@ from optuna.artifacts import FileSystemArtifactStore, upload_artifact
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.crossover import CrossoverExecutor
+from hgp_lib.mutations import MutationExecutorFactory
 from hgp_lib.populations import (
     CombinedSamplingStrategy,
     FeatureSamplingStrategy,
     InstanceSamplingStrategy,
+    PopulationGeneratorFactory,
 )
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.selections import RouletteSelection, TournamentSelection
@@ -258,10 +260,8 @@ def build_config(
     gp_config = BooleanGPConfig(
         score_fn=score_fn,
         selection=selection,
-        population_generator_fn=None,
-        population_size=population_size,
-        mutation_executor_fn=None,
-        mutation_p=mutation_p,
+        population_factory=PopulationGeneratorFactory(population_size=population_size),
+        mutation_factory=MutationExecutorFactory(mutation_p=mutation_p),
         crossover_executor=crossover_executor,
         regeneration=params.get("regeneration", False),
         regeneration_patience=params.get("regeneration_patience", 100),

--- a/scripts/optuna_hypertuning.py
+++ b/scripts/optuna_hypertuning.py
@@ -203,8 +203,8 @@ def suggest_hyperparameters(trial: optuna.Trial) -> Dict[str, Any]:
                 "feature_fraction", 0.1, max_fraction, step=0.01
             )
         if params["sampling_strategy_type"] in ("instance", "combined"):
-            params["instance_fraction"] = trial.suggest_float(
-                "instance_fraction", 0.1, max_fraction, step=0.01
+            params["sample_fraction"] = trial.suggest_float(
+                "sample_fraction", 0.1, max_fraction, step=0.01
             )
 
     return params
@@ -246,13 +246,13 @@ def build_config(
             )
         elif strategy_type == "instance":
             sampling_strategy = InstanceSamplingStrategy(
-                sample_fraction=params.get("instance_fraction", 1.0),
+                sample_fraction=params.get("sample_fraction", 1.0),
                 replace=use_replace,
             )
         else:
             sampling_strategy = CombinedSamplingStrategy(
                 feature_fraction=params.get("feature_fraction", 1.0),
-                sample_fraction=params.get("instance_fraction", 1.0),
+                sample_fraction=params.get("sample_fraction", 1.0),
                 replace=use_replace,
             )
 

--- a/scripts/paysim_benchmark.py
+++ b/scripts/paysim_benchmark.py
@@ -57,8 +57,7 @@ from hgp_lib import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.populations import (
     FeatureSamplingStrategy,
-    PopulationGenerator,
-    RandomStrategy,
+    PopulationGeneratorFactory,
 )
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule
@@ -182,9 +181,8 @@ def main(args: argparse.Namespace):
     gp_config = BooleanGPConfig(
         score_fn=f1_score,
         check_valid=is_valid,
-        population_generator=PopulationGenerator(
-            strategies=[RandomStrategy(num_literals=data.shape[1])],
-            population_size=args.population_size,
+        population_factory=PopulationGeneratorFactory(
+            population_size=args.population_size
         ),
         optimize_scorer=args.optimize_scorer,
         regeneration=args.regeneration,

--- a/scripts/paysim_profile.py
+++ b/scripts/paysim_profile.py
@@ -16,11 +16,8 @@ from timed_decorator.builder import create_timed_decorator, get_timed_decorator
 from hgp_lib import BooleanGPConfig
 from hgp_lib.algorithms import BooleanGP
 from hgp_lib.crossover import CrossoverExecutor
-from hgp_lib.mutations import (
-    MutationExecutor,
-    create_mutation_executor,
-)
-from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.mutations import MutationExecutor, MutationExecutorFactory
+from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule, Literal, And, Or
 
@@ -193,20 +190,6 @@ def main():
             return False
         return True
 
-    num_features = train_data_bin.shape[1]
-    mutation_executor = create_mutation_executor(
-        num_literals=num_features,
-        check_valid=is_rule_valid,
-        mutation_p=mutation_p,
-        num_tries=5,
-    )
-
-    random_strategy = RandomStrategy(num_literals=num_features)
-    population_generator = PopulationGenerator(
-        strategies=[random_strategy],
-        population_size=population_size,
-    )
-
     crossover_executor = CrossoverExecutor(
         crossover_p=crossover_p,
         check_valid=is_rule_valid,
@@ -218,9 +201,10 @@ def main():
         train_data=train_data_bin,
         train_labels=train_labels,
         score_fn=train_score_fn,
-        population_generator=population_generator,
-        mutation_executor=mutation_executor,
+        population_factory=PopulationGeneratorFactory(population_size=population_size),
+        mutation_factory=MutationExecutorFactory(mutation_p=mutation_p),
         crossover_executor=crossover_executor,
+        check_valid=is_rule_valid,
         regeneration=True,
         regeneration_patience=200,
     )

--- a/scripts/paysim_trainer_profile.py
+++ b/scripts/paysim_trainer_profile.py
@@ -82,7 +82,7 @@ from hgp_lib.mutations import (
 from hgp_lib.populations import (
     FeatureSamplingStrategy,
     PopulationGenerator,
-    RandomStrategy,
+    PopulationGeneratorFactory,
 )
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule
@@ -498,11 +498,6 @@ def main(args: argparse.Namespace) -> None:
     print("GP CONFIGURATION")
     print("=" * 60)
 
-    population_generator = PopulationGenerator(
-        strategies=[RandomStrategy(num_literals=train_data.shape[1])],
-        population_size=args.population_size,
-    )
-
     gp_config = BooleanGPConfig(
         train_data=train_data,
         train_labels=train_labels,
@@ -511,7 +506,9 @@ def main(args: argparse.Namespace) -> None:
         optimize_scorer=args.optimize_scorer,
         regeneration=args.regeneration,
         regeneration_patience=args.regeneration_patience,
-        population_generator=population_generator,
+        population_factory=PopulationGeneratorFactory(
+            population_size=args.population_size
+        ),
     )
 
     # Apply hierarchical GP settings if max_depth > 0

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -8,12 +8,7 @@ import hgp_lib.algorithms.boolean_gp
 from hgp_lib.algorithms import BooleanGP
 from hgp_lib.configs import BooleanGPConfig
 from hgp_lib.crossover import CrossoverExecutor
-from hgp_lib.mutations import (
-    MutationExecutor,
-    create_standard_literal_mutations,
-    create_standard_operator_mutations,
-)
-from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.rules import Rule
 from hgp_lib.selections import TournamentSelection
 
@@ -43,27 +38,13 @@ class TestBooleanGP(unittest.TestCase):
 
         self.score_fn = accuracy
 
-        self.generator = PopulationGenerator(
-            strategies=[RandomStrategy(num_literals=self.num_features)],
-            population_size=10,
-        )
-
-        self.mutation_executor = MutationExecutor(
-            literal_mutations=create_standard_literal_mutations(self.num_features),
-            operator_mutations=create_standard_operator_mutations(self.num_features),
-        )
-
     def _make_config(self, **kwargs):
-        """Helper to create BooleanGPConfig with test defaults.
-
-        Note: optimize_scorer=False by default since test scorer doesn't support sample_weight.
-        """
+        """Helper to create BooleanGPConfig with test defaults."""
         defaults = dict(
             score_fn=self.score_fn,
             train_data=self.train_data,
             train_labels=self.train_labels,
-            population_generator=self.generator,
-            mutation_executor=self.mutation_executor,
+            population_factory=PopulationGeneratorFactory(population_size=10),
             optimize_scorer=False,
         )
         defaults.update(kwargs)
@@ -75,14 +56,14 @@ class TestBooleanGP(unittest.TestCase):
                 config = self._make_config(score_fn="not callable")
                 BooleanGP(config)
 
-        with self.subTest("population_generator must be PopulationGenerator"):
+        with self.subTest("population_factory must be PopulationGeneratorFactory"):
             with self.assertRaises(TypeError):
-                config = self._make_config(population_generator="not generator")
+                config = self._make_config(population_factory="not factory")
                 BooleanGP(config)
 
-        with self.subTest("mutation_executor must be MutationExecutor"):
+        with self.subTest("mutation_factory must be MutationExecutorFactory"):
             with self.assertRaises(TypeError):
-                config = self._make_config(mutation_executor="not executor")
+                config = self._make_config(mutation_factory="not factory")
                 BooleanGP(config)
 
         with self.subTest("crossover_executor must be CrossoverExecutor"):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -17,6 +17,8 @@ from hgp_lib.configs import (
     validate_gp_config,
     validate_trainer_config,
 )
+from hgp_lib.mutations import MutationExecutorFactory
+from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.preprocessing import StandardBinarizer
 
 
@@ -98,8 +100,10 @@ class TestBooleanGPConfig(unittest.TestCase):
         self.assertEqual(config.regeneration_patience, 100)
         self.assertEqual(config.max_depth, 0)
         self.assertEqual(config.num_child_populations, 0)
-        self.assertIsNone(config.population_generator)
-        self.assertIsNone(config.mutation_executor)
+        self.assertIsInstance(config.population_factory, PopulationGeneratorFactory)
+        self.assertIsInstance(config.mutation_factory, MutationExecutorFactory)
+        self.assertEqual(config.population_factory.population_size, 100)
+        self.assertEqual(config.mutation_factory.mutation_p, 0.1)
         self.assertIsNone(config.crossover_executor)
         self.assertIsNone(config.selection)
 

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -9,12 +9,8 @@ import hgp_lib
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.crossover import CrossoverExecutor
-from hgp_lib.mutations import (
-    MutationExecutor,
-    create_standard_literal_mutations,
-    create_standard_operator_mutations,
-)
-from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.mutations import MutationExecutorFactory
+from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule
 from hgp_lib.selections import RouletteSelection
@@ -91,6 +87,7 @@ class TestGPBenchmarker(unittest.TestCase):
             trainer_config=trainer_config,
             num_runs=2,
             n_folds=2,
+            n_jobs=1,
         )
         defaults.update(kwargs)
         return BenchmarkerConfig(**defaults)
@@ -165,18 +162,16 @@ class TestGPBenchmarker(unittest.TestCase):
                 config = self._make_config(labels=np.array([[1, 0], [1, 0]]))
                 GPBenchmarker(config)
 
-        with self.subTest(
-            "population_generator must be PopulationGenerator if provided"
-        ):
+        with self.subTest("population_factory must be PopulationGeneratorFactory"):
             with self.assertRaises(TypeError):
-                gp_config = self._make_gp_config(population_generator="not a generator")
+                gp_config = self._make_gp_config(population_factory="not a factory")
                 trainer_config = self._make_trainer_config(gp_config=gp_config)
                 config = self._make_config(trainer_config=trainer_config)
                 GPBenchmarker(config)
 
-        with self.subTest("mutation_executor must be MutationExecutor if provided"):
+        with self.subTest("mutation_factory must be MutationExecutorFactory"):
             with self.assertRaises(TypeError):
-                gp_config = self._make_gp_config(mutation_executor="not an executor")
+                gp_config = self._make_gp_config(mutation_factory="not a factory")
                 trainer_config = self._make_trainer_config(gp_config=gp_config)
                 config = self._make_config(trainer_config=trainer_config)
                 GPBenchmarker(config)
@@ -312,25 +307,18 @@ class TestGPBenchmarker(unittest.TestCase):
         )
         self.assertEqual(result1.mean_test_score, result2.mean_test_score)
 
-    def test_custom_population_generator(self):
-        generator = PopulationGenerator(
-            strategies=[RandomStrategy(num_literals=self.num_features)],
-            population_size=10,
-        )
-        gp_config = self._make_gp_config(population_generator=generator)
+    def test_custom_population_factory(self):
+        factory = PopulationGeneratorFactory(population_size=10)
+        gp_config = self._make_gp_config(population_factory=factory)
         trainer_config = self._make_trainer_config(gp_config=gp_config, num_epochs=2)
         config = self._make_config(trainer_config=trainer_config, num_runs=1, n_jobs=1)
         benchmarker = GPBenchmarker(config)
         result = benchmarker.fit()
         self.assertEqual(len(result.run_metrics), 1)
 
-    def test_custom_mutation_executor(self):
-        mutation_executor = MutationExecutor(
-            literal_mutations=create_standard_literal_mutations(self.num_features),
-            operator_mutations=create_standard_operator_mutations(self.num_features),
-            mutation_p=0.1,
-        )
-        gp_config = self._make_gp_config(mutation_executor=mutation_executor)
+    def test_custom_mutation_factory(self):
+        factory = MutationExecutorFactory(mutation_p=0.1)
+        gp_config = self._make_gp_config(mutation_factory=factory)
         trainer_config = self._make_trainer_config(gp_config=gp_config, num_epochs=2)
         config = self._make_config(trainer_config=trainer_config, num_runs=1, n_jobs=1)
         benchmarker = GPBenchmarker(config)

--- a/tests/test_gp_trainer.py
+++ b/tests/test_gp_trainer.py
@@ -8,12 +8,7 @@ import hgp_lib.trainers.gp_trainer
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.trainers import GPTrainer
 from hgp_lib.crossover import CrossoverExecutor
-from hgp_lib.mutations import (
-    MutationExecutor,
-    create_standard_literal_mutations,
-    create_standard_operator_mutations,
-)
-from hgp_lib.populations import PopulationGenerator, RandomStrategy
+from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.selections import RouletteSelection, TournamentSelection
 from hgp_lib.rules import Rule
 
@@ -167,7 +162,7 @@ class TestGPTrainer(unittest.TestCase):
         self.assertIsNotNone(result.best_rule)
         self.assertIsNotNone(result.best_score)
         self.assertEqual(len(result.train_history.epochs), 5)
-        self.assertIsNone(result.val_history)
+        self.assertEqual(len(result.val_history.epochs), 0)
 
     def test_fit_with_validation(self):
         config = self._make_trainer_config(
@@ -246,26 +241,21 @@ class TestGPTrainer(unittest.TestCase):
         self.assertIsInstance(all_time_metrics.best_rule, Rule)
         self.assertIsInstance(current_metrics.best_rule, Rule)
 
-    def test_custom_population_generator(self):
-        generator = PopulationGenerator(
-            strategies=[RandomStrategy(num_literals=self.num_features)],
-            population_size=20,
-        )
+    def test_custom_population_factory(self):
+        factory = PopulationGeneratorFactory(population_size=20)
 
-        gp_config = self._make_gp_config(population_generator=generator)
+        gp_config = self._make_gp_config(population_factory=factory)
         config = self._make_trainer_config(gp_config=gp_config, num_epochs=5)
         trainer = GPTrainer(config)
 
         self.assertEqual(len(trainer.gp_algo.population), 20)
 
-    def test_custom_mutation_executor(self):
-        mutation_executor = MutationExecutor(
-            literal_mutations=create_standard_literal_mutations(self.num_features),
-            operator_mutations=create_standard_operator_mutations(self.num_features),
-            mutation_p=0.5,
-        )
+    def test_custom_mutation_factory(self):
+        from hgp_lib.mutations import MutationExecutorFactory
 
-        gp_config = self._make_gp_config(mutation_executor=mutation_executor)
+        factory = MutationExecutorFactory(mutation_p=0.5)
+
+        gp_config = self._make_gp_config(mutation_factory=factory)
         config = self._make_trainer_config(gp_config=gp_config, num_epochs=5)
         trainer = GPTrainer(config)
 

--- a/tests/test_hierarchical_gp.py
+++ b/tests/test_hierarchical_gp.py
@@ -31,15 +31,12 @@ class TestSamplingStrategies(unittest.TestCase):
 
     def test_feature_sampling_basic(self):
         """Test that FeatureSamplingStrategy samples correct number of features."""
-        strategy = FeatureSamplingStrategy(feature_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=4
-        )
+        strategy = FeatureSamplingStrategy(feature_fraction=0.25)
+        results = strategy.sample(self.data, self.labels, num_children=4)
 
-        # Should return a list with 4 results (one per child)
         self.assertEqual(len(results), 4)
 
-        # Check first result - Expected: ceil(20/4) = 5 features per child
+        # ceil(20 * 0.25) = 5 features per child
         result = results[0]
         self.assertEqual(len(result.feature_indices), 5)
         self.assertEqual(result.data.shape, (100, 5))
@@ -49,46 +46,36 @@ class TestSamplingStrategies(unittest.TestCase):
     def test_feature_sampling_with_fraction(self):
         """Test FeatureSamplingStrategy with different fractions."""
         strategy = FeatureSamplingStrategy(feature_fraction=0.5)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=4
-        )
+        results = strategy.sample(self.data, self.labels, num_children=4)
 
-        # Should return a list with 4 results
         self.assertEqual(len(results), 4)
 
-        # Expected: max(2, ceil(ceil(20/4) * 0.5)) = max(2, ceil(2.5)) = 3
-        self.assertEqual(len(results[0].feature_indices), 3)
+        # ceil(20 * 0.5) = 10 features per child
+        self.assertEqual(len(results[0].feature_indices), 10)
 
     def test_instance_sampling_basic(self):
         """Test that InstanceSamplingStrategy samples correct number of instances."""
-        strategy = InstanceSamplingStrategy(instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=4
-        )
+        strategy = InstanceSamplingStrategy(instance_fraction=0.25)
+        results = strategy.sample(self.data, self.labels, num_children=4)
 
-        # Should return a list with 4 results
         self.assertEqual(len(results), 4)
 
-        # Check first result - Expected: ceil(100/4) = 25 instances per child
+        # ceil(100 * 0.25) = 25 instances per child
         result = results[0]
         self.assertEqual(len(result.instance_indices), 25)
         self.assertEqual(result.data.shape, (25, 20))
-        # All features preserved
-        np.testing.assert_array_equal(result.feature_indices, np.arange(20))
+        self.assertIsNone(result.feature_mapping)
 
     def test_combined_sampling(self):
         """Test CombinedSamplingStrategy samples both dimensions."""
-        strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=4
+        strategy = CombinedSamplingStrategy(
+            feature_fraction=0.25, instance_fraction=0.25
         )
+        results = strategy.sample(self.data, self.labels, num_children=4)
 
-        # Should return a list with 4 results
         self.assertEqual(len(results), 4)
 
-        # Check first result
-        # Features: ceil(20/4) = 5
-        # Instances: ceil(100/4) = 25
+        # Features: ceil(20 * 0.25) = 5, Instances: ceil(100 * 0.25) = 25
         result = results[0]
         self.assertEqual(len(result.feature_indices), 5)
         self.assertEqual(len(result.instance_indices), 25)
@@ -126,7 +113,7 @@ class TestChildPopulationCreation(unittest.TestCase):
             train_labels=self.labels,
             max_depth=1,
             num_child_populations=2,
-            sampling_strategy=FeatureSamplingStrategy(feature_fraction=1.0),
+            sampling_strategy=FeatureSamplingStrategy(feature_fraction=0.5),
             top_k_transfer=5,
         )
         gp = BooleanGP(config)
@@ -136,9 +123,7 @@ class TestChildPopulationCreation(unittest.TestCase):
 
         for child in gp.child_populations:
             self.assertEqual(child.current_depth, 1)
-            # Children should have feature mapping since features are subsampled
             self.assertIsNotNone(child.feature_mapping)
-            # Child should have fewer features
             self.assertLess(child.train_data.shape[1], self.data.shape[1])
 
     def test_children_created_with_instance_sampling(self):

--- a/tests/test_hierarchical_gp.py
+++ b/tests/test_hierarchical_gp.py
@@ -55,7 +55,7 @@ class TestSamplingStrategies(unittest.TestCase):
 
     def test_instance_sampling_basic(self):
         """Test that InstanceSamplingStrategy samples correct number of instances."""
-        strategy = InstanceSamplingStrategy(instance_fraction=0.25)
+        strategy = InstanceSamplingStrategy(sample_fraction=0.25)
         results = strategy.sample(self.data, self.labels, num_children=4)
 
         self.assertEqual(len(results), 4)
@@ -68,9 +68,7 @@ class TestSamplingStrategies(unittest.TestCase):
 
     def test_combined_sampling(self):
         """Test CombinedSamplingStrategy samples both dimensions."""
-        strategy = CombinedSamplingStrategy(
-            feature_fraction=0.25, instance_fraction=0.25
-        )
+        strategy = CombinedSamplingStrategy(feature_fraction=0.25, sample_fraction=0.25)
         results = strategy.sample(self.data, self.labels, num_children=4)
 
         self.assertEqual(len(results), 4)
@@ -134,7 +132,7 @@ class TestChildPopulationCreation(unittest.TestCase):
             train_labels=self.labels,
             max_depth=1,
             num_child_populations=2,
-            sampling_strategy=InstanceSamplingStrategy(instance_fraction=1.0),
+            sampling_strategy=InstanceSamplingStrategy(sample_fraction=1.0),
             top_k_transfer=5,
         )
         gp = BooleanGP(config)
@@ -246,7 +244,7 @@ class TestHierarchicalTraining(unittest.TestCase):
             train_labels=self.labels,
             max_depth=1,
             num_child_populations=2,
-            sampling_strategy=InstanceSamplingStrategy(instance_fraction=1.0),
+            sampling_strategy=InstanceSamplingStrategy(sample_fraction=1.0),
             top_k_transfer=5,
             optimize_scorer=False,
         )
@@ -265,7 +263,7 @@ class TestHierarchicalTraining(unittest.TestCase):
             max_depth=1,
             num_child_populations=2,
             sampling_strategy=CombinedSamplingStrategy(
-                feature_fraction=1.0, instance_fraction=1.0
+                feature_fraction=1.0, sample_fraction=1.0
             ),
             top_k_transfer=5,
             optimize_scorer=False,
@@ -494,7 +492,7 @@ class TestBooleanGPSamplingIntegration(unittest.TestCase):
                 train_labels=labels,
                 max_depth=1,
                 num_child_populations=num_children,
-                sampling_strategy=InstanceSamplingStrategy(instance_fraction=1.0),
+                sampling_strategy=InstanceSamplingStrategy(sample_fraction=1.0),
                 top_k_transfer=3,
             )
             gp = BooleanGP(config)

--- a/tests/test_populations.py
+++ b/tests/test_populations.py
@@ -2,7 +2,13 @@ import unittest
 import random
 import numpy as np
 
-from hgp_lib.populations import PopulationGenerator, RandomStrategy, BestLiteralStrategy
+from hgp_lib.populations import (
+    PopulationGenerator,
+    PopulationGeneratorFactory,
+    RandomStrategy,
+    BestLiteralStrategy,
+)
+from hgp_lib.mutations import MutationExecutorFactory
 from hgp_lib.rules import And, Or, Literal
 
 
@@ -308,12 +314,169 @@ class TestPopulations(unittest.TestCase):
         import doctest
         import hgp_lib.populations.strategies
         import hgp_lib.populations.generator
+        import hgp_lib.populations.populations_factory
 
         result = doctest.testmod(hgp_lib.populations.strategies, verbose=False)
         self.assertEqual(result.failed, 0, f"Strategies doctests failed: {result}")
 
         result = doctest.testmod(hgp_lib.populations.generator, verbose=False)
         self.assertEqual(result.failed, 0, f"Generator doctests failed: {result}")
+
+        result = doctest.testmod(hgp_lib.populations.populations_factory, verbose=False)
+        self.assertEqual(result.failed, 0, f"Factory doctests failed: {result}")
+
+
+class TestPopulationGeneratorFactory(unittest.TestCase):
+    def setUp(self):
+        random.seed(42)
+        np.random.seed(42)
+
+        self.train_data = np.array(
+            [
+                [True, False, True, False],
+                [False, True, False, True],
+                [True, True, False, False],
+                [False, False, True, True],
+            ]
+        )
+        self.train_labels = np.array([1, 0, 1, 0])
+        self.num_literals = 4
+
+    def simple_score_fn(self, predictions, labels):
+        return np.mean(predictions == labels)
+
+    def test_default_factory(self):
+        factory = PopulationGeneratorFactory()
+        self.assertEqual(factory.population_size, 100)
+
+    def test_custom_population_size(self):
+        factory = PopulationGeneratorFactory(population_size=50)
+        self.assertEqual(factory.population_size, 50)
+
+    def test_population_size_must_be_positive(self):
+        with self.assertRaises(ValueError):
+            PopulationGeneratorFactory(population_size=0)
+        with self.assertRaises(ValueError):
+            PopulationGeneratorFactory(population_size=-5)
+
+    def test_population_size_must_be_int(self):
+        with self.assertRaises(TypeError):
+            PopulationGeneratorFactory(population_size=10.5)
+
+    def test_create_returns_generator(self):
+        factory = PopulationGeneratorFactory(population_size=10)
+        gen = factory.create(
+            self.num_literals,
+            self.simple_score_fn,
+            self.train_data,
+            self.train_labels,
+        )
+        self.assertIsInstance(gen, PopulationGenerator)
+
+    def test_create_generates_correct_count(self):
+        factory = PopulationGeneratorFactory(population_size=15)
+        gen = factory.create(
+            self.num_literals,
+            self.simple_score_fn,
+            self.train_data,
+            self.train_labels,
+        )
+        population = gen.generate()
+        self.assertEqual(len(population), 15)
+
+    def test_default_strategy_is_random(self):
+        factory = PopulationGeneratorFactory(population_size=5)
+        gen = factory.create(
+            self.num_literals,
+            self.simple_score_fn,
+            self.train_data,
+            self.train_labels,
+        )
+        population = gen.generate()
+        for rule in population:
+            self.assertIsInstance(rule, (And, Or))
+
+    def test_subclass_override(self):
+        class BestLiteralFactory(PopulationGeneratorFactory):
+            def create_strategies(
+                self, num_literals, score_fn, train_data, train_labels
+            ):
+                return [
+                    BestLiteralStrategy(
+                        num_literals=num_literals,
+                        score_fn=score_fn,
+                        train_data=train_data,
+                        train_labels=train_labels,
+                    )
+                ]
+
+        factory = BestLiteralFactory(population_size=5)
+        gen = factory.create(
+            self.num_literals,
+            self.simple_score_fn,
+            self.train_data,
+            self.train_labels,
+        )
+        population = gen.generate()
+        self.assertEqual(len(population), 5)
+        for rule in population:
+            self.assertIsInstance(rule, Literal)
+
+
+class TestMutationExecutorFactory(unittest.TestCase):
+    def test_default_factory(self):
+        factory = MutationExecutorFactory()
+        self.assertEqual(factory.mutation_p, 0.1)
+        self.assertEqual(factory.num_tries, 1)
+
+    def test_custom_params(self):
+        factory = MutationExecutorFactory(mutation_p=0.05, num_tries=3)
+        self.assertEqual(factory.mutation_p, 0.05)
+        self.assertEqual(factory.num_tries, 3)
+
+    def test_mutation_p_out_of_range(self):
+        with self.assertRaises(ValueError):
+            MutationExecutorFactory(mutation_p=-0.1)
+        with self.assertRaises(ValueError):
+            MutationExecutorFactory(mutation_p=1.5)
+
+    def test_mutation_p_must_be_float(self):
+        with self.assertRaises(TypeError):
+            MutationExecutorFactory(mutation_p=1)
+
+    def test_num_tries_must_be_positive(self):
+        with self.assertRaises(ValueError):
+            MutationExecutorFactory(num_tries=0)
+
+    def test_create_returns_executor(self):
+        from hgp_lib.mutations import MutationExecutor
+
+        factory = MutationExecutorFactory(mutation_p=0.5)
+        executor = factory.create(num_literals=4)
+        self.assertIsInstance(executor, MutationExecutor)
+        self.assertEqual(executor.mutation_p, 0.5)
+
+    def test_create_with_check_valid(self):
+        from hgp_lib.mutations import MutationExecutor
+
+        factory = MutationExecutorFactory(mutation_p=0.1, num_tries=3)
+
+        def valid(rule):
+            return len(rule) < 50
+
+        executor = factory.create(num_literals=4, check_valid=valid)
+        self.assertIsInstance(executor, MutationExecutor)
+        self.assertEqual(executor.num_tries, 3)
+        self.assertIsNotNone(executor.check_valid)
+
+    def test_doctests(self):
+        import doctest
+        import hgp_lib.mutations.mutation_factory
+
+        result = doctest.testmod(hgp_lib.mutations.mutation_factory, verbose=False)
+        self.assertEqual(
+            result.failed, 0, f"Mutation factory doctests failed: {result}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -21,17 +21,13 @@ class TestFeatureSamplingStrategy(unittest.TestCase):
     def test_returns_correct_number_of_results(self):
         """sample() returns exactly num_children results."""
         strategy = FeatureSamplingStrategy(feature_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=5
-        )
+        results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
     def test_each_result_has_unique_features(self):
         """Each child has unique feature indices (no duplicates within a child)."""
         strategy = FeatureSamplingStrategy(feature_fraction=1.0, replace=True)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
             unique_count = len(np.unique(result.feature_indices))
@@ -39,12 +35,9 @@ class TestFeatureSamplingStrategy(unittest.TestCase):
 
     def test_no_overlap_when_replace_false(self):
         """When replace=False, features don't overlap between children."""
-        strategy = FeatureSamplingStrategy(feature_fraction=0.5, replace=False)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        strategy = FeatureSamplingStrategy(feature_fraction=0.3, replace=False)
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
-        # Check no overlap between any two children
         for i in range(len(results)):
             for j in range(i + 1, len(results)):
                 set_i = set(results[i].feature_indices)
@@ -59,9 +52,7 @@ class TestFeatureSamplingStrategy(unittest.TestCase):
     def test_feature_mapping_correct(self):
         """feature_mapping correctly maps child indices to parent indices."""
         strategy = FeatureSamplingStrategy(feature_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
             self.assertIsNotNone(result.feature_mapping)
@@ -71,22 +62,17 @@ class TestFeatureSamplingStrategy(unittest.TestCase):
     def test_data_dimensions_correct(self):
         """Sampled data has correct dimensions."""
         strategy = FeatureSamplingStrategy(feature_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            # All instances preserved
             self.assertEqual(result.data.shape[0], len(self.labels))
-            # Features match feature_indices
             self.assertEqual(result.data.shape[1], len(result.feature_indices))
-            # instance_indices is None for feature-only sampling
             self.assertIsNone(result.instance_indices)
 
     def test_invalid_feature_fraction_raises(self):
         """feature_fraction <= 0 raises ValueError."""
         with self.assertRaises(ValueError):
-            FeatureSamplingStrategy(feature_fraction=0)
+            FeatureSamplingStrategy(feature_fraction=0.0)
         with self.assertRaises(ValueError):
             FeatureSamplingStrategy(feature_fraction=-1.0)
 
@@ -102,17 +88,13 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
     def test_returns_correct_number_of_results(self):
         """sample() returns exactly num_children results."""
         strategy = InstanceSamplingStrategy(instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=5
-        )
+        results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
     def test_each_result_has_unique_instances(self):
         """Each child has unique instance indices (no duplicates within a child)."""
         strategy = InstanceSamplingStrategy(instance_fraction=1.0, replace=True)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
             unique_count = len(np.unique(result.instance_indices))
@@ -120,12 +102,9 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
 
     def test_no_overlap_when_replace_false(self):
         """When replace=False, instances don't overlap between children."""
-        strategy = InstanceSamplingStrategy(instance_fraction=0.5, replace=False)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        strategy = InstanceSamplingStrategy(instance_fraction=0.3, replace=False)
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
-        # Check no overlap between any two children
         for i in range(len(results)):
             for j in range(i + 1, len(results)):
                 set_i = set(results[i].instance_indices)
@@ -140,24 +119,18 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
     def test_data_dimensions_correct(self):
         """Sampled data has correct dimensions."""
         strategy = InstanceSamplingStrategy(instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            # Instances match instance_indices
             self.assertEqual(result.data.shape[0], len(result.instance_indices))
-            # All features preserved
             self.assertEqual(result.data.shape[1], 20)
-            # Labels match instances
             self.assertEqual(len(result.labels), len(result.instance_indices))
-            # feature_mapping is None for instance-only sampling
             self.assertIsNone(result.feature_mapping)
 
     def test_invalid_instance_fraction_raises(self):
         """instance_fraction <= 0 raises ValueError."""
         with self.assertRaises(ValueError):
-            InstanceSamplingStrategy(instance_fraction=0)
+            InstanceSamplingStrategy(instance_fraction=0.0)
         with self.assertRaises(ValueError):
             InstanceSamplingStrategy(instance_fraction=-1.0)
 
@@ -173,9 +146,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_returns_correct_number_of_results(self):
         """sample() returns exactly num_children results."""
         strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=5
-        )
+        results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
     def test_each_result_has_unique_features(self):
@@ -183,9 +154,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
         strategy = CombinedSamplingStrategy(
             feature_fraction=1.0, instance_fraction=1.0, replace=True
         )
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
             unique_count = len(np.unique(result.feature_indices))
@@ -196,9 +165,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
         strategy = CombinedSamplingStrategy(
             feature_fraction=1.0, instance_fraction=1.0, replace=True
         )
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
             unique_count = len(np.unique(result.instance_indices))
@@ -207,11 +174,9 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_no_feature_overlap_when_replace_false(self):
         """When replace=False, features don't overlap between children."""
         strategy = CombinedSamplingStrategy(
-            feature_fraction=0.5, instance_fraction=0.5, replace=False
+            feature_fraction=0.3, instance_fraction=0.3, replace=False
         )
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for i in range(len(results)):
             for j in range(i + 1, len(results)):
@@ -227,11 +192,9 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_no_instance_overlap_when_replace_false(self):
         """When replace=False, instances don't overlap between children."""
         strategy = CombinedSamplingStrategy(
-            feature_fraction=0.5, instance_fraction=0.5, replace=False
+            feature_fraction=0.3, instance_fraction=0.3, replace=False
         )
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for i in range(len(results)):
             for j in range(i + 1, len(results)):
@@ -247,9 +210,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_feature_mapping_correct(self):
         """feature_mapping correctly maps child indices to parent indices."""
         strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
             self.assertIsNotNone(result.feature_mapping)
@@ -259,22 +220,17 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_data_dimensions_correct(self):
         """Sampled data has correct dimensions."""
         strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
-        results = strategy.sample(
-            self.data, self.labels, num_features=20, num_children=3
-        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            # Instances match instance_indices
             self.assertEqual(result.data.shape[0], len(result.instance_indices))
-            # Features match feature_indices
             self.assertEqual(result.data.shape[1], len(result.feature_indices))
-            # Labels match instances
             self.assertEqual(len(result.labels), len(result.instance_indices))
 
     def test_invalid_fractions_raise(self):
         """Invalid fractions raise ValueError."""
         with self.assertRaises(ValueError):
-            CombinedSamplingStrategy(feature_fraction=0)
+            CombinedSamplingStrategy(feature_fraction=0.0)
         with self.assertRaises(ValueError):
             CombinedSamplingStrategy(instance_fraction=-1.0)
 
@@ -297,11 +253,8 @@ class TestSamplingRandomized(unittest.TestCase):
             num_features = np.random.randint(4, 51)
             num_instances = np.random.randint(4, 101)
             num_children = np.random.randint(1, 11)
-            replace = np.random.choice([True, False])
-            # When replace=False, fraction must be <= 1.0 to avoid sample > population
-            feature_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
+            replace = bool(np.random.choice([True, False]))
+            feature_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
@@ -309,9 +262,7 @@ class TestSamplingRandomized(unittest.TestCase):
             strategy = FeatureSamplingStrategy(
                 feature_fraction=feature_fraction, replace=replace
             )
-            results = strategy.sample(
-                data, labels, num_features=num_features, num_children=num_children
-            )
+            results = strategy.sample(data, labels, num_children=int(num_children))
 
             self.assertEqual(len(results), num_children)
 
@@ -324,11 +275,8 @@ class TestSamplingRandomized(unittest.TestCase):
             num_features = np.random.randint(4, 51)
             num_instances = np.random.randint(4, 101)
             num_children = np.random.randint(1, 11)
-            replace = np.random.choice([True, False])
-            # When replace=False, fraction must be <= 1.0 to avoid sample > population
-            instance_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
+            replace = bool(np.random.choice([True, False]))
+            instance_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
@@ -336,9 +284,7 @@ class TestSamplingRandomized(unittest.TestCase):
             strategy = InstanceSamplingStrategy(
                 instance_fraction=instance_fraction, replace=replace
             )
-            results = strategy.sample(
-                data, labels, num_features=num_features, num_children=num_children
-            )
+            results = strategy.sample(data, labels, num_children=int(num_children))
 
             self.assertEqual(len(results), num_children)
 
@@ -351,14 +297,9 @@ class TestSamplingRandomized(unittest.TestCase):
             num_features = np.random.randint(4, 51)
             num_instances = np.random.randint(4, 101)
             num_children = np.random.randint(1, 11)
-            replace = np.random.choice([True, False])
-            # When replace=False, fractions must be <= 1.0 to avoid sample > population
-            feature_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
-            instance_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
+            replace = bool(np.random.choice([True, False]))
+            feature_fraction = float(np.random.uniform(0.5, 1.0))
+            instance_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
@@ -368,9 +309,7 @@ class TestSamplingRandomized(unittest.TestCase):
                 instance_fraction=instance_fraction,
                 replace=replace,
             )
-            results = strategy.sample(
-                data, labels, num_features=num_features, num_children=num_children
-            )
+            results = strategy.sample(data, labels, num_children=int(num_children))
 
             self.assertEqual(len(results), num_children)
 
@@ -383,10 +322,8 @@ class TestSamplingRandomized(unittest.TestCase):
             num_features = np.random.randint(4, 51)
             num_instances = np.random.randint(4, 101)
             num_children = np.random.randint(1, 11)
-            replace = np.random.choice([True, False])
-            feature_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
+            replace = bool(np.random.choice([True, False]))
+            feature_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
@@ -394,16 +331,12 @@ class TestSamplingRandomized(unittest.TestCase):
             strategy = FeatureSamplingStrategy(
                 feature_fraction=feature_fraction, replace=replace
             )
-            results = strategy.sample(
-                data, labels, num_features=num_features, num_children=num_children
-            )
+            results = strategy.sample(data, labels, num_children=int(num_children))
 
             for result in results:
                 self.assertIsNotNone(result.feature_mapping)
-                # Keys should be 0 to len(feature_indices)-1
                 expected_keys = set(range(len(result.feature_indices)))
                 self.assertEqual(set(result.feature_mapping.keys()), expected_keys)
-                # Each mapping should match feature_indices
                 for i, idx in enumerate(result.feature_indices):
                     self.assertEqual(result.feature_mapping[i], int(idx))
 
@@ -416,13 +349,9 @@ class TestSamplingRandomized(unittest.TestCase):
             num_features = np.random.randint(4, 51)
             num_instances = np.random.randint(4, 101)
             num_children = np.random.randint(1, 11)
-            replace = np.random.choice([True, False])
-            feature_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
-            instance_fraction = (
-                np.random.uniform(0.1, 2.0) if replace else np.random.uniform(0.1, 1.0)
-            )
+            replace = bool(np.random.choice([True, False]))
+            feature_fraction = float(np.random.uniform(0.5, 1.0))
+            instance_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
@@ -432,16 +361,12 @@ class TestSamplingRandomized(unittest.TestCase):
                 instance_fraction=instance_fraction,
                 replace=replace,
             )
-            results = strategy.sample(
-                data, labels, num_features=num_features, num_children=num_children
-            )
+            results = strategy.sample(data, labels, num_children=int(num_children))
 
             for result in results:
                 self.assertIsNotNone(result.feature_mapping)
-                # Keys should be 0 to len(feature_indices)-1
                 expected_keys = set(range(len(result.feature_indices)))
                 self.assertEqual(set(result.feature_mapping.keys()), expected_keys)
-                # Each mapping should match feature_indices
                 for i, idx in enumerate(result.feature_indices):
                     self.assertEqual(result.feature_mapping[i], int(idx))
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -87,13 +87,13 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
 
     def test_returns_correct_number_of_results(self):
         """sample() returns exactly num_children results."""
-        strategy = InstanceSamplingStrategy(instance_fraction=1.0)
+        strategy = InstanceSamplingStrategy(sample_fraction=1.0)
         results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
     def test_each_result_has_unique_instances(self):
         """Each child has unique instance indices (no duplicates within a child)."""
-        strategy = InstanceSamplingStrategy(instance_fraction=1.0, replace=True)
+        strategy = InstanceSamplingStrategy(sample_fraction=1.0, replace=True)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
@@ -102,7 +102,7 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
 
     def test_no_overlap_when_replace_false(self):
         """When replace=False, instances don't overlap between children."""
-        strategy = InstanceSamplingStrategy(instance_fraction=0.3, replace=False)
+        strategy = InstanceSamplingStrategy(sample_fraction=0.3, replace=False)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for i in range(len(results)):
@@ -118,7 +118,7 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
 
     def test_data_dimensions_correct(self):
         """Sampled data has correct dimensions."""
-        strategy = InstanceSamplingStrategy(instance_fraction=1.0)
+        strategy = InstanceSamplingStrategy(sample_fraction=1.0)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
@@ -127,12 +127,12 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
             self.assertEqual(len(result.labels), len(result.instance_indices))
             self.assertIsNone(result.feature_mapping)
 
-    def test_invalid_instance_fraction_raises(self):
-        """instance_fraction <= 0 raises ValueError."""
+    def test_invalid_sample_fraction_raises(self):
+        """sample_fraction <= 0 raises ValueError."""
         with self.assertRaises(ValueError):
-            InstanceSamplingStrategy(instance_fraction=0.0)
+            InstanceSamplingStrategy(sample_fraction=0.0)
         with self.assertRaises(ValueError):
-            InstanceSamplingStrategy(instance_fraction=-1.0)
+            InstanceSamplingStrategy(sample_fraction=-1.0)
 
 
 class TestCombinedSamplingStrategy(unittest.TestCase):
@@ -145,14 +145,14 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
 
     def test_returns_correct_number_of_results(self):
         """sample() returns exactly num_children results."""
-        strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
+        strategy = CombinedSamplingStrategy(feature_fraction=1.0, sample_fraction=1.0)
         results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
     def test_each_result_has_unique_features(self):
         """Each child has unique feature indices (no duplicates within a child)."""
         strategy = CombinedSamplingStrategy(
-            feature_fraction=1.0, instance_fraction=1.0, replace=True
+            feature_fraction=1.0, sample_fraction=1.0, replace=True
         )
         results = strategy.sample(self.data, self.labels, num_children=3)
 
@@ -163,7 +163,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_each_result_has_unique_instances(self):
         """Each child has unique instance indices (no duplicates within a child)."""
         strategy = CombinedSamplingStrategy(
-            feature_fraction=1.0, instance_fraction=1.0, replace=True
+            feature_fraction=1.0, sample_fraction=1.0, replace=True
         )
         results = strategy.sample(self.data, self.labels, num_children=3)
 
@@ -174,7 +174,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_no_feature_overlap_when_replace_false(self):
         """When replace=False, features don't overlap between children."""
         strategy = CombinedSamplingStrategy(
-            feature_fraction=0.3, instance_fraction=0.3, replace=False
+            feature_fraction=0.3, sample_fraction=0.3, replace=False
         )
         results = strategy.sample(self.data, self.labels, num_children=3)
 
@@ -192,7 +192,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
     def test_no_instance_overlap_when_replace_false(self):
         """When replace=False, instances don't overlap between children."""
         strategy = CombinedSamplingStrategy(
-            feature_fraction=0.3, instance_fraction=0.3, replace=False
+            feature_fraction=0.3, sample_fraction=0.3, replace=False
         )
         results = strategy.sample(self.data, self.labels, num_children=3)
 
@@ -209,7 +209,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
 
     def test_feature_mapping_correct(self):
         """feature_mapping correctly maps child indices to parent indices."""
-        strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
+        strategy = CombinedSamplingStrategy(feature_fraction=1.0, sample_fraction=1.0)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
@@ -219,7 +219,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
 
     def test_data_dimensions_correct(self):
         """Sampled data has correct dimensions."""
-        strategy = CombinedSamplingStrategy(feature_fraction=1.0, instance_fraction=1.0)
+        strategy = CombinedSamplingStrategy(feature_fraction=1.0, sample_fraction=1.0)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
@@ -232,7 +232,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
         with self.assertRaises(ValueError):
             CombinedSamplingStrategy(feature_fraction=0.0)
         with self.assertRaises(ValueError):
-            CombinedSamplingStrategy(instance_fraction=-1.0)
+            CombinedSamplingStrategy(sample_fraction=-1.0)
 
 
 class TestSamplingRandomized(unittest.TestCase):
@@ -276,13 +276,13 @@ class TestSamplingRandomized(unittest.TestCase):
             num_instances = np.random.randint(4, 101)
             num_children = np.random.randint(1, 11)
             replace = bool(np.random.choice([True, False]))
-            instance_fraction = float(np.random.uniform(0.5, 1.0))
+            sample_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
 
             strategy = InstanceSamplingStrategy(
-                instance_fraction=instance_fraction, replace=replace
+                sample_fraction=sample_fraction, replace=replace
             )
             results = strategy.sample(data, labels, num_children=int(num_children))
 
@@ -299,14 +299,14 @@ class TestSamplingRandomized(unittest.TestCase):
             num_children = np.random.randint(1, 11)
             replace = bool(np.random.choice([True, False]))
             feature_fraction = float(np.random.uniform(0.5, 1.0))
-            instance_fraction = float(np.random.uniform(0.5, 1.0))
+            sample_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
 
             strategy = CombinedSamplingStrategy(
                 feature_fraction=feature_fraction,
-                instance_fraction=instance_fraction,
+                sample_fraction=sample_fraction,
                 replace=replace,
             )
             results = strategy.sample(data, labels, num_children=int(num_children))
@@ -351,14 +351,14 @@ class TestSamplingRandomized(unittest.TestCase):
             num_children = np.random.randint(1, 11)
             replace = bool(np.random.choice([True, False]))
             feature_fraction = float(np.random.uniform(0.5, 1.0))
-            instance_fraction = float(np.random.uniform(0.5, 1.0))
+            sample_fraction = float(np.random.uniform(0.5, 1.0))
 
             data = np.random.rand(num_instances, num_features) > 0.5
             labels = np.random.randint(0, 2, num_instances)
 
             strategy = CombinedSamplingStrategy(
                 feature_fraction=feature_fraction,
-                instance_fraction=instance_fraction,
+                sample_fraction=sample_fraction,
                 replace=replace,
             )
             results = strategy.sample(data, labels, num_children=int(num_children))


### PR DESCRIPTION
* Introduced `PopulationGeneratorFactory` and `MutationExecutorFactory` classes,
  replacing the previous function-based approach (`create_default_population_generator`,
  `create_default_mutation_executor`, and their type aliases).
* Factories store config-time parameters (`population_size`, `mutation_p`, `num_tries`)
  and defer data-dependent construction to `create()`. Custom behavior is supported
  via subclassing (`create_strategies`, `create_literal_mutations`, `create_operator_mutations`).
* Simplified `BooleanGPConfig`: replaced `population_generator_fn`, `population_size`,
  `mutation_executor_fn`, and `mutation_p` fields with `population_factory` and
  `mutation_factory` using `dataclasses.field(default_factory=...)`.
* Simplified `BooleanGP.__init__` by removing fallback logic for default construction.
* Improved `allocate_indices_to_children` to gracefully handle `k >= n` instead of
  raising `RuntimeError`.
* Updated documentation, docstrings, tests.
* Updated scripts to use the new factory API.
* Added `matplotlib` dependency.