### PR TITLE
Closes #60. Improved documentation and test coverage for metrics module

### DIFF
--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -84,7 +84,7 @@ def execute_single_run(
     )
 
     best_fold_idx = 0
-    best_val_score = -float("inf")
+    best_fold_score = -float("inf")
     for fold_idx, (train_idx, val_idx) in enumerate(fold_splits):
         fold_train = train_data.iloc[train_idx]
         fold_train_labels = train_labels[train_idx]
@@ -116,11 +116,15 @@ def execute_single_run(
 
         trainer = GPTrainer(fold_trainer_config)
         history = trainer.fit()
-        if (
-            history.best_val_score is not None
-            and history.best_val_score > best_val_score
-        ):
-            best_val_score = history.best_val_score
+
+        # Prefer validation score; fall back to training score
+        fold_score = (
+            history.best_val_score
+            if history.best_val_score is not None
+            else history.best_train_score
+        )
+        if fold_score is not None and fold_score > best_fold_score:
+            best_fold_score = fold_score
             best_fold_idx = fold_idx
 
         folds.append(history)

--- a/hgp_lib/metrics/core.py
+++ b/hgp_lib/metrics/core.py
@@ -8,7 +8,46 @@ from ..rules import Rule
 
 @dataclass()
 class GenerationMetrics:
-    """All metrics captured at a single generation for one population."""
+    """
+    Metrics captured at a single generation for one population.
+
+    Stores per-rule training scores, complexities, the best rule found in this
+    generation, and optionally a validation score. In hierarchical GP, child
+    population metrics are nested via ``child_population_generation_metrics``.
+
+    Args:
+        best_idx (int):
+            Index of the best-scoring rule in ``train_scores``.
+        best_rule (Rule):
+            Copy of the best rule from this generation.
+        complexities (Sequence[int]):
+            Number of nodes in each rule (same order as ``train_scores``).
+        train_scores (Sequence[float]):
+            Fitness scores for every rule in the population.
+        child_population_generation_metrics (Sequence[GenerationMetrics]):
+            Metrics from child populations in hierarchical GP. Empty list for
+            flat (non-hierarchical) runs.
+        val_score (float | None):
+            Validation score of the global best rule at this generation, or ``None``
+            if validation was not performed. Default: `None`.
+
+    Examples:
+        >>> from hgp_lib.metrics import GenerationMetrics
+        >>> from hgp_lib.rules import Literal
+        >>> m = GenerationMetrics.from_population(
+        ...     best_idx=1,
+        ...     best_rule=Literal(value=1),
+        ...     train_scores=[0.7, 0.9, 0.5],
+        ...     complexities=[1, 3, 2],
+        ...     child_population_generation_metrics=[],
+        ... )
+        >>> m.best_train_score
+        0.9
+        >>> m.best_rule_complexity
+        3
+        >>> m.population_size
+        3
+    """
 
     best_idx: int
     best_rule: Rule
@@ -28,22 +67,95 @@ class GenerationMetrics:
         complexities: Sequence[int],
         child_population_generation_metrics: Sequence["GenerationMetrics"],
     ) -> "GenerationMetrics":
+        """
+        Construct a ``GenerationMetrics`` from population-level data.
+
+        This is the preferred constructor used by ``BooleanGP._new_generation``.
+
+        Args:
+            best_idx (int):
+                Index of the best rule in ``train_scores``.
+            best_rule (Rule):
+                The best rule (already copied).
+            train_scores (Sequence[float]):
+                Per-rule fitness scores.
+            complexities (Sequence[int]):
+                Per-rule node counts.
+            child_population_generation_metrics (Sequence[GenerationMetrics]):
+                Child metrics (empty list for flat GP).
+
+        Returns:
+            GenerationMetrics: A new instance with ``val_score=None``.
+
+        Examples:
+            >>> from hgp_lib.metrics import GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> m = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.8], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> m.val_score is None
+            True
+        """
         return cls(
             best_rule=best_rule,
             best_idx=best_idx,
             complexities=complexities,
             train_scores=train_scores,
-            child_population_generation_metrics=(child_population_generation_metrics),
+            child_population_generation_metrics=child_population_generation_metrics,
         )
 
     @property
     def best_train_score(self) -> float:
+        """
+        Training score of the best rule in this generation.
+
+        Examples:
+            >>> from hgp_lib.metrics import GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> m = GenerationMetrics.from_population(
+            ...     best_idx=2, best_rule=Literal(value=0),
+            ...     train_scores=[0.1, 0.2, 0.9], complexities=[1, 1, 1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> m.best_train_score
+            0.9
+        """
         return self.train_scores[self.best_idx]
 
     @property
     def best_rule_complexity(self) -> int:
+        """
+        Node count of the best rule in this generation.
+
+        Examples:
+            >>> from hgp_lib.metrics import GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> m = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.8], complexities=[5],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> m.best_rule_complexity
+            5
+        """
         return self.complexities[self.best_idx]
 
     @property
     def population_size(self) -> int:
+        """
+        Number of rules in the population at this generation.
+
+        Examples:
+            >>> from hgp_lib.metrics import GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> m = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.1, 0.2, 0.3], complexities=[1, 2, 3],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> m.population_size
+            3
+        """
         return len(self.train_scores)

--- a/hgp_lib/metrics/history.py
+++ b/hgp_lib/metrics/history.py
@@ -11,7 +11,39 @@ from .core import GenerationMetrics
 
 @dataclass
 class PopulationHistory:
