### PR TITLE
Fixes #56 (argpartition bug when top_k equals population_size)

### DIFF
--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -433,9 +433,8 @@ class BooleanGP:
             )
             # Non-root populations need reordering so top-K rules are at the front
             # for transfer to parent population during the next forward pass.
-            if self.current_depth > 0:  # top_k must be positive if current_depth > 0
-                # TODO: We had a ValueError: kth(=50) out of bounds (50)
-                # ValueError: kth(=100) out of bounds (100)
+            if self.current_depth > 0 and self._top_k < self.population_size:
+                # top_k must be positive if current_depth > 0
                 sorted_indices = np.argpartition(-selected_scores, self._top_k)
                 self.population = [self.population[i] for i in sorted_indices]
 

--- a/scripts/optuna_hypertuning.py
+++ b/scripts/optuna_hypertuning.py
@@ -10,6 +10,7 @@ import argparse
 import logging
 import os
 import traceback
+import warnings
 from pathlib import Path
 from typing import Any, Callable, Dict
 
@@ -47,6 +48,7 @@ logger = logging.getLogger(__name__)
 
 def suggest_hyperparameters(trial: optuna.Trial) -> Dict[str, Any]:
     # TODO: Use a hyperparameter_config.yaml to load the values of the hyperparameters.
+    warnings.simplefilter(action="ignore", category=UserWarning)
     params = {}
 
     params["num_bins"] = trial.suggest_int("num_bins", 2, 10)
@@ -102,7 +104,6 @@ def suggest_hyperparameters(trial: optuna.Trial) -> Dict[str, Any]:
                 "num_child_populations", 2, 5
             )
 
-        # TODO: Supress optuna user warning for range not divisible
         params["top_k_transfer"] = trial.suggest_int(
             "top_k_transfer", 10, min(100, params["population_size"] - 1), step=5
         )

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -9,7 +9,7 @@ import hgp_lib.algorithms.boolean_gp
 from hgp_lib.algorithms import BooleanGP
 from hgp_lib.configs import BooleanGPConfig
 from hgp_lib.crossover import CrossoverExecutor, CrossoverExecutorFactory
-from hgp_lib.populations import PopulationGeneratorFactory
+from hgp_lib.populations import PopulationGeneratorFactory, FeatureSamplingStrategy
 from hgp_lib.rules import Rule
 from hgp_lib.selections import TournamentSelection
 
@@ -230,6 +230,8 @@ class TestBooleanGP(unittest.TestCase):
         self.assertIsInstance(metrics.best_train_score, float)
 
     def test_doctests(self):
+        # TODO: Check if we can't make a single test file that tests the doctests for all files automatically
+        # This means that it will automatically test it, without needing to specify the module
         result = doctest.testmod(hgp_lib.algorithms.boolean_gp, verbose=False)
         self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
 
@@ -263,6 +265,18 @@ class TestBooleanGP(unittest.TestCase):
                     np.allclose(regularized, expected),
                     f"Regularized score formula failed for penalty={penalty}",
                 )
+
+    def test_top_k_equals_population_size(self):
+        config = self._make_config(
+            population_factory=PopulationGeneratorFactory(population_size=100),
+            top_k_transfer=100,
+            num_child_populations=2,
+            max_depth=2,
+            sampling_strategy=FeatureSamplingStrategy(),
+        )
+        gp = BooleanGP(config)
+
+        gp.step()
 
     def test_step_with_complexity_penalty(self):
         """Test that step() works with complexity_penalty > 0."""


### PR DESCRIPTION
* Also adds simplefilter for optuna `UserWarnings` about ranges not being divisible with step size