### PR TITLE
Closes #58. Optimized input validation for configs.

### DIFF
--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -77,35 +77,26 @@ class BooleanGP:
 
         self.current_depth = current_depth
         num_features = train_data.shape[1]
-        # TODO: Direct assignment
-        population_generator = config.population_factory.create(
+
+        self.population_generator = config.population_factory.create(
             num_features, score_fn, train_data, train_labels
         )
-        mutation_executor = config.mutation_factory.create(
+        self.mutation_executor = config.mutation_factory.create(
             num_features, config.check_valid
         )
 
-        crossover_executor = config.crossover_factory.create(config.check_valid)
+        self.crossover_executor = config.crossover_factory.create(config.check_valid)
 
         selection = config.selection
         if selection is None:
             selection = TournamentSelection()
 
-        self.population_generator = population_generator
-        self.mutation_executor = mutation_executor
-        self.crossover_executor = crossover_executor
         self.selection = selection
         self.regeneration = config.regeneration
         self.regeneration_patience = config.regeneration_patience
 
         self.population = self.population_generator.generate()
         self.population_size = len(self.population)
-
-        if config.top_k_transfer > self.population_size:
-            raise ValueError(
-                f"top_k_transfer ({config.top_k_transfer}) must be less than"
-                f" or equal to population_size ({self.population_size})"
-            )
         self._top_k = config.top_k_transfer
 
         self.best_score = -float("inf")
@@ -121,9 +112,7 @@ class BooleanGP:
         self._transfer_size: int = 0
         self.parent_rule_indices: List[int] = []
 
-        # TODO: We should always have num_child_populations > 0 if max_depth si greater than 0.
-        # Check if this is true and add the check.
-        if config.max_depth > current_depth and config.num_child_populations > 0:
+        if config.max_depth > current_depth:
             self._create_child_populations()
 
     def _create_child_populations(self) -> None:
@@ -133,12 +122,6 @@ class BooleanGP:
         behavior controlled by the replace parameter. Each SamplingResult in the
         returned list is used to configure one child population.
         """
-        if self.config.sampling_strategy is None:
-            # TODO: We should have checked this in the validate function for the config.
-            raise RuntimeError(
-                "Cannot create child populations without a sampling strategy"
-            )
-
         results = self.config.sampling_strategy.sample(
             self.train_data,
             self.train_labels,

--- a/hgp_lib/configs/benchmarker_config.py
+++ b/hgp_lib/configs/benchmarker_config.py
@@ -120,6 +120,9 @@ def validate_benchmarker_config(config: BenchmarkerConfig) -> None:
         ... )
         >>> validate_benchmarker_config(config)  # No error
     """
+    if hasattr(config, "_validated"):
+        return
+
     check_X_y(config.data, config.labels, x_type=DataFrame)
 
     # Validate trainer config (without requiring data in gp_config)
@@ -143,3 +146,5 @@ def validate_benchmarker_config(config: BenchmarkerConfig) -> None:
     check_isinstance(config.n_folds, int)
     if config.n_folds < 2:
         raise ValueError(f"n_folds must be at least 2, is {config.n_folds}")
+
+    setattr(config, "validated", True)

--- a/hgp_lib/configs/boolean_gp_config.py
+++ b/hgp_lib/configs/boolean_gp_config.py
@@ -128,10 +128,17 @@ def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> No
         >>> config = BooleanGPConfig(score_fn=accuracy, train_data=data, train_labels=labels)
         >>> validate_gp_config(config)  # No error
     """
+    if hasattr(config, "_validated_with_data"):
+        return
+
     if require_data:
         if config.train_data is None or config.train_labels is None:
             raise ValueError("train_data and train_labels are required")
         check_X_y(config.train_data, config.train_labels)
+
+    if hasattr(config, "_validated_without_data"):
+        return
+
     validate_callable(config.score_fn)
 
     check_isinstance(config.population_factory, PopulationGeneratorFactory)
@@ -178,6 +185,12 @@ def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> No
         raise ValueError(
             f"top_k_transfer must be at least 1, is {config.top_k_transfer}"
         )
+    if config.top_k_transfer > config.population_factory.population_size:
+        raise ValueError(
+            f"top_k_transfer ({config.top_k_transfer}) must be less than"
+            f" or equal to population_size ({config.population_factory.population_size})"
+        )
+
     check_isinstance(config.feedback_type, str)
     if config.feedback_type not in ("additive", "multiplicative"):
         raise ValueError(
@@ -195,3 +208,8 @@ def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> No
         raise ValueError(
             f"complexity_penalty must be non-negative, is {config.complexity_penalty}"
         )
+
+    if require_data:
+        setattr(config, "_validated_with_data", True)
+    else:
+        setattr(config, "_validated_without_data", True)

--- a/hgp_lib/configs/trainer_config.py
+++ b/hgp_lib/configs/trainer_config.py
@@ -75,7 +75,14 @@ def validate_trainer_config(config: TrainerConfig, require_data: bool = True) ->
         >>> config = TrainerConfig(gp_config=gp_config, num_epochs=10)
         >>> validate_trainer_config(config)  # No error
     """
+    if hasattr(config, "_validated_with_data"):
+        return
+
     validate_gp_config(config.gp_config, require_data=require_data)
+
+    if hasattr(config, "_validated_without_data"):
+        return
+
     check_isinstance(config.num_epochs, int)
     if config.num_epochs < 1:
         raise ValueError(
@@ -101,3 +108,8 @@ def validate_trainer_config(config: TrainerConfig, require_data: bool = True) ->
         raise ValueError(
             f"progress_update_interval must be a positive integer, is {config.progress_update_interval}"
         )
+
+    if require_data:
+        setattr(config, "_validated_with_data", True)
+    else:
+        setattr(config, "_validated_without_data", True)

--- a/hgp_lib/mutations/__init__.py
+++ b/hgp_lib/mutations/__init__.py
@@ -12,20 +12,13 @@ from .operator_mutations import (
 )
 from .mutation_executor import MutationExecutor
 from .utils import MutationError
-from .mutation_factory import (
-    MutationExecutorFactory,
-    create_standard_literal_mutations,
-    create_standard_operator_mutations,
-)
+from .mutation_factory import MutationExecutorFactory
 
 __all__ = [
     "MutationExecutor",
     "MutationExecutorFactory",
     "Mutation",
     "MutationError",
-    # Factory methods
-    "create_standard_literal_mutations",
-    "create_standard_operator_mutations",
     # Literal and operator mutations
     "DeleteMutation",
     "NegateMutation",

--- a/hgp_lib/mutations/literal_mutations.py
+++ b/hgp_lib/mutations/literal_mutations.py
@@ -1,11 +1,10 @@
 import random
-from typing import Sequence, Type, Tuple
+from typing import Type, Tuple
 
 import numpy as np
 
 from .base_mutation import Mutation
 from .utils import MutationError
-from ..utils.validation import validate_num_literals, validate_operator_types
 from ..rules import Rule, Or, And, Literal
 
 
@@ -184,7 +183,7 @@ class ReplaceLiteral(Mutation):
     def __init__(self, num_literals: int):
         super().__init__(is_literal_mutation=True, is_operator_mutation=False)
 
-        validate_num_literals(num_literals)
+        # num_literals was validated
 
         self.num_literals = num_literals
 
@@ -247,15 +246,15 @@ class PromoteLiteral(Mutation):
     """
 
     def __init__(
-        self, num_literals: int, operator_types: Sequence[Type[Rule]] = (Or, And)
+        self, num_literals: int, operator_types: Tuple[Type[Rule], ...] = (Or, And)
     ):
         super().__init__(is_literal_mutation=True, is_operator_mutation=False)
 
-        validate_num_literals(num_literals)
-        validate_operator_types(operator_types)
+        # num_literals was validated
+        # operator_types was validated
 
         self.num_literals = num_literals
-        self.operator_types: Tuple[Type[Rule], ...] = tuple(operator_types)
+        self.operator_types = operator_types
 
     def apply(self, rule: Rule):
         """

--- a/hgp_lib/mutations/mutation_executor.py
+++ b/hgp_lib/mutations/mutation_executor.py
@@ -1,5 +1,5 @@
 import random
-from typing import Callable, Sequence, Tuple, List
+from typing import Callable, Tuple, List
 
 import numpy as np
 
@@ -18,10 +18,10 @@ class MutationExecutor:
     times when a `check_valid` predicate is provided.
 
     Args:
-        literal_mutations (Sequence[Mutation]):
+        literal_mutations (Tuple[Mutation, ...]):
             Mutations that can be applied to literal nodes. The sequence must be non-empty and
             each entry must declare `is_literal_mutation=True`.
-        operator_mutations (Sequence[Mutation]):
+        operator_mutations (Tuple[Mutation, ...]):
             Mutations that can be applied to operator nodes. The sequence must be non-empty and
             each entry must declare `is_operator_mutation=True`.
         mutation_p (float):
@@ -58,8 +58,8 @@ class MutationExecutor:
 
     def __init__(
         self,
-        literal_mutations: Sequence[Mutation],
-        operator_mutations: Sequence[Mutation],
+        literal_mutations: Tuple[Mutation, ...],
+        operator_mutations: Tuple[Mutation, ...],
         mutation_p: float = 0.1,
         check_valid: Callable[[Rule], bool] | None = None,
         num_tries: int = 1,
@@ -69,9 +69,11 @@ class MutationExecutor:
         # check_valid was checked
         # num_tries was checked
         # operator_p was checked
+        # literal_mutations was checked
+        # operator_mutations was checked
         self.mutation_p: float = mutation_p
-        self.literal_mutations: Tuple[Mutation, ...] = tuple(literal_mutations)
-        self.operator_mutations: Tuple[Mutation, ...] = tuple(operator_mutations)
+        self.literal_mutations: Tuple[Mutation, ...] = literal_mutations
+        self.operator_mutations: Tuple[Mutation, ...] = operator_mutations
         self.check_valid: Callable[[Rule], bool] | None = check_valid
         self.num_tries: int = num_tries
         self.operator_p: float = operator_p

--- a/hgp_lib/mutations/mutation_factory.py
+++ b/hgp_lib/mutations/mutation_factory.py
@@ -10,81 +10,11 @@ from .literal_mutations import (
 from .operator_mutations import AddLiteral, RemoveIntermediateOperator, ReplaceOperator
 from ..rules import And, Or, Rule
 from .mutation_executor import MutationExecutor
-from ..utils.validation import check_isinstance
-
-
-def create_standard_literal_mutations(
-    num_literals: int, operator_types: Sequence[Type[Rule]] = (Or, And)
-) -> Tuple[Mutation, ...]:
-    """
-    Creates a standard set of literal-level mutations commonly used in rule evolution.
-
-    Args:
-        num_literals (int):
-            Total number of available literal values. Must be greater than `1`.
-        operator_types (Sequence[Type[Rule]]):
-            Sequence of operator classes (e.g., `(Or, And)`) used by `PromoteLiteral`.
-            Default: `(Or, And)`.
-
-    Returns:
-        Tuple[Mutation, ...]:
-            A tuple of initialized mutation instances for literals. The tuple includes:
-            1. `DeleteMutation()` - removes a rule from its parent operator.
-            2. `NegateMutation()` - toggles the negation flag of a rule.
-            3. `ReplaceLiteral(num_literals)` - replaces a literal's value with a different random one.
-            4. `PromoteLiteral(num_literals, operator_types)` - converts a literal into an operator with two literals.
-
-    Examples:
-        >>> from hgp_lib.mutations import create_standard_literal_mutations
-        >>> from hgp_lib.rules import And, Or
-        >>> mutations = create_standard_literal_mutations(num_literals=4, operator_types=(Or, And))
-        >>> [type(mutation).__name__ for mutation in mutations]
-        ['DeleteMutation', 'NegateMutation', 'ReplaceLiteral', 'PromoteLiteral']
-    """
-    return (
-        DeleteMutation(),
-        NegateMutation(),
-        ReplaceLiteral(num_literals),
-        PromoteLiteral(num_literals, operator_types),
-    )
-
-
-def create_standard_operator_mutations(
-    num_literals: int, operator_types: Sequence[Type[Rule]] = (Or, And)
-) -> Tuple[Mutation, ...]:
-    """
-    Creates a standard set of operator-level mutations used for structural modifications of rule trees.
-
-    Args:
-        num_literals (int):
-            Total number of available literal values. Must be greater than `1`.
-        operator_types (Sequence[Type[Rule]]):
-            Sequence of operator classes (e.g., `(Or, And)`) used by `ReplaceOperator`.
-            Default: `(Or, And)`.
-
-    Returns:
-        Tuple[Mutation, ...]:
-            A tuple of initialized operator-level mutation instances. The tuple includes:
-            1. `DeleteMutation()` - removes a rule from its parent operator.
-            2. `NegateMutation()` - toggles the negation flag of an operator.
-            3. `RemoveIntermediateOperator()` - removes an intermediate operator and promotes its children.
-            4. `ReplaceOperator(operator_types)` - replaces an operator with another type (e.g., `And` with `Or`).
-            5. `AddLiteral(num_literals)` - adds a new literal subrule to the operator.
-
-    Examples:
-        >>> from hgp_lib.mutations import create_standard_operator_mutations
-        >>> from hgp_lib.rules import And, Or
-        >>> mutations = create_standard_operator_mutations(num_literals=4, operator_types=(Or, And))
-        >>> [type(mutation).__name__ for mutation in mutations]
-        ['DeleteMutation', 'NegateMutation', 'RemoveIntermediateOperator', 'ReplaceOperator', 'AddLiteral']
-    """
-    return (
-        DeleteMutation(),
-        NegateMutation(),
-        RemoveIntermediateOperator(),
-        ReplaceOperator(operator_types),
-        AddLiteral(num_literals),
-    )
+from ..utils.validation import (
+    check_isinstance,
+    validate_num_literals,
+    validate_operator_types,
+)
 
 
 class MutationExecutorFactory:
@@ -93,7 +23,7 @@ class MutationExecutorFactory:
 
     Stores configuration-time parameters (`mutation_p`, `num_tries`) and defers
     data-dependent construction to `create`. Override `create_literal_mutations`
-    and/or `create_operator_mutations` to customise which mutations are used.
+    and/or `create_operator_mutations` to customize which mutations are used.
 
     Attributes:
         mutation_p (float): Per-node mutation probability. Default: `0.1`.
@@ -102,6 +32,8 @@ class MutationExecutorFactory:
         operator_p (float): Probability of selecting an operator node (vs. a literal)
             when choosing a mutation point in the rule tree. Must be in [0.0, 1.0].
             Default: `0.9`.
+        operator_types (Sequence[Type[Rule]]): Sequence of operator classes
+            (e.g., `(Or, And)`) used by mutations. Default: `(Or, And)`.
 
     Examples:
         >>> from hgp_lib.mutations import MutationExecutorFactory
@@ -126,7 +58,11 @@ class MutationExecutorFactory:
     """
 
     def __init__(
-        self, mutation_p: float = 0.1, num_tries: int = 1, operator_p: float = 0.5
+        self,
+        mutation_p: float = 0.1,
+        num_tries: int = 1,
+        operator_p: float = 0.5,
+        operator_types: Sequence[Type[Rule]] = (Or, And),
     ):
         check_isinstance(mutation_p, float)
         if mutation_p < 0.0 or mutation_p > 1.0:
@@ -141,53 +77,75 @@ class MutationExecutorFactory:
             raise ValueError(
                 f"operator_p must be between 0.0 and 1.0, got {operator_p}"
             )
+        validate_operator_types(operator_types)
+
         self.mutation_p = mutation_p
         self.num_tries = num_tries
         self.operator_p = operator_p
+        self.operator_types: Tuple[Type[Rule], ...] = tuple(operator_types)
 
-    @staticmethod
-    def create_literal_mutations(num_literals: int) -> Tuple[Mutation, ...]:
+    def create_literal_mutations(self, num_literals: int) -> Tuple[Mutation, ...]:
         """
-        Create the set of literal-level mutations.
-
-        Override this method to use custom literal mutations. The default delegates
-        to `create_standard_literal_mutations(num_literals)`.
+        Create the set of standard literal-level mutations. Override this method to use custom literal mutations.
 
         Args:
-            num_literals (int): Total number of available literal values.
+            num_literals (int):
+                Total number of available literal values. Must be greater than `1`.
 
         Returns:
             Tuple[Mutation, ...]: Literal mutations for the executor.
+
+        Examples:
+            >>> from hgp_lib.mutations import MutationExecutorFactory
+            >>> from hgp_lib.rules import And, Or
+            >>> mutations = MutationExecutorFactory().create_literal_mutations(num_literals=4)
+            >>> [type(mutation).__name__ for mutation in mutations]
+            ['DeleteMutation', 'NegateMutation', 'ReplaceLiteral', 'PromoteLiteral']
         """
-        return create_standard_literal_mutations(num_literals)
+        return (
+            DeleteMutation(),
+            NegateMutation(),
+            ReplaceLiteral(num_literals),
+            PromoteLiteral(num_literals, self.operator_types),
+        )
 
     def create_operator_mutations(self, num_literals: int) -> Tuple[Mutation, ...]:
         """
-        Create the set of operator-level mutations.
-
-        Override this method to use custom operator mutations. The default delegates
-        to `create_standard_operator_mutations(num_literals)`.
+        Create the set of standard operator-level mutations. Override this method to use custom operator mutations.
 
         Args:
             num_literals (int): Total number of available literal values.
 
         Returns:
             Tuple[Mutation, ...]: Operator mutations for the executor.
+
+            Examples:
+            >>> from hgp_lib.mutations import MutationExecutorFactory
+            >>> from hgp_lib.rules import And, Or
+            >>> mutations = MutationExecutorFactory().create_operator_mutations(num_literals=4)
+            >>> [type(mutation).__name__ for mutation in mutations]
+            ['DeleteMutation', 'NegateMutation', 'RemoveIntermediateOperator', 'ReplaceOperator', 'AddLiteral']
         """
-        return create_standard_operator_mutations(num_literals)
+        return (
+            DeleteMutation(),
+            NegateMutation(),
+            RemoveIntermediateOperator(),
+            ReplaceOperator(self.operator_types),
+            AddLiteral(num_literals),
+        )
 
     @staticmethod
     def _validate_mutations(
-        literal_mutations: Sequence[Mutation],
-        operator_mutations: Sequence[Mutation],
+        literal_mutations: Tuple[Mutation, ...],
+        operator_mutations: Tuple[Mutation, ...],
     ):
-        check_isinstance(literal_mutations, Sequence)
-        check_isinstance(operator_mutations, Sequence)
+        check_isinstance(literal_mutations, Tuple)
+        check_isinstance(operator_mutations, Tuple)
 
         if len(literal_mutations) == 0:
-            raise ValueError("literal_mutations must be a non-empty Sequence")
+            raise ValueError("literal_mutations must be a non-empty Tuple")
         if len(operator_mutations) == 0:
-            raise ValueError("operator_mutations must be a non-empty Sequence")
+            raise ValueError("operator_mutations must be a non-empty Tuple")
 
         for literal_mutation in literal_mutations:
             check_isinstance(literal_mutation, Mutation)
@@ -218,6 +176,8 @@ class MutationExecutorFactory:
         Returns:
             MutationExecutor: Configured mutation executor.
         """
+        validate_num_literals(num_literals)
+
         if check_valid is None and self.num_tries > 1:
             raise ValueError("num_tries must be 1 if check_valid is None")
 

--- a/hgp_lib/mutations/operator_mutations.py
+++ b/hgp_lib/mutations/operator_mutations.py
@@ -1,11 +1,10 @@
 import random
-from typing import Tuple, Type, Sequence
+from typing import Tuple, Type
 
 import numpy as np
 
 from .base_mutation import Mutation
 from .utils import MutationError
-from ..utils.validation import validate_num_literals, validate_operator_types
 from ..rules import Rule, Or, And, Literal
 
 
@@ -114,10 +113,12 @@ class ReplaceOperator(Mutation):
         Or(0, 1)
     """
 
-    def __init__(self, operator_types: Sequence[Type[Rule]] = (Or, And)):
+    def __init__(self, operator_types: Tuple[Type[Rule], ...] = (Or, And)):
         super().__init__(is_literal_mutation=False, is_operator_mutation=True)
-        validate_operator_types(operator_types)
-        self.operator_types: Tuple[Type[Rule], ...] = tuple(operator_types)
+
+        # operator_types was validated
+
+        self.operator_types = operator_types
 
     def apply(self, rule: Rule):
         """
@@ -175,7 +176,7 @@ class AddLiteral(Mutation):
     def __init__(self, num_literals: int):
         super().__init__(is_literal_mutation=False, is_operator_mutation=True)
 
-        validate_num_literals(num_literals)
+        # num_literals was validated
 
         self.num_literals = num_literals
         self.available_literals = set(range(num_literals))

--- a/hgp_lib/trainers/gp_trainer.py
+++ b/hgp_lib/trainers/gp_trainer.py
@@ -59,7 +59,6 @@ class GPTrainer:
         self.progress_callback = config.progress_callback
 
         self.score_fn = self.gp_algo.score_fn  # Maybe optimized
-        self._original_score_fn = self.gp_algo.original_score_fn
         if config.val_data is not None and config.gp_config.optimize_scorer:
             self.val_score_fn, self.val_data, self.val_labels = (
                 optimize_scorer_for_data(
@@ -125,3 +124,5 @@ class GPTrainer:
             generations=parent_generations,
             global_best_rule=self.gp_algo.global_best_rule,
         )
+
+    # TODO: Maybe we should add predict to allow using GPTrainer in sklearn pipelines

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -163,15 +163,6 @@ class TestMutations(unittest.TestCase):
         with self.subTest("Validate Constructor"):
             with self.assertRaises(TypeError):
                 mutation = ReplaceLiteral()
-            with self.assertRaises(TypeError):
-                mutation = ReplaceLiteral("x")
-            with self.assertRaises(TypeError):
-                mutation = ReplaceLiteral(1.0)
-            with self.assertRaises(TypeError):
-                mutation = ReplaceLiteral([1])
-
-            with self.assertRaises(ValueError):
-                mutation = ReplaceLiteral(-1)
 
         rule = Or(
             [
@@ -206,26 +197,6 @@ class TestMutations(unittest.TestCase):
         with self.subTest("Validate Constructor"):
             with self.assertRaises(TypeError):
                 mutation = PromoteLiteral()
-            with self.assertRaises(TypeError):
-                mutation = PromoteLiteral("x")
-            with self.assertRaises(TypeError):
-                mutation = PromoteLiteral(1.0)
-            with self.assertRaises(TypeError):
-                mutation = PromoteLiteral([1])
-
-            with self.assertRaises(ValueError):
-                mutation = PromoteLiteral(-1)
-
-            with self.assertRaises(TypeError):
-                mutation = PromoteLiteral(2, dict())
-
-            with self.assertRaises(ValueError):
-                mutation = PromoteLiteral(2, [])
-            with self.assertRaises(ValueError):
-                mutation = PromoteLiteral(2, [Or])
-
-            with self.assertRaises(TypeError):
-                mutation = PromoteLiteral(2, [Or, 1])
 
         mutation = PromoteLiteral(2, [Or, And])
 
@@ -271,20 +242,6 @@ class TestMutations(unittest.TestCase):
         self.assertEqual(str(rule), "And(4, 0, 1, 2, 3)")
 
     def test_replace_operator(self):
-        with self.subTest("Validate Constructor"):
-            with self.assertRaises(TypeError):
-                mutation = ReplaceOperator(1)
-            with self.assertRaises(TypeError):
-                mutation = ReplaceOperator(dict())
-
-            with self.assertRaises(ValueError):
-                mutation = ReplaceOperator([])
-            with self.assertRaises(ValueError):
-                mutation = ReplaceOperator([Or])
-
-            with self.assertRaises(TypeError):
-                mutation = ReplaceOperator([Or, 1])
-
         mutation = ReplaceOperator()
 
         self.assertFalse(mutation.is_literal_mutation)
@@ -307,18 +264,6 @@ class TestMutations(unittest.TestCase):
         self.assertTrue(rule.negated)
 
     def test_add_literal(self):
-        with self.subTest("Validate Constructor"):
-            with self.assertRaises(TypeError):
-                mutation = AddLiteral()
-            with self.assertRaises(TypeError):
-                mutation = AddLiteral("x")
-            with self.assertRaises(TypeError):
-                mutation = AddLiteral(1.0)
-            with self.assertRaises(TypeError):
-                mutation = AddLiteral([1])
-
-            with self.assertRaises(ValueError):
-                mutation = AddLiteral(-1)
 
         mutation = AddLiteral(5)
 
@@ -373,7 +318,7 @@ class TestMutations(unittest.TestCase):
                     def create_literal_mutations(
                         self, num_literals: int
                     ) -> Tuple[Mutation, ...]:
-                        return []
+                        return tuple()
 
                 BadMutationFactory().create(5)
 
@@ -395,7 +340,7 @@ class TestMutations(unittest.TestCase):
                     def create_operator_mutations(
                         self, num_literals: int
                     ) -> Tuple[Mutation, ...]:
-                        return []
+                        return tuple()
 
                 BadMutationFactory().create(5)
 
@@ -415,9 +360,9 @@ class TestMutations(unittest.TestCase):
 
                 class BadMutationFactory(MutationExecutorFactory):
                     def create_literal_mutations(
-                        self, num_literals: int
+                        self, num_literals: int, operator_types
                     ) -> Tuple[Mutation, ...]:
-                        return [_ToggleOperatorMutation()]
+                        return (_ToggleOperatorMutation(),)
 
                 BadMutationFactory().create(5)
 
@@ -426,11 +371,11 @@ class TestMutations(unittest.TestCase):
 
                 class BadMutationFactory(MutationExecutorFactory):
                     def create_operator_mutations(
-                        self, num_literals: int
+                        self, num_literals: int, operator_types
                     ) -> Tuple[Mutation, ...]:
-                        return [_IncrementLiteralMutation()]
+                        return (_IncrementLiteralMutation(),)
 
-                BadMutationFactory().create()
+                BadMutationFactory().create(5)
 
         with self.subTest("num_tries requires check_valid"):
             with self.assertRaises(ValueError):


### PR DESCRIPTION
* Skipping config validation if already validated. Added `_validated` flag to configs in order to allow fast exit when validating input.
* Moved all input validation from `BooleanGP.__init__` to `validate_gp_config`.
* Removed sampling_strategy check from `_create_child_populations`.
* Removed `create_standard_literal_mutations` and `create_standard_operator_mutations`. Added their functionality to `MutationExecutorFactory`.
* Moved input validation from MutationClasses to `MutationExecutorFactory`. Input validation for num_literals or operator_types is done only once, not in every Mutation class
* `operator_types` are now Tuple instead of Sequence, skipping one additional conversion to tuple.
* `operator_types` can now be configured from `MutationExecutorFactory`. All input validation was moved to `MutationExecutorFactory`. `MutationExecutorFactory.create_literal_mutations` and `MutationExecutorFactory.create_operator_mutations` were updated.
* Updated the mutation tests and removed input validation tests.