-    """Complete history of a population across all generations."""
+    """
+    Complete history of a population across all training generations.
+
+    Stores the global best rule, training and validation confusion matrix values,
+    and a list of ``GenerationMetrics`` — one per epoch. Used as the return type
+    of ``GPTrainer.fit()`` and as fold-level results inside ``RunResult``.
+
+    Args:
+        global_best_rule (Rule):
+            The best rule found across all generations (by validation score when
+            available, otherwise by training score).
+        tp (int): True positives of the global best rule on training data.
+        fp (int): False positives of the global best rule on training data.
+        fn (int): False negatives of the global best rule on training data.
+        tn (int): True negatives of the global best rule on training data.
+        val_tp (int | None): True positives on validation data, or ``None``. Default: `None`.
+        val_fp (int | None): False positives on validation data, or ``None``. Default: `None`.
+        val_fn (int | None): False negatives on validation data, or ``None``. Default: `None`.
+        val_tn (int | None): True negatives on validation data, or ``None``. Default: `None`.
+        generations (List[GenerationMetrics]):
+            Per-epoch metrics. Default: empty list.
+
+    Examples:
+        >>> from hgp_lib.metrics import PopulationHistory, GenerationMetrics
+        >>> from hgp_lib.rules import Literal
+        >>> ph = PopulationHistory(
+        ...     global_best_rule=Literal(value=0), tp=5, fp=1, fn=2, tn=7,
+        ... )
+        >>> len(ph.generations)
+        0
+        >>> ph.best_val_score is None
+        True
+    """
 
     global_best_rule: Rule
     tp: int
@@ -30,7 +62,59 @@ class PopulationHistory:
 
     @cached_property
     def best_val_score(self):
+        """
+        Maximum validation score across all generations, or ``None`` if no
+        generation has a validation score.
+
+        Examples:
+            >>> from dataclasses import replace
+            >>> from hgp_lib.metrics import PopulationHistory, GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> g1 = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.8], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> g2 = replace(g1, val_score=0.6)
+            >>> g3 = replace(g1, val_score=0.9)
+            >>> ph = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g1, g2, g3],
+            ... )
+            >>> ph.best_val_score
+            0.9
+        """
         val_scores = [x.val_score for x in self.generations if x.val_score is not None]
         if len(val_scores) == 0:
-            return None  # Can't be None if validation data exists.
+            return None
         return max(val_scores)
+
+    @cached_property
+    def best_train_score(self):
+        """
+        Maximum training score across all generations, or ``None`` if there are
+        no generations.
+
+        Examples:
+            >>> from hgp_lib.metrics import PopulationHistory, GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> g1 = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.6], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> g2 = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.9], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> ph = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g1, g2],
+            ... )
+            >>> ph.best_train_score
+            0.9
+        """
+        if len(self.generations) == 0:
+            return None
+        return max([g.best_train_score for g in self.generations])

--- a/hgp_lib/metrics/results.py
+++ b/hgp_lib/metrics/results.py
@@ -12,7 +12,41 @@ from ..rules import Rule
 
 @dataclass
 class RunResult:
-    """Result of one complete run with k-fold cross-validation."""
+    """
+    Result of one complete benchmark run with k-fold cross-validation.
+
+    Contains per-fold training histories, the test-set evaluation of the best
+    fold's rule, and the confusion matrix on the held-out test set.
+
+    Args:
+        run_id (int): Zero-based index of this run.
+        seed (int): Random seed used for the stratified split and k-fold.
+        best_fold_idx (int): Index of the fold with the highest validation score.
+        folds (List[PopulationHistory]): Training history for each fold.
+        test_score (float): Score of the best rule on the held-out test set.
+        test_tp (int): True positives on the test set.
+        test_fp (int): False positives on the test set.
+        test_fn (int): False negatives on the test set.
+        test_tn (int): True negatives on the test set.
+        feature_names (Dict[int, str]): Mapping from feature index to column name
+            (from the binarizer fitted on the best fold).
+
+    Examples:
+        >>> from hgp_lib.metrics import RunResult, PopulationHistory
+        >>> from hgp_lib.rules import Literal
+        >>> fold = PopulationHistory(
+        ...     global_best_rule=Literal(value=0), tp=3, fp=1, fn=0, tn=6,
+        ... )
+        >>> run = RunResult(
+        ...     run_id=0, seed=42, best_fold_idx=0, folds=[fold],
+        ...     test_score=0.85, test_tp=4, test_fp=1, test_fn=1, test_tn=4,
+        ...     feature_names={0: "age", 1: "income"},
+        ... )
+        >>> run.best_rule
+        0
+        >>> run.test_confusion_matrix
+        '[TP: 4, FP: 1, FN: 1, TN: 4]'
+    """
 
     run_id: int
     seed: int
@@ -26,17 +60,81 @@ class RunResult:
     feature_names: Dict[int, str]
 
     @cached_property
-    def best_fold(self):
+    def best_fold(self) -> PopulationHistory:
+        """
+        The ``PopulationHistory`` of the fold with the highest validation score.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> f0 = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=1, fp=0, fn=0, tn=1,
+            ... )
+            >>> f1 = PopulationHistory(
+            ...     global_best_rule=Literal(value=1), tp=2, fp=0, fn=0, tn=2,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=1, folds=[f0, f1],
+            ...     test_score=0.9, test_tp=1, test_fp=0, test_fn=0, test_tn=1,
+            ...     feature_names={},
+            ... )
+            >>> run.best_fold is f1
+            True
+        """
         return self.folds[self.best_fold_idx]
 
     @cached_property
     def best_rule(self) -> Rule:
-        """Get best rule from best fold (by validation score)."""
+        """
+        The global best rule from the best fold.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=5), tp=0, fp=0, fn=0, tn=0,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> str(run.best_rule)
+            '5'
+        """
         return self.best_fold.global_best_rule
 
     @cached_property
     def fold_val_scores(self) -> List[float]:
-        """Get best validation score from each fold."""
+        """
+        Best validation score from each fold (folds without validation are excluded).
+
+        Examples:
+            >>> from dataclasses import replace
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory, GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> g = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.8], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> g_val = replace(g, val_score=0.7)
+            >>> f0 = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g_val],
+            ... )
+            >>> f1 = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g],
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[f0, f1],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> run.fold_val_scores
+            [0.7]
+        """
         return [
             fold.best_val_score
             for fold in self.folds
@@ -44,20 +142,134 @@ class RunResult:
         ]
 
     @cached_property
+    def fold_train_scores(self) -> List[float]:
+        """
+        Best training score from each fold (folds without generations are excluded).
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory, GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> g = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.8], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g],
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> run.fold_train_scores
+            [0.8]
+        """
+        return [
+            fold.best_train_score
+            for fold in self.folds
+            if fold.best_train_score is not None
+        ]
+
+    @cached_property
     def mean_val_score(self) -> float:
-        """Get mean of best validation scores across all folds."""
+        """
+        Mean of the best validation scores across all folds. Returns ``0.0`` if no
+        fold has a validation score.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> run.mean_val_score
+            0.0
+        """
         scores = self.fold_val_scores
         if len(scores) == 0:
             return 0.0
         return float(np.mean(scores))
 
     @cached_property
+    def mean_train_score(self) -> float:
+        """
+        Mean of the best training scores across all folds. Returns ``0.0`` if no
+        fold has training generations.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory, GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> g = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.85], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g],
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> run.mean_train_score
+            0.85
+        """
+        scores = self.fold_train_scores
+        if len(scores) == 0:
+            return 0.0
+        return float(np.mean(scores))
+
+    @cached_property
     def train_confusion_matrix(self) -> str:
+        """
+        Formatted confusion matrix string for the best fold's training data.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=3, fp=1, fn=2, tn=4,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> run.train_confusion_matrix
+            '[TP: 3, FP: 1, FN: 2, TN: 4]'
+        """
         best_fold = self.best_fold
         return f"[TP: {best_fold.tp}, FP: {best_fold.fp}, FN: {best_fold.fn}, TN: {best_fold.tn}]"
 
     @cached_property
     def val_confusion_matrix(self) -> str:
+        """
+        Formatted confusion matrix string for the best fold's validation data.
+        Returns ``"[]"`` if no validation data was used.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> run.val_confusion_matrix
+            '[]'
+        """
         best_fold = self.best_fold
         if best_fold.val_tp is None:
             return "[]"
@@ -65,30 +277,125 @@ class RunResult:
 
     @cached_property
     def test_confusion_matrix(self) -> str:
+        """
+        Formatted confusion matrix string for the held-out test set.
+
+        Examples:
+            >>> from hgp_lib.metrics import RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=5, test_fp=2, test_fn=1, test_tn=7,
+            ...     feature_names={},
+            ... )
+            >>> run.test_confusion_matrix
+            '[TP: 5, FP: 2, FN: 1, TN: 7]'
+        """
         return f"[TP: {self.test_tp}, FP: {self.test_fp}, FN: {self.test_fn}, TN: {self.test_tn}]"
 
 
 @dataclass
 class ExperimentResult:
-    """Aggregated results across multiple runs."""
+    """
+    Aggregated results across multiple benchmark runs.
+
+    Args:
+        runs (List[RunResult]): Results from each independent run.
+
+    Examples:
+        >>> from dataclasses import replace
+        >>> from hgp_lib.metrics import ExperimentResult, RunResult, PopulationHistory, GenerationMetrics
+        >>> from hgp_lib.rules import Literal
+        >>> g = GenerationMetrics.from_population(
+        ...     best_idx=0, best_rule=Literal(value=0),
+        ...     train_scores=[0.8], complexities=[1],
+        ...     child_population_generation_metrics=[],
+        ... )
+        >>> g_low = replace(g, val_score=0.5)
+        >>> g_high = replace(g, val_score=0.9)
+        >>> fold_low = PopulationHistory(
+        ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+        ...     generations=[g_low],
+        ... )
+        >>> fold_high = PopulationHistory(
+        ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+        ...     generations=[g_high],
+        ... )
+        >>> r1 = RunResult(
+        ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold_low],
+        ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+        ...     feature_names={},
+        ... )
+        >>> r2 = RunResult(
+        ...     run_id=1, seed=1, best_fold_idx=0, folds=[fold_high],
+        ...     test_score=0.9, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+        ...     feature_names={},
+        ... )
+        >>> exp = ExperimentResult(runs=[r1, r2])
+        >>> exp.test_scores
+        [0.8, 0.9]
+        >>> exp.best_run.run_id
+        1
+    """
 
     runs: List[RunResult]
 
     @cached_property
     def best_run(self) -> RunResult:
         """
-        Get the run with the highest mean validation score across folds.
+        The run with the highest mean validation score across folds. When no run
+        has validation scores, falls back to mean training score.
 
         Returns:
-            RunResult with highest mean validation score.
+            RunResult: The best-performing run.
+
+        Examples:
+            >>> from hgp_lib.metrics import ExperimentResult, RunResult, PopulationHistory, GenerationMetrics
+            >>> from hgp_lib.rules import Literal
+            >>> g_low = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.5], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> g_high = GenerationMetrics.from_population(
+            ...     best_idx=0, best_rule=Literal(value=0),
+            ...     train_scores=[0.9], complexities=[1],
+            ...     child_population_generation_metrics=[],
+            ... )
+            >>> f_low = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g_low],
+            ... )
+            >>> f_high = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ...     generations=[g_high],
+            ... )
+            >>> r1 = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[f_low],
+            ...     test_score=0.7, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> r2 = RunResult(
+            ...     run_id=1, seed=1, best_fold_idx=0, folds=[f_high],
+            ...     test_score=0.9, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> ExperimentResult(runs=[r1, r2]).best_run.run_id
+            1
         """
+        # Use validation scores when available, otherwise fall back to training
+        has_val = any(run.mean_val_score > 0.0 for run in self.runs)
+
         best_run = None
         best_mean = -float("inf")
 
         for run in self.runs:
-            mean_val = run.mean_val_score
-            if mean_val > best_mean:
-                best_mean = mean_val
+            score = run.mean_val_score if has_val else run.mean_train_score
+            if score > best_mean:
+                best_mean = score
                 best_run = run
 
         return best_run
@@ -96,19 +403,45 @@ class ExperimentResult:
     @cached_property
     def best_rule(self) -> Rule:
         """
-        Get the best rule from the best fold of the best run.
-
-        Best run = run with highest mean validation score across folds.
-        Best fold = fold with highest best validation score in best run.
-        Best rule = rule with highest validation score in best fold.
+        The best rule from the best fold of the best run.
 
         Returns:
-            Best Rule.
+            Rule: The overall best rule across the entire experiment.
+
+        Examples:
+            >>> from hgp_lib.metrics import ExperimentResult, RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=7), tp=0, fp=0, fn=0, tn=0,
+            ... )
+            >>> run = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> str(ExperimentResult(runs=[run]).best_rule)
+            '7'
         """
         best_run = self.best_run
         return best_run.folds[best_run.best_fold_idx].global_best_rule
 
     @cached_property
     def test_scores(self) -> list[float]:
-        """Get test scores from all runs."""
+        """
+        Test scores from all runs.
+
+        Examples:
+            >>> from hgp_lib.metrics import ExperimentResult, RunResult, PopulationHistory
+            >>> from hgp_lib.rules import Literal
+            >>> fold = PopulationHistory(
+            ...     global_best_rule=Literal(value=0), tp=0, fp=0, fn=0, tn=0,
+            ... )
+            >>> r = RunResult(
+            ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
+            ...     test_score=0.75, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
+            ...     feature_names={},
+            ... )
+            >>> ExperimentResult(runs=[r]).test_scores
+            [0.75]
+        """
         return [run.test_score for run in self.runs]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,94 +1,121 @@
 """Unit tests for PopulationHistory."""
 
+import doctest
 import unittest
 from dataclasses import replace
 
+import hgp_lib.metrics.history
 from hgp_lib.metrics.history import PopulationHistory
 from hgp_lib.metrics.core import GenerationMetrics
 from hgp_lib.rules import Literal
 
 
 class TestPopulationHistory(unittest.TestCase):
-    """Tests for PopulationHistory dataclass."""
+    def _make_gen(self, val_score=None, train_score=0.8):
+        g = GenerationMetrics.from_population(
+            best_idx=0,
+            best_rule=Literal(value=0),
+            train_scores=[train_score],
+            complexities=[1],
+            child_population_generation_metrics=[],
+        )
+        if val_score is not None:
+            g = replace(g, val_score=val_score)
+        return g
 
-    def test_empty_history(self):
-        """Test empty history has zero generations."""
-        ph = PopulationHistory(
+    def _make_history(self, generations=None, **kwargs):
+        defaults = dict(
             global_best_rule=Literal(value=0),
             tp=0,
             fp=0,
             fn=0,
             tn=0,
         )
+        defaults.update(kwargs)
+        if generations is not None:
+            defaults["generations"] = generations
+        return PopulationHistory(**defaults)
+
+    # ------------------------------------------------------------------ #
+    #  Construction
+    # ------------------------------------------------------------------ #
+    def test_empty_history(self):
+        ph = self._make_history()
         self.assertEqual(len(ph.generations), 0)
 
     def test_with_generations(self):
-        """Test history with generations."""
-        gen = GenerationMetrics.from_population(
-            best_idx=0,
-            best_rule=Literal(value=0),
-            train_scores=[0.8],
-            complexities=[1],
-            child_population_generation_metrics=[],
-        )
-        ph = PopulationHistory(
-            global_best_rule=Literal(value=0),
-            tp=0,
-            fp=0,
-            fn=0,
-            tn=0,
-            generations=[gen],
-        )
+        ph = self._make_history(generations=[self._make_gen()])
         self.assertEqual(len(ph.generations), 1)
 
+    def test_confusion_matrix_fields(self):
+        ph = self._make_history(tp=5, fp=2, fn=1, tn=7)
+        self.assertEqual(ph.tp, 5)
+        self.assertEqual(ph.fp, 2)
+        self.assertEqual(ph.fn, 1)
+        self.assertEqual(ph.tn, 7)
+
+    def test_val_confusion_matrix_defaults_none(self):
+        ph = self._make_history()
+        self.assertIsNone(ph.val_tp)
+        self.assertIsNone(ph.val_fp)
+        self.assertIsNone(ph.val_fn)
+        self.assertIsNone(ph.val_tn)
+
+    def test_val_confusion_matrix_set(self):
+        ph = self._make_history(val_tp=3, val_fp=1, val_fn=0, val_tn=6)
+        self.assertEqual(ph.val_tp, 3)
+        self.assertEqual(ph.val_tn, 6)
+
+    # ------------------------------------------------------------------ #
+    #  best_val_score
+    # ------------------------------------------------------------------ #
     def test_best_val_score_none_when_no_val(self):
-        """Test best_val_score is None when no validation scores exist."""
-        gen = GenerationMetrics.from_population(
-            best_idx=0,
-            best_rule=Literal(value=0),
-            train_scores=[0.8],
-            complexities=[1],
-            child_population_generation_metrics=[],
-        )
-        ph = PopulationHistory(
-            global_best_rule=Literal(value=0),
-            generations=[gen],
-            tp=0,
-            fp=0,
-            fn=0,
-            tn=0,
-        )
+        ph = self._make_history(generations=[self._make_gen()])
         self.assertIsNone(ph.best_val_score)
 
-    def test_best_val_score_with_val(self):
-        """Test best_val_score returns max val score."""
-        gen1 = GenerationMetrics.from_population(
-            best_idx=0,
-            best_rule=Literal(value=0),
-            train_scores=[0.8],
-            complexities=[1],
-            child_population_generation_metrics=[],
-        )
-        gen1 = replace(gen1, val_score=0.6)
+    def test_best_val_score_single(self):
+        ph = self._make_history(generations=[self._make_gen(val_score=0.7)])
+        self.assertAlmostEqual(ph.best_val_score, 0.7)
 
-        gen2 = GenerationMetrics.from_population(
-            best_idx=0,
-            best_rule=Literal(value=0),
-            train_scores=[0.9],
-            complexities=[1],
-            child_population_generation_metrics=[],
+    def test_best_val_score_max(self):
+        ph = self._make_history(
+            generations=[
+                self._make_gen(val_score=0.6),
+                self._make_gen(val_score=0.9),
+                self._make_gen(val_score=0.75),
+            ]
         )
-        gen2 = replace(gen2, val_score=0.75)
+        self.assertAlmostEqual(ph.best_val_score, 0.9)
 
-        ph = PopulationHistory(
-            global_best_rule=Literal(value=0),
-            generations=[gen1, gen2],
-            tp=0,
-            fp=0,
-            fn=0,
-            tn=0,
+    def test_best_val_score_mixed_none(self):
+        """Generations without val_score should be ignored."""
+        ph = self._make_history(
+            generations=[
+                self._make_gen(),
+                self._make_gen(val_score=0.5),
+                self._make_gen(),
+            ]
         )
-        self.assertAlmostEqual(ph.best_val_score, 0.75)
+        self.assertAlmostEqual(ph.best_val_score, 0.5)
+
+    def test_best_val_score_all_none(self):
+        ph = self._make_history(generations=[self._make_gen(), self._make_gen()])
+        self.assertIsNone(ph.best_val_score)
+
+    # ------------------------------------------------------------------ #
+    #  global_best_rule
+    # ------------------------------------------------------------------ #
+    def test_global_best_rule(self):
+        rule = Literal(value=5)
+        ph = self._make_history(global_best_rule=rule)
+        self.assertIs(ph.global_best_rule, rule)
+
+    # ------------------------------------------------------------------ #
+    #  Doctests
+    # ------------------------------------------------------------------ #
+    def test_doctests(self):
+        result = doctest.testmod(hgp_lib.metrics.history, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
 
 
 if __name__ == "__main__":

--- a/tests/test_metrics_core.py
+++ b/tests/test_metrics_core.py
@@ -1,91 +1,106 @@
-"""Unit tests for GenerationMetrics construction."""
+"""Unit tests for GenerationMetrics."""
 
+import doctest
 import unittest
+from dataclasses import replace
 
+import hgp_lib.metrics.core
 from hgp_lib.metrics.core import GenerationMetrics
 from hgp_lib.rules import Literal, And
 
 
 class TestGenerationMetrics(unittest.TestCase):
-    """Tests for GenerationMetrics construction and properties."""
-
-    def test_from_population_basic(self):
-        """Test basic construction computes all derived fields correctly."""
-        best_rule = And([Literal(value=1), Literal(value=2)])
-        train_scores = [0.7, 0.9]
-        complexities = [1, 3]
-
-        metrics = GenerationMetrics.from_population(
-            best_idx=1,
-            best_rule=best_rule,
-            train_scores=train_scores,
-            complexities=complexities,
-            child_population_generation_metrics=[],
-        )
-
-        self.assertEqual(metrics.population_size, 2)
-        self.assertEqual(metrics.complexities, [1, 3])
-        self.assertEqual(str(metrics.best_rule), "And(1, 2)")
-        self.assertAlmostEqual(metrics.best_train_score, 0.9)
-
-    def test_from_population_with_val_score(self):
-        """Test construction with validation score via replace."""
-        from dataclasses import replace
-
-        best_rule = Literal(value=0)
-        metrics = GenerationMetrics.from_population(
+    def _make(self, **kwargs):
+        defaults = dict(
             best_idx=0,
-            best_rule=best_rule,
+            best_rule=Literal(value=0),
             train_scores=[0.8],
             complexities=[1],
             child_population_generation_metrics=[],
         )
+        defaults.update(kwargs)
+        return GenerationMetrics.from_population(**defaults)
 
-        metrics_with_val = replace(metrics, val_score=0.6)
-        self.assertEqual(metrics_with_val.val_score, 0.6)
-        self.assertIsNone(metrics.val_score)
-
-    def test_hierarchical_metrics(self):
-        """Test construction with child population metrics."""
-        child = GenerationMetrics.from_population(
-            best_idx=0,
-            best_rule=Literal(value=0),
-            train_scores=[0.5],
-            complexities=[1],
-            child_population_generation_metrics=[],
+    # ------------------------------------------------------------------ #
+    #  from_population
+    # ------------------------------------------------------------------ #
+    def test_from_population_basic(self):
+        m = self._make(
+            best_idx=1,
+            best_rule=And([Literal(value=1), Literal(value=2)]),
+            train_scores=[0.7, 0.9],
+            complexities=[1, 3],
         )
+        self.assertEqual(m.population_size, 2)
+        self.assertAlmostEqual(m.best_train_score, 0.9)
+        self.assertEqual(str(m.best_rule), "And(1, 2)")
 
-        metrics = GenerationMetrics.from_population(
-            best_idx=0,
-            best_rule=Literal(value=0),
+    def test_from_population_val_score_is_none(self):
+        m = self._make()
+        self.assertIsNone(m.val_score)
+
+    def test_from_population_with_val_score(self):
+        m = replace(self._make(), val_score=0.6)
+        self.assertEqual(m.val_score, 0.6)
+
+    # ------------------------------------------------------------------ #
+    #  best_train_score
+    # ------------------------------------------------------------------ #
+    def test_best_train_score(self):
+        m = self._make(best_idx=2, train_scores=[0.3, 0.5, 0.9], complexities=[1, 2, 3])
+        self.assertAlmostEqual(m.best_train_score, 0.9)
+
+    def test_best_train_score_first(self):
+        m = self._make(best_idx=0, train_scores=[1.0, 0.5])
+        self.assertAlmostEqual(m.best_train_score, 1.0)
+
+    # ------------------------------------------------------------------ #
+    #  best_rule_complexity
+    # ------------------------------------------------------------------ #
+    def test_best_rule_complexity(self):
+        m = self._make(best_idx=1, train_scores=[0.3, 0.9], complexities=[1, 5])
+        self.assertEqual(m.best_rule_complexity, 5)
+
+    def test_best_rule_complexity_single(self):
+        m = self._make(best_idx=0, complexities=[7])
+        self.assertEqual(m.best_rule_complexity, 7)
+
+    # ------------------------------------------------------------------ #
+    #  population_size
+    # ------------------------------------------------------------------ #
+    def test_population_size(self):
+        m = self._make(train_scores=[0.1, 0.2, 0.3], complexities=[1, 2, 3])
+        self.assertEqual(m.population_size, 3)
+
+    def test_population_size_single(self):
+        m = self._make()
+        self.assertEqual(m.population_size, 1)
+
+    # ------------------------------------------------------------------ #
+    #  child_population_generation_metrics
+    # ------------------------------------------------------------------ #
+    def test_hierarchical_metrics(self):
+        child = self._make(train_scores=[0.5])
+        parent = self._make(
             train_scores=[0.7],
-            complexities=[1],
             child_population_generation_metrics=[child],
         )
-
-        self.assertEqual(len(metrics.child_population_generation_metrics), 1)
-
-    def test_best_train_score(self):
-        """Test best_train_score property."""
-        metrics = GenerationMetrics.from_population(
-            best_idx=1,
-            best_rule=Literal(value=1),
-            train_scores=[0.3, 0.9, 0.5],
-            complexities=[1, 3, 2],
-            child_population_generation_metrics=[],
+        self.assertEqual(len(parent.child_population_generation_metrics), 1)
+        self.assertAlmostEqual(
+            parent.child_population_generation_metrics[0].best_train_score,
+            0.5,
         )
-        self.assertAlmostEqual(metrics.best_train_score, 0.9)
 
-    def test_best_rule_complexity(self):
-        """Test best_rule_complexity property."""
-        metrics = GenerationMetrics.from_population(
-            best_idx=1,
-            best_rule=Literal(value=1),
-            train_scores=[0.3, 0.9],
-            complexities=[1, 5],
-            child_population_generation_metrics=[],
-        )
-        self.assertEqual(metrics.best_rule_complexity, 5)
+    def test_empty_children(self):
+        m = self._make()
+        self.assertEqual(len(m.child_population_generation_metrics), 0)
+
+    # ------------------------------------------------------------------ #
+    #  Doctests
+    # ------------------------------------------------------------------ #
+    def test_doctests(self):
+        result = doctest.testmod(hgp_lib.metrics.core, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
 
 
 if __name__ == "__main__":

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,269 @@
+"""Unit tests for RunResult and ExperimentResult."""
+
+import doctest
+import unittest
+from dataclasses import replace
+
+import hgp_lib.metrics.results
+from hgp_lib.metrics.core import GenerationMetrics
+from hgp_lib.metrics.history import PopulationHistory
+from hgp_lib.metrics.results import RunResult, ExperimentResult
+from hgp_lib.rules import Literal
+
+
+class _Helpers:
+    """Shared factory methods for building test fixtures."""
+
+    @staticmethod
+    def make_gen(val_score=None):
+        g = GenerationMetrics.from_population(
+            best_idx=0,
+            best_rule=Literal(value=0),
+            train_scores=[0.8],
+            complexities=[1],
+            child_population_generation_metrics=[],
+        )
+        if val_score is not None:
+            g = replace(g, val_score=val_score)
+        return g
+
+    @staticmethod
+    def make_fold(rule_value=0, val_score=None, train_score=None, **kwargs):
+        gens = []
+        if val_score is not None or train_score is not None:
+            g = _Helpers.make_gen(val_score=val_score)
+            if train_score is not None:
+                g = replace(g, train_scores=[train_score])
+            gens = [g]
+        defaults = dict(
+            global_best_rule=Literal(value=rule_value),
+            tp=3,
+            fp=1,
+            fn=2,
+            tn=4,
+            generations=gens,
+        )
+        defaults.update(kwargs)
+        return PopulationHistory(**defaults)
+
+    @staticmethod
+    def make_run(
+        run_id=0, seed=42, folds=None, best_fold_idx=0, test_score=0.8, **kwargs
+    ):
+        if folds is None:
+            folds = [_Helpers.make_fold()]
+        defaults = dict(
+            run_id=run_id,
+            seed=seed,
+            best_fold_idx=best_fold_idx,
+            folds=folds,
+            test_score=test_score,
+            test_tp=4,
+            test_fp=1,
+            test_fn=1,
+            test_tn=4,
+            feature_names={0: "col_a", 1: "col_b"},
+        )
+        defaults.update(kwargs)
+        return RunResult(**defaults)
+
+
+class TestRunResult(unittest.TestCase, _Helpers):
+    # ------------------------------------------------------------------ #
+    #  best_fold
+    # ------------------------------------------------------------------ #
+    def test_best_fold(self):
+        f0 = self.make_fold(rule_value=0)
+        f1 = self.make_fold(rule_value=1)
+        run = self.make_run(folds=[f0, f1], best_fold_idx=1)
+        self.assertIs(run.best_fold, f1)
+
+    def test_best_fold_single(self):
+        f = self.make_fold()
+        run = self.make_run(folds=[f], best_fold_idx=0)
+        self.assertIs(run.best_fold, f)
+
+    # ------------------------------------------------------------------ #
+    #  best_rule
+    # ------------------------------------------------------------------ #
+    def test_best_rule(self):
+        f = self.make_fold(rule_value=7)
+        run = self.make_run(folds=[f])
+        self.assertEqual(str(run.best_rule), "7")
+
+    def test_best_rule_from_correct_fold(self):
+        f0 = self.make_fold(rule_value=0)
+        f1 = self.make_fold(rule_value=9)
+        run = self.make_run(folds=[f0, f1], best_fold_idx=1)
+        self.assertEqual(str(run.best_rule), "9")
+
+    # ------------------------------------------------------------------ #
+    #  fold_val_scores
+    # ------------------------------------------------------------------ #
+    def test_fold_val_scores_all_have_val(self):
+        f0 = self.make_fold(val_score=0.7)
+        f1 = self.make_fold(val_score=0.9)
+        run = self.make_run(folds=[f0, f1])
+        self.assertEqual(run.fold_val_scores, [0.7, 0.9])
+
+    def test_fold_val_scores_none_excluded(self):
+        f0 = self.make_fold(val_score=0.7)
+        f1 = self.make_fold()  # no val
+        run = self.make_run(folds=[f0, f1])
+        self.assertEqual(run.fold_val_scores, [0.7])
+
+    def test_fold_val_scores_all_none(self):
+        run = self.make_run(folds=[self.make_fold(), self.make_fold()])
+        self.assertEqual(run.fold_val_scores, [])
+
+    # ------------------------------------------------------------------ #
+    #  mean_val_score
+    # ------------------------------------------------------------------ #
+    def test_mean_val_score(self):
+        f0 = self.make_fold(val_score=0.6)
+        f1 = self.make_fold(val_score=0.8)
+        run = self.make_run(folds=[f0, f1])
+        self.assertAlmostEqual(run.mean_val_score, 0.7)
+
+    def test_mean_val_score_no_val(self):
+        run = self.make_run(folds=[self.make_fold()])
+        self.assertEqual(run.mean_val_score, 0.0)
+
+    # ------------------------------------------------------------------ #
+    #  Confusion matrix strings
+    # ------------------------------------------------------------------ #
+    def test_train_confusion_matrix(self):
+        f = self.make_fold(tp=5, fp=2, fn=1, tn=7)
+        run = self.make_run(folds=[f])
+        self.assertEqual(run.train_confusion_matrix, "[TP: 5, FP: 2, FN: 1, TN: 7]")
+
+    def test_val_confusion_matrix_with_val(self):
+        f = self.make_fold(val_tp=3, val_fp=1, val_fn=0, val_tn=6)
+        run = self.make_run(folds=[f])
+        self.assertEqual(run.val_confusion_matrix, "[TP: 3, FP: 1, FN: 0, TN: 6]")
+
+    def test_val_confusion_matrix_no_val(self):
+        run = self.make_run(folds=[self.make_fold()])
+        self.assertEqual(run.val_confusion_matrix, "[]")
+
+    def test_test_confusion_matrix(self):
+        run = self.make_run(test_tp=5, test_fp=2, test_fn=1, test_tn=7)
+        self.assertEqual(run.test_confusion_matrix, "[TP: 5, FP: 2, FN: 1, TN: 7]")
+
+    # ------------------------------------------------------------------ #
+    #  fold_train_scores
+    # ------------------------------------------------------------------ #
+    def test_fold_train_scores(self):
+        f0 = self.make_fold(train_score=0.7)
+        f1 = self.make_fold(train_score=0.9)
+        run = self.make_run(folds=[f0, f1])
+        self.assertEqual(run.fold_train_scores, [0.7, 0.9])
+
+    def test_fold_train_scores_empty_folds(self):
+        run = self.make_run(folds=[self.make_fold()])  # no generations
+        self.assertEqual(run.fold_train_scores, [])
+
+    # ------------------------------------------------------------------ #
+    #  mean_train_score
+    # ------------------------------------------------------------------ #
+    def test_mean_train_score(self):
+        f0 = self.make_fold(train_score=0.6)
+        f1 = self.make_fold(train_score=0.8)
+        run = self.make_run(folds=[f0, f1])
+        self.assertAlmostEqual(run.mean_train_score, 0.7)
+
+    def test_mean_train_score_no_generations(self):
+        run = self.make_run(folds=[self.make_fold()])
+        self.assertEqual(run.mean_train_score, 0.0)
+
+    # ------------------------------------------------------------------ #
+    #  feature_names
+    # ------------------------------------------------------------------ #
+    def test_feature_names(self):
+        run = self.make_run(feature_names={0: "age", 1: "income"})
+        self.assertEqual(run.feature_names[0], "age")
+        self.assertEqual(run.feature_names[1], "income")
+
+
+class TestExperimentResult(unittest.TestCase, _Helpers):
+    # ------------------------------------------------------------------ #
+    #  best_run
+    # ------------------------------------------------------------------ #
+    def test_best_run_single(self):
+        run = self.make_run(run_id=0)
+        exp = ExperimentResult(runs=[run])
+        self.assertIs(exp.best_run, run)
+
+    def test_best_run_picks_highest_mean_val(self):
+        r0 = self.make_run(run_id=0, folds=[self.make_fold(val_score=0.5)])
+        r1 = self.make_run(run_id=1, folds=[self.make_fold(val_score=0.9)])
+        exp = ExperimentResult(runs=[r0, r1])
+        self.assertEqual(exp.best_run.run_id, 1)
+
+    def test_best_run_no_val_uses_first(self):
+        """When no folds have val scores, mean_val_score=0.0 for all; first run wins."""
+        r0 = self.make_run(run_id=0)
+        r1 = self.make_run(run_id=1)
+        exp = ExperimentResult(runs=[r0, r1])
+        self.assertEqual(exp.best_run.run_id, 0)
+
+    def test_best_run_falls_back_to_train_score(self):
+        """When no run has val scores, best_run should use mean_train_score."""
+        r0 = self.make_run(run_id=0, folds=[self.make_fold(train_score=0.5)])
+        r1 = self.make_run(run_id=1, folds=[self.make_fold(train_score=0.9)])
+        exp = ExperimentResult(runs=[r0, r1])
+        self.assertEqual(exp.best_run.run_id, 1)
+
+    def test_best_run_prefers_val_over_train(self):
+        """When val scores exist, best_run should use them even if train is higher."""
+        r0 = self.make_run(
+            run_id=0, folds=[self.make_fold(val_score=0.9, train_score=0.5)]
+        )
+        r1 = self.make_run(
+            run_id=1, folds=[self.make_fold(val_score=0.3, train_score=0.99)]
+        )
+        exp = ExperimentResult(runs=[r0, r1])
+        self.assertEqual(exp.best_run.run_id, 0)
+
+    # ------------------------------------------------------------------ #
+    #  best_rule
+    # ------------------------------------------------------------------ #
+    def test_best_rule(self):
+        f = self.make_fold(rule_value=42)
+        run = self.make_run(folds=[f])
+        exp = ExperimentResult(runs=[run])
+        self.assertEqual(str(exp.best_rule), "42")
+
+    def test_best_rule_from_best_run(self):
+        r0 = self.make_run(
+            run_id=0, folds=[self.make_fold(rule_value=1, val_score=0.3)]
+        )
+        r1 = self.make_run(
+            run_id=1, folds=[self.make_fold(rule_value=9, val_score=0.9)]
+        )
+        exp = ExperimentResult(runs=[r0, r1])
+        self.assertEqual(str(exp.best_rule), "9")
+
+    # ------------------------------------------------------------------ #
+    #  test_scores
+    # ------------------------------------------------------------------ #
+    def test_test_scores(self):
+        r0 = self.make_run(test_score=0.7)
+        r1 = self.make_run(test_score=0.9)
+        exp = ExperimentResult(runs=[r0, r1])
+        self.assertEqual(exp.test_scores, [0.7, 0.9])
+
+    def test_test_scores_single(self):
+        exp = ExperimentResult(runs=[self.make_run(test_score=0.85)])
+        self.assertEqual(exp.test_scores, [0.85])
+
+    # ------------------------------------------------------------------ #
+    #  Doctests
+    # ------------------------------------------------------------------ #
+    def test_doctests(self):
+        result = doctest.testmod(hgp_lib.metrics.results, verbose=False)
+        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Added docstrings and doctests for all metrics.
* Added `PopulationHistory.best_train_score` property.
* Added `RunResult.fold_train_scores` and RunResult.mean_train_score properties.
* `ExperimentResult.best_run` now falls back to mean_train_score when no run has validation scores.
* Created and expanded tests.
