### PR TITLE
Improving the usage of StandardBinarizer. Adding support for NaN values, string and object-type columns. Improved input validation. Refactoring the binarization framework into an extensible, pluggable architecture.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ data/
 
 # Mac specific
 .DS_store
+.DS_Store
 
 # Output logs
 outputs

--- a/docs/api/preprocessing.md
+++ b/docs/api/preprocessing.md
@@ -1,5 +1,33 @@
 # Preprocessing
 
+## Binarizers
+
+::: hgp_lib.preprocessing.base.Binarizer
+
 ::: hgp_lib.preprocessing.binarizer.StandardBinarizer
+
+::: hgp_lib.preprocessing.sklearn_binarizer.SklearnBinarizer
+
+## Binning Strategies
+
+::: hgp_lib.preprocessing.binning.BinningStrategy
+
+::: hgp_lib.preprocessing.binning.QuantileBinning
+
+::: hgp_lib.preprocessing.binning.SupervisedTreeBinning
+
+## Warnings
+
+::: hgp_lib.preprocessing.warnings.BinarizerWarning
+
+::: hgp_lib.preprocessing.warnings.StringColumnWarning
+
+::: hgp_lib.preprocessing.warnings.HighCardinalityWarning
+
+::: hgp_lib.preprocessing.warnings.UnseenNaNWarning
+
+## Utilities
+
+::: hgp_lib.preprocessing.utils.is_categorical_like
 
 ::: hgp_lib.preprocessing.utils.load_data

--- a/docs/guide/binarization.md
+++ b/docs/guide/binarization.md
@@ -17,7 +17,7 @@ Every binarizer follows the same contract, so implementations are interchangeabl
 
 ## How columns are converted
 
-The `StandardBinarizer` handles three kinds of columns.
+The [`StandardBinarizer`(../api/preprocessing.md#hgp_lib.preprocessing.binarizer.StandardBinarizer)] handles three kinds of columns.
 
 - Boolean columns pass through unchanged.
 - Categorical, string, and object columns are one-hot encoded into one boolean column per unique value.
@@ -54,7 +54,7 @@ Treat `k` as a hyperparameter to tune.
 
 ## Parameters
 
-The `StandardBinarizer` exposes the following parameters.
+The [`StandardBinarizer`(../api/preprocessing.md#hgp_lib.preprocessing.binarizer.StandardBinarizer)] exposes the following parameters.
 
 - `num_bins`: the default number of bins for numeric columns. Must be at least 2. Default is 5.
 - `column_strategy`: a per-column override for the number of bins, as a dict of column name to bin count. Default is none.
@@ -122,7 +122,7 @@ class MedianSplit(BinningStrategy):
 binarizer = StandardBinarizer(numeric_binning=MedianSplit())
 ```
 
-To change how a whole column type is handled, subclass `StandardBinarizer` and override the matching hooks: `_fit_boolean` / `_transform_boolean`, `_fit_categorical` / `_transform_categorical`, or `_fit_numeric` / `_transform_numeric`.
+To change how a whole column type is handled, subclass [`StandardBinarizer`(../api/preprocessing.md#hgp_lib.preprocessing.binarizer.StandardBinarizer)] and override the matching hooks: `_fit_boolean` / `_transform_boolean`, `_fit_categorical` / `_transform_categorical`, or `_fit_numeric` / `_transform_numeric`.
 The `_fit_*` hooks return `(name, values)` pairs, and the `_transform_*` hooks return the values in the same order.
 
 ## Using a scikit-learn discretizer

--- a/docs/guide/binarization.md
+++ b/docs/guide/binarization.md
@@ -1,31 +1,46 @@
 # Binarization
 
 Boolean GP works on boolean data.
-The [`StandardBinarizer`](../api/preprocessing.md#hgp_lib.preprocessing.binarizer.StandardBinarizer) converts a mixed-type DataFrame into a purely boolean one.
+A [`Binarizer`](../api/preprocessing.md#hgp_lib.preprocessing.base.Binarizer) converts a mixed-type DataFrame into a purely boolean one.
 Each output column is a boolean feature that a rule can test.
+The default implementation is [`StandardBinarizer`](../api/preprocessing.md#hgp_lib.preprocessing.binarizer.StandardBinarizer).
+
+## The Binarizer contract
+
+Every binarizer follows the same contract, so implementations are interchangeable.
+
+- `fit_transform(X, y=None)` learns the encoding and returns a boolean DataFrame.
+- `transform(X)` applies the learned encoding and returns a boolean DataFrame with the same columns, in the same order.
+- `is_fitted` reports whether the binarizer has been fitted.
+
+[`GPBenchmarker`](../api/benchmarkers.md#hgp_lib.benchmarkers.gp_benchmarker.GPBenchmarker) relies on this contract, fitting a fresh copy per fold.
 
 ## How columns are converted
 
-The binarizer handles three kinds of columns.
+The `StandardBinarizer` handles three kinds of columns.
 
 - Boolean columns pass through unchanged.
-- Categorical columns are one-hot encoded into one boolean column per unique value.
+- Categorical, string, and object columns are one-hot encoded into one boolean column per unique value.
 - Numeric columns are split into bins, and each bin becomes one boolean column.
 
 A numeric column with `k` bins produces up to `k` boolean columns.
 A bin column is true when the original value falls inside that bin.
 
+String and object columns are treated as categorical, and this raises a [`StringColumnWarning`](../api/preprocessing.md#hgp_lib.preprocessing.warnings.StringColumnWarning).
+Set the column to a pandas `category` dtype to make the intent explicit and avoid the warning.
+A categorical column whose values are all distinct is skipped with a [`HighCardinalityWarning`](../api/preprocessing.md#hgp_lib.preprocessing.warnings.HighCardinalityWarning), since one-hot encoding it would produce one feature per row.
+
 ## Numeric binning strategies
 
-The bin edges for a numeric column are learned at fit time.
-The strategy depends on whether labels are passed to `fit_transform`.
+Numeric bin edges are computed by a [`BinningStrategy`](../api/preprocessing.md#hgp_lib.preprocessing.binning.BinningStrategy).
+When no strategy is set, the binarizer picks one based on whether labels are passed to `fit_transform`.
 
-When labels are provided, the binarizer uses a decision-tree strategy.
+With labels, it uses [`SupervisedTreeBinning`](../api/preprocessing.md#hgp_lib.preprocessing.binning.SupervisedTreeBinning).
 It trains a decision tree on the single feature against the labels and takes the split thresholds as bin edges.
 The tree picks up to `k - 1` thresholds with the highest information gain, which produces `k` bins aligned with the class boundaries.
 This is label-aware, so the bins separate the classes better than unsupervised binning.[@albert2025evolving]
 
-When no labels are provided, the binarizer uses quantile binning.
+Without labels, it uses [`QuantileBinning`](../api/preprocessing.md#hgp_lib.preprocessing.binning.QuantileBinning).
 Edges are placed at evenly spaced quantiles, so each bin holds a similar number of samples.
 Quantile binning does not use the labels, so it can miss class-separating thresholds.
 
@@ -39,11 +54,12 @@ Treat `k` as a hyperparameter to tune.
 
 ## Parameters
 
-The [`StandardBinarizer`](../api/preprocessing.md#hgp_lib.preprocessing.binarizer.StandardBinarizer) exposes the following parameters.
+The `StandardBinarizer` exposes the following parameters.
 
 - `num_bins`: the default number of bins for numeric columns. Must be at least 2. Default is 5.
 - `column_strategy`: a per-column override for the number of bins, as a dict of column name to bin count. Default is none.
 - `precision`: the number of decimals used when formatting numeric bin boundary names. Must be at least 0. Default is 3.
+- `numeric_binning`: an explicit [`BinningStrategy`](../api/preprocessing.md#hgp_lib.preprocessing.binning.BinningStrategy) for numeric columns. When set, it is used regardless of whether labels are provided. Default is none.
 
 The `column_strategy` parameter is what sets this binarizer apart from the common scikit-learn discretizers.
 A tool such as `KBinsDiscretizer` applies one bin count to all numeric columns.
@@ -57,6 +73,11 @@ binarizer = StandardBinarizer(
     column_strategy={"amount": 10},   # amount uses 10 bins instead
 )
 ```
+
+## Missing values
+
+A column that contains missing values also produces a boolean `<col>_is_NA` indicator column, so a rule can test whether a value was missing.
+At transform time, if a column has missing values that were not seen during fit, no new column is created and those rows are encoded as all-false, which raises a [`UnseenNaNWarning`](../api/preprocessing.md#hgp_lib.preprocessing.warnings.UnseenNaNWarning).
 
 ## Readable bin names
 
@@ -83,6 +104,42 @@ test_bool = binarizer.transform(test_data)
 Fitting only on the training data is what prevents leakage.
 For benchmarking, the [`GPBenchmarker`](../api/benchmarkers.md#hgp_lib.benchmarkers.gp_benchmarker.GPBenchmarker) handles this per fold, so you do not call the binarizer yourself.
 See [Benchmarking](benchmarking.md) for the workflow.
+
+## Custom binning
+
+To change only how numeric edges are chosen, implement a [`BinningStrategy`](../api/preprocessing.md#hgp_lib.preprocessing.binning.BinningStrategy) and pass it as `numeric_binning`.
+The strategy receives the feature values, the optional labels, and the number of bins, and returns sorted edges bounded by `-inf` and `inf`.
+
+```python
+import numpy as np
+from hgp_lib.preprocessing import StandardBinarizer
+from hgp_lib.preprocessing.binning import BinningStrategy
+
+class MedianSplit(BinningStrategy):
+    def compute_edges(self, values, y, n_bins):
+        return np.array([-np.inf, float(np.median(values)), np.inf])
+
+binarizer = StandardBinarizer(numeric_binning=MedianSplit())
+```
+
+To change how a whole column type is handled, subclass `StandardBinarizer` and override the matching hooks: `_fit_boolean` / `_transform_boolean`, `_fit_categorical` / `_transform_categorical`, or `_fit_numeric` / `_transform_numeric`.
+The `_fit_*` hooks return `(name, values)` pairs, and the `_transform_*` hooks return the values in the same order.
+
+## Using a scikit-learn discretizer
+
+To use a scikit-learn transformer instead, wrap it in [`SklearnBinarizer`](../api/preprocessing.md#hgp_lib.preprocessing.sklearn_binarizer.SklearnBinarizer).
+The wrapper fits the transformer, converts its output to a boolean DataFrame, and derives readable column names.
+
+```python
+from sklearn.preprocessing import KBinsDiscretizer
+from hgp_lib.preprocessing import SklearnBinarizer
+
+binarizer = SklearnBinarizer(
+    KBinsDiscretizer(n_bins=5, encode="onehot-dense", strategy="quantile")
+)
+```
+
+Pass the wrapper anywhere a binarizer is accepted, including `BenchmarkerConfig.binarizer`.
 
 ## References
 

--- a/hgp_lib/benchmarkers/gp_benchmarker.py
+++ b/hgp_lib/benchmarkers/gp_benchmarker.py
@@ -121,6 +121,7 @@ class GPBenchmarker:
 
         if self.config.show_run_progress:
             self.config.trainer_config.leave_progress_bar = False
+            self.config.binarizer.leave_progress_bar = False
 
         for run_id in tqdm(
             range(self.config.num_runs),

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -55,6 +55,7 @@ def execute_single_run(
     show_epochs = (
         config.show_epoch_progress and trainer_template.progress_bar and not use_queue
     )
+    config.binarizer.progress_bar = show_epochs
 
     np.random.seed(seed)
     random.seed(seed)

--- a/hgp_lib/configs/benchmarker_config.py
+++ b/hgp_lib/configs/benchmarker_config.py
@@ -2,9 +2,8 @@ from dataclasses import dataclass
 
 from numpy import ndarray
 from pandas import DataFrame
-from sklearn.preprocessing import KBinsDiscretizer
 
-from ..preprocessing import StandardBinarizer
+from ..preprocessing import Binarizer
 from ..utils.validation import check_isinstance, check_X_y
 from .trainer_config import TrainerConfig, validate_trainer_config
 
@@ -32,13 +31,13 @@ class BenchmarkerConfig:
         trainer_config (TrainerConfig): Template configuration for training. The nested
             `gp_config` does not need `train_data`/`train_labels` (they will be set
             per fold by the benchmarker).
-        binarizer (StandardBinarizer | KBinsDiscretizer | None): Binarizer to transform
-            features into boolean columns. A fresh `deepcopy` is fitted per fold so
-            the original stays unfitted. When `None` (default), a
-            `StandardBinarizer()` with default settings is used, which applies
-            one-hot-encoding to categorical features and decision-tree-based binarization
-            (5 bins) to numerical features. The binarizer must **not** be already fitted.
-            Default: `None`.
+        binarizer (Binarizer | None): Binarizer to transform features into boolean
+            columns. A fresh `deepcopy` is fitted per fold so the original stays
+            unfitted. When `None` (default), a `StandardBinarizer()` with default
+            settings is used, which applies one-hot-encoding to categorical features
+            and decision-tree-based binarization (5 bins) to numerical features. To use
+            a scikit-learn discretizer instead, wrap it in `SklearnBinarizer`. The
+            binarizer must **not** be already fitted. Default: `None`.
         num_runs (int): Number of benchmark runs with different random seeds. Default: `30`.
         test_size (float): Fraction of data to hold out for testing. Default: `0.2`.
         n_folds (int): Number of folds for k-fold cross-validation. Default: `5`.
@@ -76,7 +75,7 @@ class BenchmarkerConfig:
     data: DataFrame
     labels: ndarray
     trainer_config: TrainerConfig
-    binarizer: StandardBinarizer | KBinsDiscretizer | None = None
+    binarizer: Binarizer | None = None
     num_runs: int = 30
     test_size: float = 0.2
     n_folds: int = 5
@@ -128,13 +127,9 @@ def validate_benchmarker_config(config: BenchmarkerConfig) -> None:
     # Validate trainer config (without requiring data in gp_config)
     validate_trainer_config(config.trainer_config, require_data=False)
 
-    # TODO: Test that KBinsDiscretizer works end-to-end with the benchmarker runner.
-    #       The runner currently calls binarizer.fit_transform(X, y) and .transform(X)
-    #       and expects DataFrame outputs with .columns and .to_numpy(). KBinsDiscretizer
-    #       returns numpy arrays, so an adapter or protocol may be needed.
     if config.binarizer is not None:
-        check_isinstance(config.binarizer, (StandardBinarizer, KBinsDiscretizer))
-        if hasattr(config.binarizer, "_is_fitted") and config.binarizer._is_fitted:
+        check_isinstance(config.binarizer, Binarizer)
+        if config.binarizer.is_fitted:
             raise ValueError(
                 "binarizer must not be fitted before passing to BenchmarkerConfig"
             )

--- a/hgp_lib/configs/benchmarker_config.py
+++ b/hgp_lib/configs/benchmarker_config.py
@@ -37,7 +37,7 @@ class BenchmarkerConfig:
             settings is used, which applies one-hot-encoding to categorical features
             and decision-tree-based binarization (5 bins) to numerical features. To use
             a scikit-learn discretizer instead, wrap it in `SklearnBinarizer`. The
-            binarizer must **not** be already fitted. Default: `None`.
+            binarizer must not be already fitted. Default: `None`.
         num_runs (int): Number of benchmark runs with different random seeds. Default: `30`.
         test_size (float): Fraction of data to hold out for testing. Default: `0.2`.
         n_folds (int): Number of folds for k-fold cross-validation. Default: `5`.

--- a/hgp_lib/configs/trainer_config.py
+++ b/hgp_lib/configs/trainer_config.py
@@ -19,7 +19,7 @@ class TrainerConfig:
         val_labels (ndarray | None): Validation labels; optional.
         val_every (int): Validate every N epochs.
         progress_bar (bool): Whether to show progress bar.
-        leave_progress_bar (bool): Whether to show progress bar.
+        leave_progress_bar (bool): Whether to leave progress bar.
         progress_callback (Callable[[int], None] | None): Optional callback for progress updates.
             Called every `progress_update_interval` epochs with the number of epochs completed.
             Useful for external progress tracking (e.g., multiprocessing progress bars).

--- a/hgp_lib/preprocessing/__init__.py
+++ b/hgp_lib/preprocessing/__init__.py
@@ -1,4 +1,26 @@
+from .base import Binarizer
 from .binarizer import StandardBinarizer
-from .utils import load_data
+from .sklearn_binarizer import SklearnBinarizer
+from .binning import BinningStrategy, QuantileBinning, SupervisedTreeBinning
+from .utils import is_categorical_like, load_data
+from .warnings import (
+    BinarizerWarning,
+    HighCardinalityWarning,
+    StringColumnWarning,
+    UnseenNaNWarning,
+)
 
-__all__ = ["StandardBinarizer", "load_data"]
+__all__ = [
+    "Binarizer",
+    "StandardBinarizer",
+    "SklearnBinarizer",
+    "BinningStrategy",
+    "QuantileBinning",
+    "SupervisedTreeBinning",
+    "is_categorical_like",
+    "load_data",
+    "BinarizerWarning",
+    "HighCardinalityWarning",
+    "StringColumnWarning",
+    "UnseenNaNWarning",
+]

--- a/hgp_lib/preprocessing/base.py
+++ b/hgp_lib/preprocessing/base.py
@@ -1,0 +1,63 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+
+class Binarizer(ABC):
+    """
+    Abstract base class for binarizers.
+
+    A binarizer converts a mixed-type ``pandas.DataFrame`` into a purely boolean
+    ``DataFrame``, where every column is a boolean feature that a rule can test.
+    Concrete implementations must preserve this contract so they are interchangeable,
+    for example inside ``GPBenchmarker``, which fits a fresh copy per fold.
+
+    Contract:
+        - ``fit_transform(X, y=None)`` learns the encoding from ``X`` (and optional
+          labels ``y``) and returns a boolean ``DataFrame``.
+        - ``transform(X)`` applies the learned encoding to new data and returns a
+          boolean ``DataFrame`` with the same columns, in the same order, as the
+          output of ``fit_transform``.
+        - ``is_fitted`` reports whether the binarizer has been fitted.
+
+    Examples:
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> from hgp_lib.preprocessing.base import Binarizer
+        >>> class PassThrough(Binarizer):
+        ...     def fit_transform(self, X, y=None):
+        ...         self._is_fitted = True
+        ...         return X.astype(bool)
+        ...     def transform(self, X):
+        ...         return X.astype(bool)
+        >>> b = PassThrough()
+        >>> b.is_fitted
+        False
+        >>> _ = b.fit_transform(pd.DataFrame({"x": [True, False]}))
+        >>> b.is_fitted
+        True
+    """
+
+    _is_fitted: bool = False
+
+    @property
+    def is_fitted(self) -> bool:
+        """Whether the binarizer has been fitted."""
+        return self._is_fitted
+
+    @abstractmethod
+    def fit_transform(
+        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+    ) -> pd.DataFrame:
+        """
+        Learn the encoding from ``X`` (and optional labels ``y``) and return the
+        transformed boolean ``DataFrame``.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        """Apply the learned encoding to new data and return a boolean ``DataFrame``."""
+        raise NotImplementedError()

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -1,26 +1,51 @@
-from typing import Optional, Set
+from typing import List, Optional, Set, Tuple
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
-from pandas.core.dtypes.common import is_string_dtype, is_object_dtype
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.tree._tree import TREE_UNDEFINED
 
 from hgp_lib.utils.validation import check_isinstance
+from hgp_lib.utils.warnings import warn_once
+
+from .base import Binarizer
+from .binning import BinningStrategy, QuantileBinning, SupervisedTreeBinning
+from .utils import is_categorical_like
+from .warnings import (
+    HighCardinalityWarning,
+    StringColumnWarning,
+    UnseenNaNWarning,
+)
+
+# A produced boolean feature: its base name and the boolean values.
+Piece = Tuple[str, np.ndarray]
 
 
-class StandardBinarizer:
+class StandardBinarizer(Binarizer):
     """
     Converts a mixed-type DataFrame into a purely boolean DataFrame.
 
-    Boolean columns are passed through unchanged. Categorical columns are one-hot encoded
-    into one boolean column per unique value. Numeric columns are discretised into bins and
-    then one-hot encoded, using either quantile-based or decision-tree-based binning depending
-    on whether target labels are supplied.
+    Boolean columns are passed through unchanged. Categorical columns are one-hot
+    encoded into one boolean column per unique value. Numeric columns are discretised
+    into bins and then one-hot encoded, using a :class:`BinningStrategy`.
 
-    After ``fit_transform`` the binarizer stores the learned bin edges and categorical
-    mappings so that ``transform`` can apply the same encoding to new data.
+    Column handling:
+
+    - Boolean columns are kept as is.
+    - Categorical, string, and object columns are one-hot encoded. String and object
+      columns trigger a :class:`StringColumnWarning`, since setting a ``category``
+      dtype is clearer. A column whose values are all distinct is dropped with a
+      :class:`HighCardinalityWarning`, because one-hot encoding it carries no
+      generalization.
+    - Numeric columns are split into bins by a :class:`BinningStrategy`. When ``y`` is
+      provided and no strategy is set, :class:`SupervisedTreeBinning` is used, otherwise
+      :class:`QuantileBinning`.
+    - A column that contains missing values also gets a boolean ``<col>_is_NA``
+      indicator column.
+
+    To change how numeric bins are chosen, pass a ``numeric_binning`` strategy or
+    subclass and override ``_fit_numeric`` / ``_transform_numeric``. Categorical and
+    boolean handling can be changed the same way through their ``_fit_*`` / ``_transform_*``
+    hooks.
 
     Args:
         num_bins (int):
@@ -31,6 +56,10 @@ class StandardBinarizer:
         precision (int):
             Number of decimal places used when formatting numeric bin boundary names.
             Must be >= 0. Default: `3`.
+        numeric_binning (BinningStrategy | None):
+            Strategy for computing numeric bin edges. When `None`, the binarizer uses
+            :class:`SupervisedTreeBinning` if labels are provided to ``fit_transform``
+            and :class:`QuantileBinning` otherwise. Default: `None`.
 
     Examples:
         >>> import pandas as pd
@@ -54,23 +83,31 @@ class StandardBinarizer:
         num_bins: int = 5,
         column_strategy: Optional[dict[str, int]] = None,
         precision: int = 3,
+        numeric_binning: Optional[BinningStrategy] = None,
     ):
-        self._validate_params(num_bins, column_strategy, precision)
+        self._validate_params(num_bins, column_strategy, precision, numeric_binning)
         self.num_bins = num_bins
         self.column_strategy = column_strategy or {}
         self.precision = precision
+        self.numeric_binning = numeric_binning
         self.column_precision: dict[str, int] = {}
 
         self._categorical_values: dict = {}
         self._numerical_bins: dict = {}
-        self._columns = tuple()
-        self._na_columns: Set[str] = set()
-        self._is_fitted = False
-        self._original_columns = None
         self._original_column_dtypes: dict = {}
+        self._output_names: dict = {}
+        self._na_columns: Set[str] = set()
+        self._skipped_columns: Set[str] = set()
+        self._columns: Tuple[str, ...] = tuple()
+        self._original_columns = None
+        self._is_fitted = False
 
     def _validate_params(
-        self, num_bins: int, column_strategy: Optional[dict[str, int]], precision: int
+        self,
+        num_bins: int,
+        column_strategy: Optional[dict[str, int]],
+        precision: int,
+        numeric_binning: Optional[BinningStrategy],
     ) -> None:
         check_isinstance(num_bins, int)
         if num_bins < 2:
@@ -89,99 +126,284 @@ class StandardBinarizer:
         if precision < 0:
             raise ValueError(f"precision must be an integer >= 0, is {precision}")
 
-    @staticmethod
-    def _is_category(column_values: pd.Series) -> bool:
-        return (
-            isinstance(column_values.dtype, pd.CategoricalDtype)
-            or is_string_dtype(column_values)
-            or is_object_dtype(column_values)
+        if numeric_binning is not None:
+            check_isinstance(numeric_binning, BinningStrategy)
+
+    # ------------------------------------------------------------------ #
+    #  Public API
+    # ------------------------------------------------------------------ #
+    def fit_transform(
+        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+    ) -> pd.DataFrame:
+        """
+        Learn the binarisation mapping from ``X`` (and optionally ``y``) and return the
+        transformed boolean DataFrame.
+
+        Args:
+            X (pd.DataFrame):
+                Input DataFrame whose columns are boolean, categorical, string, object,
+                or numeric.
+            y (np.ndarray | None):
+                Optional target labels used for supervised binning of numeric columns.
+                Default: `None`.
+
+        Returns:
+            pd.DataFrame: A DataFrame with only boolean columns.
+
+        Raises:
+            TypeError: If ``X`` is not a DataFrame.
+            ValueError: If a column has an unsupported dtype.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from hgp_lib.preprocessing import StandardBinarizer
+            >>> df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
+            >>> result = StandardBinarizer(num_bins=2).fit_transform(df)
+            >>> result.shape
+            (4, 2)
+            >>> all(result.dtypes == bool)
+            True
+        """
+        check_isinstance(X, pd.DataFrame)
+        self._reset_state()
+
+        outputs: dict = {}
+        used_names: Set[str] = set()
+
+        for column in X.columns:
+            series = X[column]
+            nan_mask = series.isna().to_numpy()
+
+            pieces: List[Piece] = []
+            if nan_mask.any():
+                self._na_columns.add(column)
+                pieces.append((f"{column}_is_NA", nan_mask))
+
+            pieces.extend(self._fit_column(column, series, y, nan_mask))
+
+            names: List[str] = []
+            for base_name, values in pieces:
+                name = self._ensure_unique_column_names(used_names, base_name)
+                outputs[name] = values
+                names.append(name)
+            self._output_names[column] = names
+
+        self._original_columns = X.columns
+        self._columns = tuple(outputs.keys())
+        self._is_fitted = True
+        return pd.DataFrame(outputs, index=X.index)
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        """
+        Apply the previously learned binarisation to new data.
+
+        The input must have the same columns, in the same order and with the same
+        dtypes, as the data used during fitting.
+
+        Args:
+            X (pd.DataFrame):
+                Input DataFrame with the same schema as the fitting data.
+
+        Returns:
+            pd.DataFrame: A boolean DataFrame with the same column layout as the fitted output.
+
+        Raises:
+            TypeError: If ``X`` is not a DataFrame.
+            ValueError: If the binarizer has not been fitted yet, or if a column dtype
+                differs from the one seen during fitting.
+            RuntimeError: If the columns differ from the fitting data.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from hgp_lib.preprocessing import StandardBinarizer
+            >>> b = StandardBinarizer(num_bins=2)
+            >>> _ = b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}))
+            >>> b.transform(pd.DataFrame({"x": [1.5, 3.5]})).shape
+            (2, 2)
+        """
+        check_isinstance(X, pd.DataFrame)
+        if not self._is_fitted:
+            raise ValueError("Binarizer must be fitted before calling transform")
+        if not self._original_columns.equals(X.columns):
+            raise RuntimeError(
+                f"Original columns do not match current columns. "
+                f"Original columns: {self._original_columns}. Current columns: {X.columns}."
+            )
+
+        outputs: dict = {}
+        for column in X.columns:
+            series = X[column]
+            names = self._output_names[column]
+            values_list: List[np.ndarray] = []
+
+            nan_mask = series.isna().to_numpy()
+            if column in self._na_columns:
+                values_list.append(nan_mask)
+            elif nan_mask.any():
+                warn_once(UnseenNaNWarning(column))
+
+            if column not in self._skipped_columns:
+                values_list.extend(self._transform_column(column, series))
+
+            if len(values_list) != len(names):
+                raise RuntimeError(
+                    f"Column '{column}' produced {len(values_list)} features at transform "
+                    f"but {len(names)} were produced at fit."
+                )
+            for name, values in zip(names, values_list):
+                outputs[name] = values
+
+        return pd.DataFrame(outputs, index=X.index)
+
+    # ------------------------------------------------------------------ #
+    #  Per-dtype fit hooks (override to customise behaviour)
+    # ------------------------------------------------------------------ #
+    def _fit_column(
+        self,
+        column: str,
+        series: pd.Series,
+        y: Optional[np.ndarray],
+        nan_mask: np.ndarray,
+    ) -> List[Piece]:
+        """Dispatch a single column to the matching dtype hook and record its dtype."""
+        if is_bool_dtype(series):
+            self._original_column_dtypes[column] = "bool"
+            return self._fit_boolean(column, series)
+        if is_categorical_like(series):
+            self._original_column_dtypes[column] = "category"
+            return self._fit_categorical(column, series)
+        if is_numeric_dtype(series):
+            self._original_column_dtypes[column] = "numeric"
+            return self._fit_numeric(column, series, y, nan_mask)
+        raise ValueError(
+            f"Unsupported column type for column {column} of type {series.dtype}"
         )
 
-    def _get_tree_based_bins(
-        self, X: np.ndarray, y: np.ndarray, n_bins: int
-    ) -> np.ndarray:
-        """
-        Compute bin edges for a single numeric feature using a decision-tree classifier.
+    def _fit_boolean(self, column: str, series: pd.Series) -> List[Piece]:
+        """Pass a boolean column through as a single feature."""
+        return [(column, series.to_numpy(dtype=bool))]
 
-        The tree is trained to predict ``y`` from ``X`` and its internal split thresholds
-        become the bin boundaries. If ``X`` has one or fewer unique values, a single
-        ``[-inf, inf]`` bin is returned.
+    def _fit_categorical(self, column: str, series: pd.Series) -> List[Piece]:
+        """One-hot encode a categorical, string, or object column."""
+        if not isinstance(series.dtype, pd.CategoricalDtype):
+            warn_once(StringColumnWarning(column))
 
-        Args:
-            X (np.ndarray):
-                1-D array of feature values.
-            y (np.ndarray):
-                1-D array of target labels, same length as ``X``.
-            n_bins (int):
-                Maximum number of bins (passed as ``max_leaf_nodes`` to the tree).
+        unique_values = series.dropna().unique()
+        if len(unique_values) == len(series):
+            warn_once(HighCardinalityWarning(column))
+            self._skipped_columns.add(column)
+            return []
 
-        Returns:
-            np.ndarray: Sorted bin edges starting with ``-inf`` and ending with ``inf``.
+        self._categorical_values[column] = unique_values
+        return [
+            (f"{column}={value}", (series == value).to_numpy())
+            for value in unique_values
+        ]
 
-        Examples:
-            >>> import numpy as np
-            >>> from hgp_lib.preprocessing import StandardBinarizer
-            >>> b = StandardBinarizer()
-            >>> bins = b._get_tree_based_bins(
-            ...     np.array([1.0, 2.0, 3.0, 4.0]),
-            ...     np.array([0, 0, 1, 1]),
-            ...     n_bins=2,
-            ... )
-            >>> bins.tolist()
-            [-inf, 2.5, inf]
-        """
-        if len(np.unique(X)) <= 1:
-            return np.array([-np.inf, np.inf])
+    def _fit_numeric(
+        self,
+        column: str,
+        series: pd.Series,
+        y: Optional[np.ndarray],
+        nan_mask: np.ndarray,
+    ) -> List[Piece]:
+        """Bin a numeric column and one-hot encode the bins."""
+        n_bins = self.column_strategy.get(column, self.num_bins)
+        values = series.to_numpy()
 
-        tree = DecisionTreeClassifier(max_leaf_nodes=n_bins)
-        tree.fit(X.reshape(-1, 1), y, check_input=False)
-        thresholds = np.sort(tree.tree_.threshold[tree.tree_.feature != TREE_UNDEFINED])
+        fit_values = values
+        fit_y = y
+        if nan_mask.any():
+            keep = ~nan_mask
+            fit_values = values[keep]
+            if fit_y is not None:
+                fit_y = fit_y[keep]
 
-        return np.concatenate([[-np.inf], thresholds, [np.inf]])
+        strategy = self._resolve_numeric_binning(y)
+        edges = strategy.compute_edges(fit_values, fit_y, n_bins)
+        self._numerical_bins[column] = edges
 
-    def _get_quantile_based_bins(self, X: np.ndarray, n_bins: int) -> np.ndarray:
-        """
-        Compute bin edges for a single numeric feature using quantile percentiles.
+        binned = pd.cut(values, bins=edges, labels=False, include_lowest=True)
+        return [
+            (
+                self._format_numeric_bin_name(column, edges[i], edges[i + 1]),
+                binned == i,
+            )
+            for i in range(len(edges) - 1)
+        ]
 
-        Edges are placed at evenly spaced quantiles. Duplicate edges are removed so the
-        actual number of bins may be fewer than ``n_bins`` when many values are identical.
-        If ``X`` has one or fewer unique values, a single ``[-inf, inf]`` bin is returned.
+    # ------------------------------------------------------------------ #
+    #  Per-dtype transform hooks (override to customise behaviour)
+    # ------------------------------------------------------------------ #
+    def _transform_column(self, column: str, series: pd.Series) -> List[np.ndarray]:
+        """Apply the learned encoding for a single column, verifying its dtype."""
+        expected = self._original_column_dtypes[column]
+        actual = self._infer_kind(column, series)
+        if actual != expected:
+            raise ValueError(
+                f"Original column {column} was {expected}. "
+                f"Current column is {actual}. Current column must be {expected}."
+            )
+        if expected == "bool":
+            return self._transform_boolean(series)
+        if expected == "category":
+            return self._transform_categorical(column, series)
+        return self._transform_numeric(column, series)
 
-        Args:
-            X (np.ndarray):
-                1-D array of feature values.
-            n_bins (int):
-                Desired number of bins.
+    def _transform_boolean(self, series: pd.Series) -> List[np.ndarray]:
+        return [series.to_numpy(dtype=bool)]
 
-        Returns:
-            np.ndarray: Sorted unique bin edges starting with ``-inf`` and ending with ``inf``.
+    def _transform_categorical(
+        self, column: str, series: pd.Series
+    ) -> List[np.ndarray]:
+        return [
+            (series == value).to_numpy() for value in self._categorical_values[column]
+        ]
 
-        Examples:
-            >>> import numpy as np
-            >>> from hgp_lib.preprocessing import StandardBinarizer
-            >>> b = StandardBinarizer()
-            >>> bins = b._get_quantile_based_bins(np.array([1.0, 2.0, 3.0, 4.0]), n_bins=2)
-            >>> bins.tolist()
-            [-inf, 2.5, inf]
-        """
-        if len(np.unique(X)) <= 1:
-            return np.array([-np.inf, np.inf])
+    def _transform_numeric(self, column: str, series: pd.Series) -> List[np.ndarray]:
+        edges = self._numerical_bins[column]
+        binned = pd.cut(
+            series.to_numpy(), bins=edges, labels=False, include_lowest=True
+        )
+        return [binned == i for i in range(len(edges) - 1)]
 
-        quantiles = np.linspace(0, 100, n_bins + 1)
-        bins = np.percentile(X, quantiles)
-        bins[0] = -np.inf
-        bins[-1] = np.inf
-        return np.unique(bins)
+    # ------------------------------------------------------------------ #
+    #  Helpers
+    # ------------------------------------------------------------------ #
+    def _resolve_numeric_binning(self, y: Optional[np.ndarray]) -> BinningStrategy:
+        """Pick the numeric binning strategy: the configured one, or a default by ``y``."""
+        if self.numeric_binning is not None:
+            return self.numeric_binning
+        return SupervisedTreeBinning() if y is not None else QuantileBinning()
+
+    def _infer_kind(self, column: str, series: pd.Series) -> str:
+        if is_bool_dtype(series):
+            return "bool"
+        if is_categorical_like(series):
+            return "category"
+        if is_numeric_dtype(series):
+            return "numeric"
+        raise ValueError(
+            f"Unsupported column type for column {column} of type {series.dtype}"
+        )
+
+    def _reset_state(self) -> None:
+        self._categorical_values = {}
+        self._numerical_bins = {}
+        self._original_column_dtypes = {}
+        self._output_names = {}
+        self._na_columns = set()
+        self._skipped_columns = set()
+        self._columns = tuple()
+        self._original_columns = None
+        self._is_fitted = False
 
     def _ensure_unique_column_names(
         self, column_names: Set[str], new_column_name: str
     ) -> str:
         """
-        Register ``new_column_name`` in ``column_names``, appending a numeric suffix if the
-        name already exists to avoid collisions.
-
-        The set is mutated in place: the chosen (possibly suffixed) name is added before
-        returning.
+        Register ``new_column_name`` in ``column_names``, appending a numeric suffix if
+        the name already exists to avoid collisions. The set is mutated in place.
 
         Args:
             column_names (Set[str]):
@@ -219,125 +441,6 @@ class StandardBinarizer:
                 column_names.add(new_column_name)
                 return new_column_name
 
-    def fit_transform(
-        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
-    ) -> pd.DataFrame:
-        """
-        Learn the binarisation mapping from ``X`` (and optionally ``y``) and return the
-        transformed boolean DataFrame.
-
-        When ``y`` is provided, numeric columns are binned using a decision-tree strategy
-        that maximises class separation. Otherwise, quantile-based binning is used.
-
-        Args:
-            X (pd.DataFrame):
-                Input DataFrame whose columns are boolean, categorical, or numeric.
-            y (np.ndarray | None):
-                Optional target labels used for supervised (tree-based) binning of numeric
-                columns. Default: `None`.
-
-        Returns:
-            pd.DataFrame: A DataFrame with only boolean columns.
-
-        Raises:
-            TypeError: If ``X`` is not a DataFrame.
-            ValueError: If a column has an unsupported dtype.
-
-        Examples:
-            >>> import numpy as np
-            >>> import pandas as pd
-            >>> from hgp_lib.preprocessing import StandardBinarizer
-            >>> df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
-            >>> binarizer = StandardBinarizer(num_bins=2)
-            >>> result = binarizer.fit_transform(df)
-            >>> result.shape
-            (4, 2)
-            >>> all(result.dtypes == bool)
-            True
-        """
-        check_isinstance(X, pd.DataFrame)
-        columns = {}
-        column_names = set()
-
-        for column in X.columns:
-            current_column = X[column]
-
-            nan_mask = current_column.isna()
-            has_nan = nan_mask.any()
-
-            if has_nan:
-                # TODO Add tests for Nan columns
-                self._na_columns.add(column)
-                new_column_name = self._ensure_unique_column_names(
-                    column_names, f"{column}_is_NA"
-                )
-                columns[new_column_name] = nan_mask
-
-            if is_bool_dtype(current_column):
-                self._original_column_dtypes[column] = "bool"
-                new_column_name = self._ensure_unique_column_names(column_names, column)
-                columns[new_column_name] = current_column
-                # Ignore NaN values for boolean dtypes. They should not exist in the first place
-
-            elif self._is_category(current_column):
-                # TODO: Raise a warning that we treat strings as categories.
-                #  Alert users that they should set the strings as objects
-                # We should also check that the number of unique values is not equal to the number of possible values
-                # If it matches, we should raise a warning and skip this column.
-                self._original_column_dtypes[column] = "category"
-                # TODO: Update the documentation for Nan columns and string dtypes
-                unique_values = current_column.unique().dropna()
-                self._categorical_values[column] = unique_values
-                for value in unique_values:
-                    new_column_name = self._ensure_unique_column_names(
-                        column_names, f"{column}={value}"
-                    )
-                    columns[new_column_name] = current_column == value
-
-            elif is_numeric_dtype(current_column):
-                self._original_column_dtypes[column] = "numeric"
-                n_bins = self.column_strategy.get(column, self.num_bins)
-                values = current_column.values
-
-                values_here = values
-                y_here = y
-                if has_nan:
-                    not_nan = ~nan_mask
-                    values_here = values_here[not_nan]
-                    if y_here is not None:
-                        y_here = y_here[not_nan]
-
-                if y is None:
-                    bins = self._get_quantile_based_bins(values_here, n_bins)
-                else:
-                    bins = self._get_tree_based_bins(values_here, y_here, n_bins)
-
-                self._numerical_bins[column] = bins
-
-                binned_values = pd.cut(
-                    values, bins=bins, labels=False, include_lowest=True
-                )
-
-                for bin_idx in range(len(bins) - 1):
-                    # This skips NaNs
-                    new_column_name = self._ensure_unique_column_names(
-                        column_names,
-                        self._format_numeric_bin_name(
-                            column, bins[bin_idx], bins[bin_idx + 1]
-                        ),
-                    )
-                    columns[new_column_name] = binned_values == bin_idx
-
-            else:
-                raise ValueError(
-                    f"Unsupported column type for column {column} of type {current_column.dtype}"
-                )
-
-        self._original_columns = X.columns
-        self._columns = tuple(columns.keys())
-        self._is_fitted = True
-        return pd.DataFrame(columns, index=X.index)
-
     def _format_numeric_bin_name(self, column: str, left: float, right: float) -> str:
         """
         Build a human-readable label for a numeric bin.
@@ -348,23 +451,20 @@ class StandardBinarizer:
         - Right is ``inf``: ``"left <= column"``
         - Both finite: ``"left <= column < right"``
 
-        Boundary values are formatted using the precision configured for the column
-        (falling back to ``self.precision``).
-
         Args:
             column (str):
                 Name of the original numeric column.
             left (float):
-                Left (inclusive) boundary of the bin.
+                Left boundary of the bin.
             right (float):
-                Right (exclusive) boundary of the bin.
+                Right boundary of the bin.
 
         Returns:
             str: Formatted bin label.
 
         Examples:
-            >>> from hgp_lib.preprocessing import StandardBinarizer
             >>> import numpy as np
+            >>> from hgp_lib.preprocessing import StandardBinarizer
             >>> b = StandardBinarizer(precision=2)
             >>> b._format_numeric_bin_name("x", -np.inf, 3.0)
             'x < 3.00'
@@ -379,99 +479,6 @@ class StandardBinarizer:
         if np.isposinf(right):
             return f"{left:.{precision}f} <= {column}"
         return f"{left:.{precision}f} <= {column} < {right:.{precision}f}"
-
-    def _verify_column_dtype(self, column_name, column_type: str):
-        original_dtype = self._original_column_dtypes[column_name]
-        if original_dtype != column_type:
-            raise ValueError(
-                f"Original column {column_name} was {original_dtype}. "
-                f"Current column is {column_type}. "
-                f"Current column must be {original_dtype}."
-            )
-
-    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
-        """
-        Apply the previously learned binarisation to new data.
-
-        The binarizer must have been fitted via ``fit_transform`` before calling this method.
-        The input DataFrame must have the same columns (in the same order and with the same
-        dtypes) as the one used during fitting.
-
-        Args:
-            X (pd.DataFrame):
-                Input DataFrame with the same schema as the fitting data.
-
-        Returns:
-            pd.DataFrame: A boolean DataFrame with the same column layout as the fitted output.
-
-        Raises:
-            TypeError: If ``X`` is not a DataFrame.
-            ValueError: If the binarizer has not been fitted yet, or if a column has an
-                unsupported dtype.
-
-        Examples:
-            >>> import pandas as pd
-            >>> from hgp_lib.preprocessing import StandardBinarizer
-            >>> train = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
-            >>> binarizer = StandardBinarizer(num_bins=2)
-            >>> _ = binarizer.fit_transform(train)
-            >>> test = pd.DataFrame({"x": [1.5, 3.5]})
-            >>> result = binarizer.transform(test)
-            >>> result.shape
-            (2, 2)
-        """
-        check_isinstance(X, pd.DataFrame)
-
-        if not self._is_fitted:
-            raise ValueError("Binarizer must be fitted before calling transform")
-        if not self._original_columns.equals(X.columns):
-            raise RuntimeError(
-                f"Original columns do not match current columns. "
-                f"Original columns: {self._original_columns}. Current columns: {X.columns}."
-            )
-
-        columns = {}
-        column_index = 0
-
-        for column in X.columns:
-            current_column = X[column]
-            # TODO: We should check if we have nan but we didn't have nan when fitting
-
-            if column in self._na_columns:
-                column_name = self._columns[column_index]
-                column_index += 1
-                columns[column_name] = current_column.isna()
-
-            if is_bool_dtype(current_column):
-                self._verify_column_dtype(column, "bool")
-                column_name = self._columns[column_index]
-                column_index += 1
-                columns[column_name] = current_column
-
-            elif self._is_category(current_column):
-                self._verify_column_dtype(column, "category")
-                for value in self._categorical_values[column]:
-                    column_name = self._columns[column_index]
-                    column_index += 1
-                    columns[column_name] = current_column == value
-
-            elif is_numeric_dtype(current_column):
-                self._verify_column_dtype(column, "numeric")
-                bins = self._numerical_bins[column]
-                binned_values = pd.cut(
-                    current_column, bins=bins, labels=False, include_lowest=True
-                )
-                for bin_idx in range(len(bins) - 1):
-                    column_name = self._columns[column_index]
-                    column_index += 1
-                    columns[column_name] = binned_values == bin_idx
-
-            else:
-                raise ValueError(
-                    f"Unsupported column type for column {column} of type {current_column.dtype}"
-                )
-
-        return pd.DataFrame(columns, index=X.index)
 
 
 if __name__ == "__main__":

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -17,9 +17,6 @@ from .warnings import (
     UnseenNaNWarning,
 )
 
-# A produced boolean feature: its base name and the boolean values.
-Piece = Tuple[str, np.ndarray]
-
 
 class StandardBinarizer(Binarizer):
     """
@@ -186,7 +183,7 @@ class StandardBinarizer(Binarizer):
             series = X[column]
             nan_mask = series.isna().to_numpy()
 
-            pieces: List[Piece] = []
+            pieces = []
             if nan_mask.any():
                 self._na_columns.add(column)
                 pieces.append((f"{column}_is_NA", nan_mask))
@@ -278,7 +275,7 @@ class StandardBinarizer(Binarizer):
         series: pd.Series,
         y: Optional[np.ndarray],
         nan_mask: np.ndarray,
-    ) -> List[Piece]:
+    ):
         """Dispatch a single column to the matching dtype hook and record its dtype."""
         if is_bool_dtype(series):
             self._original_column_dtypes[column] = "bool"
@@ -293,11 +290,11 @@ class StandardBinarizer(Binarizer):
             f"Unsupported column type for column {column} of type {series.dtype}"
         )
 
-    def _fit_boolean(self, column: str, series: pd.Series) -> List[Piece]:
+    def _fit_boolean(self, column: str, series: pd.Series):
         """Pass a boolean column through as a single feature."""
         return [(column, series.to_numpy(dtype=bool))]
 
-    def _fit_categorical(self, column: str, series: pd.Series) -> List[Piece]:
+    def _fit_categorical(self, column: str, series: pd.Series):
         """One-hot encode a categorical, string, or object column."""
         if not isinstance(series.dtype, pd.CategoricalDtype):
             warn_once(StringColumnWarning(column))
@@ -320,7 +317,7 @@ class StandardBinarizer(Binarizer):
         series: pd.Series,
         y: Optional[np.ndarray],
         nan_mask: np.ndarray,
-    ) -> List[Piece]:
+    ):
         """Bin a numeric column and one-hot encode the bins."""
         n_bins = self.column_strategy.get(column, self.num_bins)
         values = series.to_numpy()

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Set, Tuple
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
+from tqdm import tqdm
 
 from hgp_lib.utils.validation import check_isinstance
 from hgp_lib.utils.warnings import warn_once
@@ -60,6 +61,11 @@ class StandardBinarizer(Binarizer):
             Strategy for computing numeric bin edges. When `None`, the binarizer uses
             :class:`SupervisedTreeBinning` if labels are provided to ``fit_transform``
             and :class:`QuantileBinning` otherwise. Default: `None`.
+        progress_bar (bool):
+            Whether to show progress bar. Default: `True`.
+        leave_progress_bar (bool):
+            Whether to leave progress bar. Default: `False`.
+
 
     Examples:
         >>> import pandas as pd
@@ -84,6 +90,8 @@ class StandardBinarizer(Binarizer):
         column_strategy: Optional[dict[str, int]] = None,
         precision: int = 3,
         numeric_binning: Optional[BinningStrategy] = None,
+        progress_bar: bool = True,
+        leave_progress_bar: bool = False,
     ):
         self._validate_params(num_bins, column_strategy, precision, numeric_binning)
         self.num_bins = num_bins
@@ -91,6 +99,8 @@ class StandardBinarizer(Binarizer):
         self.precision = precision
         self.numeric_binning = numeric_binning
         self.column_precision: dict[str, int] = {}
+        self.progress_bar = progress_bar
+        self.leave_progress_bar = leave_progress_bar
 
         self._categorical_values: dict = {}
         self._numerical_bins: dict = {}
@@ -129,9 +139,6 @@ class StandardBinarizer(Binarizer):
         if numeric_binning is not None:
             check_isinstance(numeric_binning, BinningStrategy)
 
-    # ------------------------------------------------------------------ #
-    #  Public API
-    # ------------------------------------------------------------------ #
     def fit_transform(
         self, X: pd.DataFrame, y: Optional[np.ndarray] = None
     ) -> pd.DataFrame:
@@ -170,7 +177,12 @@ class StandardBinarizer(Binarizer):
         outputs: dict = {}
         used_names: Set[str] = set()
 
-        for column in X.columns:
+        for column in tqdm(
+            X.columns,
+            disable=not self.progress_bar,
+            desc="Fitting binarizer",
+            leave=self.leave_progress_bar,
+        ):
             series = X[column]
             nan_mask = series.isna().to_numpy()
 
@@ -231,7 +243,12 @@ class StandardBinarizer(Binarizer):
             )
 
         outputs: dict = {}
-        for column in X.columns:
+        for column in tqdm(
+            X.columns,
+            disable=not self.progress_bar,
+            desc="Transforming binarizer",
+            leave=self.leave_progress_bar,
+        ):
             series = X[column]
             names = self._output_names[column]
             values_list: List[np.ndarray] = []
@@ -255,9 +272,6 @@ class StandardBinarizer(Binarizer):
 
         return pd.DataFrame(outputs, index=X.index)
 
-    # ------------------------------------------------------------------ #
-    #  Per-dtype fit hooks (override to customise behaviour)
-    # ------------------------------------------------------------------ #
     def _fit_column(
         self,
         column: str,
@@ -332,9 +346,6 @@ class StandardBinarizer(Binarizer):
             for i in range(len(edges) - 1)
         ]
 
-    # ------------------------------------------------------------------ #
-    #  Per-dtype transform hooks (override to customise behaviour)
-    # ------------------------------------------------------------------ #
     def _transform_column(self, column: str, series: pd.Series) -> List[np.ndarray]:
         """Apply the learned encoding for a single column, verifying its dtype."""
         expected = self._original_column_dtypes[column]
@@ -367,9 +378,6 @@ class StandardBinarizer(Binarizer):
         )
         return [binned == i for i in range(len(edges) - 1)]
 
-    # ------------------------------------------------------------------ #
-    #  Helpers
-    # ------------------------------------------------------------------ #
     def _resolve_numeric_binning(self, y: Optional[np.ndarray]) -> BinningStrategy:
         """Pick the numeric binning strategy: the configured one, or a default by ``y``."""
         if self.numeric_binning is not None:

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -3,7 +3,7 @@ from typing import Optional, Set
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
-from pandas.core.dtypes.common import is_string_dtype
+from pandas.core.dtypes.common import is_string_dtype, is_object_dtype
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.tree._tree import TREE_UNDEFINED
 
@@ -66,6 +66,8 @@ class StandardBinarizer:
         self._columns = tuple()
         self._na_columns: Set[str] = set()
         self._is_fitted = False
+        self._original_columns = None
+        self._original_column_dtypes: dict = {}
 
     def _validate_params(
         self, num_bins: int, column_strategy: Optional[dict[str, int]], precision: int
@@ -86,6 +88,14 @@ class StandardBinarizer:
         check_isinstance(precision, int)
         if precision < 0:
             raise ValueError(f"precision must be an integer >= 0, is {precision}")
+
+    @staticmethod
+    def _is_category(column_values: pd.Series) -> bool:
+        return (
+            isinstance(column_values.dtype, pd.CategoricalDtype)
+            or is_string_dtype(column_values)
+            or is_object_dtype(column_values)
+        )
 
     def _get_tree_based_bins(
         self, X: np.ndarray, y: np.ndarray, n_bins: int
@@ -264,13 +274,17 @@ class StandardBinarizer:
                 columns[new_column_name] = nan_mask
 
             if is_bool_dtype(current_column):
+                self._original_column_dtypes[column] = "bool"
                 new_column_name = self._ensure_unique_column_names(column_names, column)
                 columns[new_column_name] = current_column
                 # Ignore NaN values for boolean dtypes. They should not exist in the first place
 
-            elif isinstance(
-                current_column.dtype, pd.CategoricalDtype
-            ) or is_string_dtype(current_column):
+            elif self._is_category(current_column):
+                # TODO: Raise a warning that we treat strings as categories.
+                #  Alert users that they should set the strings as objects
+                # We should also check that the number of unique values is not equal to the number of possible values
+                # If it matches, we should raise a warning and skip this column.
+                self._original_column_dtypes[column] = "category"
                 # TODO: Update the documentation for Nan columns and string dtypes
                 unique_values = current_column.unique().dropna()
                 self._categorical_values[column] = unique_values
@@ -281,6 +295,7 @@ class StandardBinarizer:
                     columns[new_column_name] = current_column == value
 
             elif is_numeric_dtype(current_column):
+                self._original_column_dtypes[column] = "numeric"
                 n_bins = self.column_strategy.get(column, self.num_bins)
                 values = current_column.values
 
@@ -365,6 +380,15 @@ class StandardBinarizer:
             return f"{left:.{precision}f} <= {column}"
         return f"{left:.{precision}f} <= {column} < {right:.{precision}f}"
 
+    def _verify_column_dtype(self, column_name, column_type: str):
+        original_dtype = self._original_column_dtypes[column_name]
+        if original_dtype != column_type:
+            raise ValueError(
+                f"Original column {column_name} was {original_dtype}. "
+                f"Current column is {column_type}. "
+                f"Current column must be {original_dtype}."
+            )
+
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """
         Apply the previously learned binarisation to new data.
@@ -411,6 +435,7 @@ class StandardBinarizer:
 
         for column in X.columns:
             current_column = X[column]
+            # TODO: We should check if we have nan but we didn't have nan when fitting
 
             if column in self._na_columns:
                 column_name = self._columns[column_index]
@@ -418,19 +443,20 @@ class StandardBinarizer:
                 columns[column_name] = current_column.isna()
 
             if is_bool_dtype(current_column):
+                self._verify_column_dtype(column, "bool")
                 column_name = self._columns[column_index]
                 column_index += 1
                 columns[column_name] = current_column
 
-            elif isinstance(
-                current_column.dtype, pd.CategoricalDtype
-            ) or is_string_dtype(current_column):
+            elif self._is_category(current_column):
+                self._verify_column_dtype(column, "category")
                 for value in self._categorical_values[column]:
                     column_name = self._columns[column_index]
                     column_index += 1
                     columns[column_name] = current_column == value
 
             elif is_numeric_dtype(current_column):
+                self._verify_column_dtype(column, "numeric")
                 bins = self._numerical_bins[column]
                 binned_values = pd.cut(
                     current_column, bins=bins, labels=False, include_lowest=True

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -15,6 +15,7 @@ from .warnings import (
     HighCardinalityWarning,
     StringColumnWarning,
     UnseenNaNWarning,
+    EmptyBinarizationWarning,
 )
 
 
@@ -197,6 +198,10 @@ class StandardBinarizer(Binarizer):
                 names.append(name)
             self._output_names[column] = names
 
+        if len(outputs) == 0:
+            warn_once(EmptyBinarizationWarning())
+            outputs["default"] = np.ones(len(X), dtype=bool)
+
         self._original_columns = X.columns
         self._columns = tuple(outputs.keys())
         self._is_fitted = True
@@ -234,6 +239,7 @@ class StandardBinarizer(Binarizer):
         if not self._is_fitted:
             raise ValueError("Binarizer must be fitted before calling transform")
         if not self._original_columns.equals(X.columns):
+            # TODO: We should add custom Errors in the library where it makes sense.;
             raise RuntimeError(
                 f"Original columns do not match current columns. "
                 f"Original columns: {self._original_columns}. Current columns: {X.columns}."
@@ -267,6 +273,10 @@ class StandardBinarizer(Binarizer):
             for name, values in zip(names, values_list):
                 outputs[name] = values
 
+        if len(outputs) == 0:
+            warn_once(EmptyBinarizationWarning())
+            outputs["default"] = np.ones(len(X), dtype=bool)
+
         return pd.DataFrame(outputs, index=X.index)
 
     def _fit_column(
@@ -277,6 +287,7 @@ class StandardBinarizer(Binarizer):
         nan_mask: np.ndarray,
     ):
         """Dispatch a single column to the matching dtype hook and record its dtype."""
+        # TODO: Instead of string values, we should have an enum. And an enum-like dispatch.
         if is_bool_dtype(series):
             self._original_column_dtypes[column] = "bool"
             return self._fit_boolean(column, series)

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -3,7 +3,9 @@ from typing import Optional, Set
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
+from pandas.core.dtypes.common import is_string_dtype
 from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree._tree import TREE_UNDEFINED
 
 from hgp_lib.utils.validation import check_isinstance
 
@@ -62,6 +64,7 @@ class StandardBinarizer:
         self._categorical_values: dict = {}
         self._numerical_bins: dict = {}
         self._columns = tuple()
+        self._na_columns: Set[str] = set()
         self._is_fitted = False
 
     def _validate_params(
@@ -122,9 +125,7 @@ class StandardBinarizer:
 
         tree = DecisionTreeClassifier(max_leaf_nodes=n_bins)
         tree.fit(X.reshape(-1, 1), y, check_input=False)
-
-        thresholds = tree.tree_.threshold[tree.tree_.feature == 0]
-        thresholds = np.sort(thresholds[thresholds != -2])
+        thresholds = np.sort(tree.tree_.threshold[tree.tree_.feature != TREE_UNDEFINED])
 
         return np.concatenate([[-np.inf], thresholds, [np.inf]])
 
@@ -249,46 +250,72 @@ class StandardBinarizer:
         column_names = set()
 
         for column in X.columns:
-            if is_bool_dtype(X[column]):
-                new_column_name = self._ensure_unique_column_names(column_names, column)
-                columns[new_column_name] = X[column]
+            current_column = X[column]
 
-            elif isinstance(X[column].dtype, pd.CategoricalDtype):
-                unique_values = X[column].unique()
+            nan_mask = current_column.isna()
+            has_nan = nan_mask.any()
+
+            if has_nan:
+                # TODO Add tests for Nan columns
+                self._na_columns.add(column)
+                new_column_name = self._ensure_unique_column_names(
+                    column_names, f"{column}_is_NA"
+                )
+                columns[new_column_name] = nan_mask
+
+            if is_bool_dtype(current_column):
+                new_column_name = self._ensure_unique_column_names(column_names, column)
+                columns[new_column_name] = current_column
+                # Ignore NaN values for boolean dtypes. They should not exist in the first place
+
+            elif isinstance(
+                current_column.dtype, pd.CategoricalDtype
+            ) or is_string_dtype(current_column):
+                # TODO: Update the documentation for Nan columns and string dtypes
+                unique_values = current_column.unique().dropna()
                 self._categorical_values[column] = unique_values
                 for value in unique_values:
                     new_column_name = self._ensure_unique_column_names(
                         column_names, f"{column}={value}"
                     )
-                    columns[new_column_name] = X[column] == value
+                    columns[new_column_name] = current_column == value
 
-            elif is_numeric_dtype(X[column]):
+            elif is_numeric_dtype(current_column):
                 n_bins = self.column_strategy.get(column, self.num_bins)
+                values = current_column.values
 
-                bins = (
-                    self._get_tree_based_bins(X[column].values, y, n_bins)
-                    if y is not None
-                    else self._get_quantile_based_bins(X[column].values, n_bins)
-                )
+                values_here = values
+                y_here = y
+                if has_nan:
+                    not_nan = ~nan_mask
+                    values_here = values_here[not_nan]
+                    if y_here is not None:
+                        y_here = y_here[not_nan]
+
+                if y is None:
+                    bins = self._get_quantile_based_bins(values_here, n_bins)
+                else:
+                    bins = self._get_tree_based_bins(values_here, y_here, n_bins)
 
                 self._numerical_bins[column] = bins
 
                 binned_values = pd.cut(
-                    X[column], bins=bins, labels=False, include_lowest=True
+                    values, bins=bins, labels=False, include_lowest=True
                 )
 
                 for bin_idx in range(len(bins) - 1):
-                    new_column_name = self._format_numeric_bin_name(
-                        column, bins[bin_idx], bins[bin_idx + 1]
-                    )
+                    # This skips NaNs
                     new_column_name = self._ensure_unique_column_names(
-                        column_names, new_column_name
+                        column_names,
+                        self._format_numeric_bin_name(
+                            column, bins[bin_idx], bins[bin_idx + 1]
+                        ),
                     )
                     columns[new_column_name] = binned_values == bin_idx
 
             else:
                 raise ValueError(
-                    f"Unsupported column type for column {column} of type {X[column].dtype}"
+                    f"Unsupported column type for column {column} of type {current_column.dtype}"
                 )
 
         self._original_columns = X.columns
@@ -383,21 +410,30 @@ class StandardBinarizer:
         column_index = 0
 
         for column in X.columns:
-            if is_bool_dtype(X[column]):
+            current_column = X[column]
+
+            if column in self._na_columns:
                 column_name = self._columns[column_index]
                 column_index += 1
-                columns[column_name] = X[column]
+                columns[column_name] = current_column.isna()
 
-            elif isinstance(X[column].dtype, pd.CategoricalDtype):
+            if is_bool_dtype(current_column):
+                column_name = self._columns[column_index]
+                column_index += 1
+                columns[column_name] = current_column
+
+            elif isinstance(
+                current_column.dtype, pd.CategoricalDtype
+            ) or is_string_dtype(current_column):
                 for value in self._categorical_values[column]:
                     column_name = self._columns[column_index]
                     column_index += 1
-                    columns[column_name] = X[column] == value
+                    columns[column_name] = current_column == value
 
-            elif is_numeric_dtype(X[column]):
+            elif is_numeric_dtype(current_column):
                 bins = self._numerical_bins[column]
                 binned_values = pd.cut(
-                    X[column], bins=bins, labels=False, include_lowest=True
+                    current_column, bins=bins, labels=False, include_lowest=True
                 )
                 for bin_idx in range(len(bins) - 1):
                     column_name = self._columns[column_index]
@@ -406,7 +442,7 @@ class StandardBinarizer:
 
             else:
                 raise ValueError(
-                    f"Unsupported column type for column {column} of type {X[column].dtype}"
+                    f"Unsupported column type for column {column} of type {current_column.dtype}"
                 )
 
         return pd.DataFrame(columns, index=X.index)

--- a/hgp_lib/preprocessing/binning.py
+++ b/hgp_lib/preprocessing/binning.py
@@ -1,0 +1,105 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import numpy as np
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.tree._tree import TREE_UNDEFINED
+
+
+class BinningStrategy(ABC):
+    """
+    Strategy for computing bin edges of a single numeric feature.
+
+    A strategy turns a 1-D array of values (and optional labels) into a sorted array
+    of bin edges. The edges always start with ``-inf`` and end with ``inf`` so that
+    values outside the fitted range still fall into a bin. ``StandardBinarizer``
+    delegates numeric binning to a strategy, so a custom binning method only needs to
+    subclass this class and implement ``compute_edges``.
+
+    Examples:
+        >>> import numpy as np
+        >>> from hgp_lib.preprocessing.binning import QuantileBinning
+        >>> QuantileBinning().compute_edges(np.array([1.0, 2.0, 3.0, 4.0]), None, 2).tolist()
+        [-inf, 2.5, inf]
+    """
+
+    @abstractmethod
+    def compute_edges(
+        self, values: np.ndarray, y: Optional[np.ndarray], n_bins: int
+    ) -> np.ndarray:
+        """
+        Compute sorted bin edges for a single numeric feature.
+
+        Args:
+            values (np.ndarray):
+                1-D array of feature values, with missing values already removed.
+            y (np.ndarray | None):
+                Optional 1-D label array aligned with ``values``, for supervised strategies.
+            n_bins (int):
+                Desired maximum number of bins.
+
+        Returns:
+            np.ndarray: Sorted bin edges beginning with ``-inf`` and ending with ``inf``.
+        """
+        raise NotImplementedError()
+
+
+class QuantileBinning(BinningStrategy):
+    """
+    Unsupervised binning that places edges at evenly spaced quantiles.
+
+    Each bin holds a similar number of samples. Duplicate edges are removed, so the
+    actual number of bins may be fewer than ``n_bins`` when many values are identical.
+    A feature with one or fewer unique values yields a single ``[-inf, inf]`` bin.
+
+    Examples:
+        >>> import numpy as np
+        >>> from hgp_lib.preprocessing.binning import QuantileBinning
+        >>> QuantileBinning().compute_edges(np.array([5.0, 5.0, 5.0]), None, 3).tolist()
+        [-inf, inf]
+    """
+
+    def compute_edges(
+        self, values: np.ndarray, y: Optional[np.ndarray], n_bins: int
+    ) -> np.ndarray:
+        if len(np.unique(values)) <= 1:
+            return np.array([-np.inf, np.inf])
+
+        quantiles = np.linspace(0, 100, n_bins + 1)
+        edges = np.percentile(values, quantiles)
+        edges[0] = -np.inf
+        edges[-1] = np.inf
+        return np.unique(edges)
+
+
+class SupervisedTreeBinning(BinningStrategy):
+    """
+    Supervised binning that uses a decision tree to place class-aware edges.
+
+    A shallow decision tree is fit to predict ``y`` from the single feature, and its
+    split thresholds become the bin edges. The edges maximize class separation, which
+    typically produces more informative features than unsupervised binning. A feature
+    with one or fewer unique values yields a single ``[-inf, inf]`` bin.
+
+    Examples:
+        >>> import numpy as np
+        >>> from hgp_lib.preprocessing.binning import SupervisedTreeBinning
+        >>> SupervisedTreeBinning().compute_edges(
+        ...     np.array([1.0, 2.0, 3.0, 4.0]), np.array([0, 0, 1, 1]), 2
+        ... ).tolist()
+        [-inf, 2.5, inf]
+    """
+
+    def compute_edges(
+        self, values: np.ndarray, y: Optional[np.ndarray], n_bins: int
+    ) -> np.ndarray:
+        if y is None:
+            raise ValueError("SupervisedTreeBinning requires labels y")
+        if len(np.unique(values)) <= 1:
+            return np.array([-np.inf, np.inf])
+
+        tree = DecisionTreeClassifier(max_leaf_nodes=n_bins)
+        tree.fit(values.reshape(-1, 1), y, check_input=False)
+        thresholds = np.sort(tree.tree_.threshold[tree.tree_.feature != TREE_UNDEFINED])
+
+        return np.concatenate([[-np.inf], thresholds, [np.inf]])

--- a/hgp_lib/preprocessing/sklearn_binarizer.py
+++ b/hgp_lib/preprocessing/sklearn_binarizer.py
@@ -1,0 +1,69 @@
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+from hgp_lib.utils.validation import check_isinstance
+
+from .base import Binarizer
+
+
+class SklearnBinarizer(Binarizer):
+    """
+    Adapter that lets a scikit-learn transformer be used as a :class:`Binarizer`.
+
+    It wraps a transformer that outputs a dense one-hot or otherwise binary array, for
+    example ``KBinsDiscretizer(encode="onehot-dense")``, and returns a boolean
+    ``DataFrame`` with readable column names. This makes scikit-learn discretizers
+    interchangeable with :class:`StandardBinarizer`, including inside ``GPBenchmarker``.
+
+    The wrapped transformer must implement ``fit_transform(X, y)`` and ``transform(X)``.
+    Column names are taken from ``get_feature_names_out`` when available, otherwise they
+    are generated positionally.
+
+    Args:
+        transformer:
+            An unfitted scikit-learn transformer producing a binary array.
+
+    Examples:
+        >>> import pandas as pd
+        >>> from sklearn.preprocessing import KBinsDiscretizer
+        >>> from hgp_lib.preprocessing import SklearnBinarizer
+        >>> disc = KBinsDiscretizer(n_bins=2, encode="onehot-dense", strategy="uniform")
+        >>> b = SklearnBinarizer(disc)
+        >>> out = b.fit_transform(pd.DataFrame({"x": [0.0, 1.0, 2.0, 3.0]}))
+        >>> bool(out.to_numpy().dtype == bool)
+        True
+    """
+
+    def __init__(self, transformer):
+        self.transformer = transformer
+        self._columns: Optional[List[str]] = None
+        self._is_fitted = False
+
+    def fit_transform(
+        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+    ) -> pd.DataFrame:
+        check_isinstance(X, pd.DataFrame)
+        array = np.asarray(self.transformer.fit_transform(X, y))
+        self._columns = self._feature_names(X, array.shape[1])
+        self._is_fitted = True
+        return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        check_isinstance(X, pd.DataFrame)
+        if not self._is_fitted:
+            raise ValueError("Binarizer must be fitted before calling transform")
+        array = np.asarray(self.transformer.transform(X))
+        return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
+
+    def _feature_names(self, X: pd.DataFrame, n_features: int) -> List[str]:
+        if hasattr(self.transformer, "get_feature_names_out"):
+            try:
+                return list(self.transformer.get_feature_names_out(list(X.columns)))
+            except Exception:
+                try:
+                    return list(self.transformer.get_feature_names_out())
+                except Exception:
+                    pass
+        return [f"feature_{i}" for i in range(n_features)]

--- a/hgp_lib/preprocessing/utils.py
+++ b/hgp_lib/preprocessing/utils.py
@@ -3,7 +3,41 @@ from typing import Tuple
 
 import pandas as pd
 from numpy import ndarray
+from pandas.api.types import is_object_dtype, is_string_dtype
 from pathlib import Path
+
+
+def is_categorical_like(column: pd.Series) -> bool:
+    """
+    Return whether a column should be treated as categorical.
+
+    A column is categorical-like when it uses the pandas ``category`` dtype, or holds
+    strings or Python objects. Numeric and boolean columns are not categorical-like.
+
+    Args:
+        column (pd.Series):
+            The column to inspect.
+
+    Returns:
+        bool: ``True`` if the column is categorical, string, or object dtype.
+
+    Examples:
+        >>> import pandas as pd
+        >>> from hgp_lib.preprocessing.utils import is_categorical_like
+        >>> is_categorical_like(pd.Series(pd.Categorical(["a", "b"])))
+        True
+        >>> is_categorical_like(pd.Series(["a", "b"], dtype="string"))
+        True
+        >>> is_categorical_like(pd.Series([1.0, 2.0]))
+        False
+        >>> is_categorical_like(pd.Series([True, False]))
+        False
+    """
+    return (
+        isinstance(column.dtype, pd.CategoricalDtype)
+        or is_string_dtype(column)
+        or is_object_dtype(column)
+    )
 
 
 def load_data(data_path: str) -> Tuple[pd.DataFrame, ndarray]:

--- a/hgp_lib/preprocessing/warnings.py
+++ b/hgp_lib/preprocessing/warnings.py
@@ -60,3 +60,11 @@ class UnseenNaNWarning(BinarizerWarning):
             f"Column '{column}' has NaN values that were not seen during fit; "
             f"these rows are encoded as all-false."
         )
+
+
+class EmptyBinarizationWarning(BinarizerWarning):
+    def __init__(self):
+        super().__init__(
+            "Empty binarization. An 'all-true' default column is generated. "
+            "Please check the input data and provide binarization-compatible columns."
+        )

--- a/hgp_lib/preprocessing/warnings.py
+++ b/hgp_lib/preprocessing/warnings.py
@@ -1,0 +1,62 @@
+class BinarizerWarning(Warning):
+    """Base class for warnings raised by binarizers."""
+
+
+class StringColumnWarning(BinarizerWarning):
+    """
+    A string or object column is being treated as categorical.
+
+    Setting the column to a pandas ``category`` dtype makes the intent explicit and
+    avoids this warning.
+
+    Examples:
+        >>> from hgp_lib.preprocessing.warnings import StringColumnWarning
+        >>> str(StringColumnWarning("city"))
+        "Column 'city' has a string or object dtype and is treated as categorical. Set it to a 'category' dtype to make this explicit."
+    """
+
+    def __init__(self, column: str):
+        super().__init__(
+            f"Column '{column}' has a string or object dtype and is treated as "
+            f"categorical. Set it to a 'category' dtype to make this explicit."
+        )
+
+
+class HighCardinalityWarning(BinarizerWarning):
+    """
+    An all-distinct categorical column is skipped.
+
+    One-hot encoding a column whose values are all distinct would produce one boolean
+    feature per row, which carries no generalization, so the column is dropped.
+
+    Examples:
+        >>> from hgp_lib.preprocessing.warnings import HighCardinalityWarning
+        >>> str(HighCardinalityWarning("user_id"))
+        "Column 'user_id' has all-distinct values and is skipped, since one-hot encoding it would produce one feature per row."
+    """
+
+    def __init__(self, column: str):
+        super().__init__(
+            f"Column '{column}' has all-distinct values and is skipped, since "
+            f"one-hot encoding it would produce one feature per row."
+        )
+
+
+class UnseenNaNWarning(BinarizerWarning):
+    """
+    A column contains NaN at transform time but did not at fit time.
+
+    No new column is created for these values, so the affected rows fall into no bin
+    and are encoded as all-false for that column.
+
+    Examples:
+        >>> from hgp_lib.preprocessing.warnings import UnseenNaNWarning
+        >>> str(UnseenNaNWarning("amount"))
+        "Column 'amount' has NaN values that were not seen during fit; these rows are encoded as all-false."
+    """
+
+    def __init__(self, column: str):
+        super().__init__(
+            f"Column '{column}' has NaN values that were not seen during fit; "
+            f"these rows are encoded as all-false."
+        )

--- a/hgp_lib/utils/warnings.py
+++ b/hgp_lib/utils/warnings.py
@@ -1,0 +1,33 @@
+import warnings
+from typing import Set
+
+# Messages of warnings already emitted in this process, used to deduplicate.
+_emitted_messages: Set[str] = set()
+
+
+def warn_once(warning: Warning) -> None:
+    """
+    Emit a warning at most once per process, keyed by its message.
+
+    The warning is passed in already constructed, so its message (including any
+    dynamic values) lives on the warning class itself. Repeated warnings with the
+    same message are suppressed, independent of the active warning filters.
+
+    Args:
+        warning (Warning):
+            A constructed warning instance to emit.
+
+    Examples:
+        >>> import warnings
+        >>> from hgp_lib.utils.warnings import warn_once
+        >>> with warnings.catch_warnings(record=True) as caught:
+        ...     warnings.simplefilter("always")
+        ...     warn_once(UserWarning("a unique warn_once doctest message"))
+        ...     [str(entry.message) for entry in caught]
+        ['a unique warn_once doctest message']
+    """
+    message = str(warning)
+    if message in _emitted_messages:
+        return
+    _emitted_messages.add(message)
+    warnings.warn(warning, stacklevel=2)

--- a/tests/test_binarizer.py
+++ b/tests/test_binarizer.py
@@ -5,10 +5,26 @@ import numpy as np
 import pandas as pd
 
 import hgp_lib.preprocessing.binarizer
+import hgp_lib.preprocessing.binning
+import hgp_lib.preprocessing.sklearn_binarizer
+import hgp_lib.preprocessing.warnings
 from hgp_lib.preprocessing import StandardBinarizer
+from hgp_lib.preprocessing.binning import (
+    BinningStrategy,
+    QuantileBinning,
+    SupervisedTreeBinning,
+)
+from hgp_lib.preprocessing.warnings import (
+    HighCardinalityWarning,
+    StringColumnWarning,
+    UnseenNaNWarning,
+)
 
 
 class TestStandardBinarizer(unittest.TestCase):
+    # Warnings deduplicate per process by message, so warning-asserting tests use
+    # column names unique across the suite to stay independent of run order.
+
     # ------------------------------------------------------------------ #
     #  Validation
     # ------------------------------------------------------------------ #
@@ -19,7 +35,6 @@ class TestStandardBinarizer(unittest.TestCase):
     def test_num_bins_minimum(self):
         with self.assertRaises(ValueError):
             StandardBinarizer(num_bins=1)
-        # boundary: 2 is valid
         StandardBinarizer(num_bins=2)
 
     def test_column_strategy_must_be_dict(self):
@@ -41,8 +56,11 @@ class TestStandardBinarizer(unittest.TestCase):
     def test_precision_minimum(self):
         with self.assertRaises(ValueError):
             StandardBinarizer(precision=-1)
-        # boundary: 0 is valid
         StandardBinarizer(precision=0)
+
+    def test_numeric_binning_must_be_strategy(self):
+        with self.assertRaises(TypeError):
+            StandardBinarizer(numeric_binning=object())
 
     def test_fit_transform_requires_dataframe(self):
         b = StandardBinarizer()
@@ -51,8 +69,7 @@ class TestStandardBinarizer(unittest.TestCase):
 
     def test_transform_requires_dataframe(self):
         b = StandardBinarizer()
-        df = pd.DataFrame({"x": [1.0, 2.0]})
-        b.fit_transform(df)
+        b.fit_transform(pd.DataFrame({"x": [1.0, 2.0]}))
         with self.assertRaises(TypeError):
             b.transform(np.array([[1.0]]))
 
@@ -60,21 +77,6 @@ class TestStandardBinarizer(unittest.TestCase):
         b = StandardBinarizer()
         with self.assertRaises(ValueError):
             b.transform(pd.DataFrame({"x": [1.0]}))
-
-    def test_unsupported_dtype_fit_transform(self):
-        b = StandardBinarizer()
-        df = pd.DataFrame({"s": pd.array(["a", "b"], dtype="string")})
-        with self.assertRaises(ValueError, msg="Unsupported column type"):
-            b.fit_transform(df)
-
-    def test_unsupported_dtype_transform(self):
-        # TODO: We should add a test in which the data type changes
-        b = StandardBinarizer()
-        train = pd.DataFrame({"x": [True, False]})
-        b.fit_transform(train)
-        test = pd.DataFrame({"x": pd.array(["a", "b"], dtype="string")})
-        with self.assertRaises(ValueError):
-            b.transform(test)
 
     # ------------------------------------------------------------------ #
     #  Boolean columns
@@ -86,11 +88,9 @@ class TestStandardBinarizer(unittest.TestCase):
         self.assertEqual(result["flag"].tolist(), [True, False, True])
 
     def test_bool_transform(self):
-        train = pd.DataFrame({"flag": [True, False]})
         b = StandardBinarizer()
-        b.fit_transform(train)
-        test = pd.DataFrame({"flag": [False, True, True]})
-        result = b.transform(test)
+        b.fit_transform(pd.DataFrame({"flag": [True, False]}))
+        result = b.transform(pd.DataFrame({"flag": [False, True, True]}))
         self.assertEqual(result["flag"].tolist(), [False, True, True])
 
     # ------------------------------------------------------------------ #
@@ -99,166 +99,190 @@ class TestStandardBinarizer(unittest.TestCase):
     def test_categorical_one_hot(self):
         df = pd.DataFrame({"color": pd.Categorical(["r", "g", "b", "r"])})
         result = StandardBinarizer().fit_transform(df)
-        # one column per unique value
-        self.assertEqual(result.shape, (4, 3))
-        # first row is "r" → color=r should be True
-        self.assertTrue(result.iloc[0]["color=r"])
-        self.assertFalse(result.iloc[0]["color=g"])
+        self.assertEqual(list(result.columns), ["color=r", "color=g", "color=b"])
+        self.assertEqual(result["color=r"].tolist(), [True, False, False, True])
+        self.assertEqual(result["color=g"].tolist(), [False, True, False, False])
+        self.assertEqual(result["color=b"].tolist(), [False, False, True, False])
 
     def test_categorical_transform(self):
-        train = pd.DataFrame({"color": pd.Categorical(["r", "g", "b"])})
         b = StandardBinarizer()
-        b.fit_transform(train)
-        test = pd.DataFrame({"color": pd.Categorical(["g", "r"])})
-        result = b.transform(test)
+        b.fit_transform(pd.DataFrame({"color": pd.Categorical(["r", "g", "b", "r"])}))
+        result = b.transform(pd.DataFrame({"color": pd.Categorical(["g", "r"])}))
         self.assertEqual(result.shape[0], 2)
         self.assertTrue(result.iloc[0]["color=g"])
 
+    def test_string_column_treated_as_categorical_with_warning(self):
+        df = pd.DataFrame({"s_string": pd.array(["a", "a", "b"], dtype="string")})
+        b = StandardBinarizer()
+        with self.assertWarns(StringColumnWarning):
+            result = b.fit_transform(df)
+        self.assertEqual(list(result.columns), ["s_string=a", "s_string=b"])
+        self.assertEqual(result["s_string=a"].tolist(), [True, True, False])
+        self.assertEqual(result["s_string=b"].tolist(), [False, False, True])
+
+    def test_object_column_treated_as_categorical_with_warning(self):
+        df = pd.DataFrame({"s_object": ["a", "a", "b"]})
+        b = StandardBinarizer()
+        with self.assertWarns(StringColumnWarning):
+            result = b.fit_transform(df)
+        self.assertEqual(list(result.columns), ["s_object=a", "s_object=b"])
+
+    def test_all_unique_categorical_is_skipped_with_warning(self):
+        df = pd.DataFrame({"id_fit": pd.Categorical(["a", "b", "c"])})
+        b = StandardBinarizer()
+        with self.assertWarns(HighCardinalityWarning):
+            result = b.fit_transform(df)
+        self.assertEqual(result.shape, (3, 0))
+        self.assertIn("id_fit", b._skipped_columns)
+
+    def test_all_unique_categorical_skipped_on_transform(self):
+        b = StandardBinarizer()
+        with self.assertWarns(HighCardinalityWarning):
+            b.fit_transform(pd.DataFrame({"id_tr": pd.Categorical(["a", "b", "c"])}))
+        result = b.transform(pd.DataFrame({"id_tr": pd.Categorical(["a", "a", "a"])}))
+        self.assertEqual(result.shape, (3, 0))
+
     # ------------------------------------------------------------------ #
-    #  Numeric columns – quantile binning (no y)
+    #  Numeric columns
     # ------------------------------------------------------------------ #
     def test_numeric_quantile_binning(self):
         df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
-        b = StandardBinarizer(num_bins=2)
-        result = b.fit_transform(df)
-        # all output columns should be boolean
+        result = StandardBinarizer(num_bins=2).fit_transform(df)
         for col in result.columns:
             self.assertTrue(result[col].dtype == bool)
-        # each row should belong to exactly one bin
         self.assertTrue((result.sum(axis=1) == 1).all())
+
+    def test_numeric_exact_columns_and_values(self):
+        df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
+        result = StandardBinarizer(num_bins=2).fit_transform(df)
+        self.assertEqual(list(result.columns), ["x < 2.500", "2.500 <= x"])
+        self.assertEqual(result["x < 2.500"].tolist(), [True, True, False, False])
+        self.assertEqual(result["2.500 <= x"].tolist(), [False, False, True, True])
 
     def test_numeric_column_strategy_override(self):
         df = pd.DataFrame({"a": range(20), "b": range(20)})
         b = StandardBinarizer(num_bins=3, column_strategy={"a": 2})
         result = b.fit_transform(df)
-        # "a" gets 2 bins, "b" gets 3 bins (default)
-        # Column names contain the original column name in the bin label
         self.assertEqual(len(b._numerical_bins["a"]) - 1, 2)
         self.assertEqual(len(b._numerical_bins["b"]) - 1, 3)
         self.assertEqual(result.shape, (20, 5))
 
     def test_numeric_constant_column(self):
-        """A column with a single unique value should produce one bin [-inf, inf]."""
         df = pd.DataFrame({"x": [5.0, 5.0, 5.0]})
-        b = StandardBinarizer(num_bins=3)
-        result = b.fit_transform(df)
-        # only one bin possible
+        result = StandardBinarizer(num_bins=3).fit_transform(df)
         self.assertEqual(result.shape[1], 1)
         self.assertTrue(result.iloc[0, 0])
 
-    # ------------------------------------------------------------------ #
-    #  Numeric columns – tree-based binning (with y)
-    # ------------------------------------------------------------------ #
     def test_numeric_tree_binning(self):
-        np.random.seed(42)
         df = pd.DataFrame({"x": np.arange(100, dtype=float)})
         y = (df["x"] > 50).astype(int).values
-        b = StandardBinarizer(num_bins=3)
-        result = b.fit_transform(df, y=y)
+        result = StandardBinarizer(num_bins=3).fit_transform(df, y=y)
         for col in result.columns:
             self.assertTrue(result[col].dtype == bool)
         self.assertTrue((result.sum(axis=1) == 1).all())
 
-    def test_tree_binning_constant_column(self):
-        df = pd.DataFrame({"x": [7.0, 7.0, 7.0]})
-        y = np.array([0, 1, 0])
-        b = StandardBinarizer(num_bins=3)
-        result = b.fit_transform(df, y=y)
-        self.assertEqual(result.shape[1], 1)
+    def test_custom_numeric_binning_strategy(self):
+        class MedianSplit(BinningStrategy):
+            def compute_edges(self, values, y, n_bins):
+                return np.array([-np.inf, float(np.median(values)), np.inf])
+
+        b = StandardBinarizer(numeric_binning=MedianSplit())
+        # Custom strategy is used even when labels are provided.
+        result = b.fit_transform(
+            pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}), y=np.array([0, 0, 1, 1])
+        )
+        self.assertEqual(result.shape, (4, 2))
+        np.testing.assert_array_equal(b._numerical_bins["x"], [-np.inf, 2.5, np.inf])
 
     # ------------------------------------------------------------------ #
-    #  _get_tree_based_bins
+    #  NaN handling
     # ------------------------------------------------------------------ #
-    def test_tree_bins_constant_returns_single_bin(self):
-        b = StandardBinarizer()
-        bins = b._get_tree_based_bins(np.array([3.0, 3.0, 3.0]), np.array([0, 1, 0]), 3)
-        np.testing.assert_array_equal(bins, [-np.inf, np.inf])
+    def test_numeric_nan_creates_indicator_column(self):
+        df = pd.DataFrame({"x": [1.0, np.nan, 3.0, 4.0]})
+        b = StandardBinarizer(num_bins=2)
+        result = b.fit_transform(df)
+        self.assertIn("x_is_NA", result.columns)
+        self.assertEqual(result["x_is_NA"].tolist(), [False, True, False, False])
+        self.assertIn("x", b._na_columns)
+        # NaN row falls into no numeric bin.
+        bin_cols = [c for c in result.columns if c != "x_is_NA"]
+        self.assertEqual(result.loc[1, bin_cols].sum(), 0)
 
-    def test_tree_bins_produces_sorted_edges(self):
-        b = StandardBinarizer()
-        X = np.arange(50, dtype=float)
-        y = (X > 25).astype(int)
-        bins = b._get_tree_based_bins(X, y, n_bins=3)
-        self.assertTrue(np.all(np.diff(bins) > 0))
+    def test_nan_indicator_preserved_on_transform(self):
+        b = StandardBinarizer(num_bins=2)
+        b.fit_transform(pd.DataFrame({"x": [1.0, np.nan, 3.0, 4.0]}))
+        result = b.transform(pd.DataFrame({"x": [2.0, 3.0]}))
+        # The NA indicator column exists even when new data has no NaN.
+        self.assertIn("x_is_NA", result.columns)
+        self.assertEqual(result["x_is_NA"].tolist(), [False, False])
 
-    def test_tree_bins_boundaries(self):
-        b = StandardBinarizer()
-        X = np.arange(20, dtype=float)
-        y = (X >= 10).astype(int)
-        bins = b._get_tree_based_bins(X, y, n_bins=2)
-        self.assertEqual(bins[0], -np.inf)
-        self.assertEqual(bins[-1], np.inf)
-        self.assertGreaterEqual(len(bins), 3)  # at least one internal threshold
+    def test_unseen_nan_on_transform_warns(self):
+        b = StandardBinarizer(num_bins=2)
+        b.fit_transform(pd.DataFrame({"x_unseen": [1.0, 2.0, 3.0, 4.0]}))
+        with self.assertWarns(UnseenNaNWarning):
+            result = b.transform(pd.DataFrame({"x_unseen": [2.0, np.nan]}))
+        # No indicator column created; NaN row is all-false.
+        self.assertNotIn("x_unseen_is_NA", result.columns)
+        self.assertEqual(result.iloc[1].sum(), 0)
 
-    def test_tree_bins_respects_max_bins(self):
-        b = StandardBinarizer()
+    # ------------------------------------------------------------------ #
+    #  Binning strategies
+    # ------------------------------------------------------------------ #
+    def test_quantile_constant_returns_single_bin(self):
+        edges = QuantileBinning().compute_edges(np.array([5.0, 5.0, 5.0]), None, 3)
+        np.testing.assert_array_equal(edges, [-np.inf, np.inf])
+
+    def test_quantile_boundaries_and_sorted(self):
+        edges = QuantileBinning().compute_edges(np.arange(100, dtype=float), None, 4)
+        self.assertEqual(edges[0], -np.inf)
+        self.assertEqual(edges[-1], np.inf)
+        self.assertTrue(np.all(np.diff(edges) > 0))
+
+    def test_quantile_deduplicates(self):
+        X = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+        edges = QuantileBinning().compute_edges(X, None, 5)
+        self.assertEqual(len(edges), len(set(edges)))
+
+    def test_tree_requires_labels(self):
+        with self.assertRaises(ValueError):
+            SupervisedTreeBinning().compute_edges(np.arange(10, dtype=float), None, 3)
+
+    def test_tree_constant_returns_single_bin(self):
+        edges = SupervisedTreeBinning().compute_edges(
+            np.array([3.0, 3.0, 3.0]), np.array([0, 1, 0]), 3
+        )
+        np.testing.assert_array_equal(edges, [-np.inf, np.inf])
+
+    def test_tree_boundaries_and_max_bins(self):
         X = np.arange(100, dtype=float)
         y = np.array([0, 1, 2, 3] * 25)
-        bins = b._get_tree_based_bins(X, y, n_bins=4)
-        # number of bins = len(edges) - 1, should be <= n_bins
-        self.assertLessEqual(len(bins) - 1, 4)
-
-    # ------------------------------------------------------------------ #
-    #  _get_quantile_based_bins
-    # ------------------------------------------------------------------ #
-    def test_quantile_bins_constant_returns_single_bin(self):
-        b = StandardBinarizer()
-        bins = b._get_quantile_based_bins(np.array([5.0, 5.0, 5.0]), 3)
-        np.testing.assert_array_equal(bins, [-np.inf, np.inf])
-
-    def test_quantile_bins_produces_sorted_unique_edges(self):
-        b = StandardBinarizer()
-        bins = b._get_quantile_based_bins(np.arange(100, dtype=float), 4)
-        self.assertTrue(np.all(np.diff(bins) > 0))
-
-    def test_quantile_bins_boundaries(self):
-        b = StandardBinarizer()
-        bins = b._get_quantile_based_bins(np.array([1.0, 2.0, 3.0, 4.0]), 2)
-        self.assertEqual(bins[0], -np.inf)
-        self.assertEqual(bins[-1], np.inf)
-
-    def test_quantile_bins_deduplicates(self):
-        """Many repeated values should collapse duplicate edges."""
-        b = StandardBinarizer()
-        X = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
-        bins = b._get_quantile_based_bins(X, n_bins=5)
-        # np.unique removes duplicates, so we should have <= 5+1 edges
-        self.assertLessEqual(len(bins), 6)
-        # all edges unique
-        self.assertEqual(len(bins), len(set(bins)))
+        edges = SupervisedTreeBinning().compute_edges(X, y, n_bins=4)
+        self.assertEqual(edges[0], -np.inf)
+        self.assertEqual(edges[-1], np.inf)
+        self.assertLessEqual(len(edges) - 1, 4)
 
     # ------------------------------------------------------------------ #
     #  _ensure_unique_column_names
     # ------------------------------------------------------------------ #
     def test_ensure_unique_new_name(self):
         b = StandardBinarizer()
-        names: set[str] = set()
-        result = b._ensure_unique_column_names(names, "col")
-        self.assertEqual(result, "col")
+        names: set = set()
+        self.assertEqual(b._ensure_unique_column_names(names, "col"), "col")
         self.assertIn("col", names)
 
     def test_ensure_unique_collision_adds_suffix(self):
         b = StandardBinarizer()
-        names: set[str] = {"col"}
+        names = {"col"}
         b._ensure_unique_column_names(names, "col")
-        # A suffixed version should have been added
         self.assertTrue(any(n.startswith("col_") for n in names))
 
     def test_ensure_unique_multiple_collisions(self):
         b = StandardBinarizer()
-        names: set[str] = set()
+        names: set = set()
         b._ensure_unique_column_names(names, "x")
         b._ensure_unique_column_names(names, "x")
         b._ensure_unique_column_names(names, "x")
-        # Should have 3 distinct entries
         self.assertEqual(len(names), 3)
-
-    def test_ensure_unique_does_not_modify_unrelated(self):
-        b = StandardBinarizer()
-        names: set[str] = {"other"}
-        b._ensure_unique_column_names(names, "col")
-        self.assertIn("other", names)
-        self.assertIn("col", names)
 
     # ------------------------------------------------------------------ #
     #  _format_numeric_bin_name
@@ -283,42 +307,12 @@ class TestStandardBinarizer(unittest.TestCase):
         b = StandardBinarizer(precision=5)
         b.column_precision["x"] = 1
         self.assertEqual(b._format_numeric_bin_name("x", 1.0, 2.0), "1.0 <= x < 2.0")
-        # other columns still use default
         self.assertEqual(
             b._format_numeric_bin_name("y", 1.0, 2.0), "1.00000 <= y < 2.00000"
         )
 
     # ------------------------------------------------------------------ #
-    #  Numeric bin name formatting (existing)
-    # ------------------------------------------------------------------ #
-    def test_bin_name_precision(self):
-        df = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
-        b = StandardBinarizer(num_bins=2, precision=1)
-        result = b.fit_transform(df)
-        # leftmost bin should look like "x < ..."
-        left_col = [c for c in result.columns if c.startswith("x <")]
-        self.assertTrue(len(left_col) >= 1)
-
-    def test_bin_name_column_precision_override(self):
-        b = StandardBinarizer(precision=3)
-        b.column_precision["x"] = 0
-        name = b._format_numeric_bin_name("x", -np.inf, 2.5)
-        self.assertEqual(name, "x < 2")
-
-    def test_bin_name_left_inf(self):
-        b = StandardBinarizer(precision=2)
-        self.assertEqual(b._format_numeric_bin_name("v", -np.inf, 3.0), "v < 3.00")
-
-    def test_bin_name_right_inf(self):
-        b = StandardBinarizer(precision=2)
-        self.assertEqual(b._format_numeric_bin_name("v", 1.0, np.inf), "1.00 <= v")
-
-    def test_bin_name_finite(self):
-        b = StandardBinarizer(precision=1)
-        self.assertEqual(b._format_numeric_bin_name("v", 1.0, 3.0), "1.0 <= v < 3.0")
-
-    # ------------------------------------------------------------------ #
-    #  Mixed-type DataFrame
+    #  Mixed types
     # ------------------------------------------------------------------ #
     def test_mixed_types(self):
         df = pd.DataFrame(
@@ -328,9 +322,7 @@ class TestStandardBinarizer(unittest.TestCase):
                 "val": [10.0, 20.0, 30.0, 40.0],
             }
         )
-        b = StandardBinarizer(num_bins=2)
-        result = b.fit_transform(df)
-        # bool(1) + categorical(2) + numeric(>=1)
+        result = StandardBinarizer(num_bins=2).fit_transform(df)
         self.assertGreaterEqual(result.shape[1], 4)
         for col in result.columns:
             self.assertTrue(result[col].dtype == bool)
@@ -339,68 +331,40 @@ class TestStandardBinarizer(unittest.TestCase):
     #  transform consistency
     # ------------------------------------------------------------------ #
     def test_transform_matches_fit_transform_columns(self):
-        train = pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]})
         b = StandardBinarizer(num_bins=2)
-        fit_result = b.fit_transform(train)
-        test = pd.DataFrame({"x": [1.5, 3.5]})
-        transform_result = b.transform(test)
+        fit_result = b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}))
+        transform_result = b.transform(pd.DataFrame({"x": [1.5, 3.5]}))
         self.assertEqual(list(fit_result.columns), list(transform_result.columns))
 
     def test_transform_preserves_index(self):
-        train = pd.DataFrame({"x": [1.0, 2.0, 3.0]}, index=[10, 20, 30])
         b = StandardBinarizer(num_bins=2)
-        result = b.fit_transform(train)
+        result = b.fit_transform(
+            pd.DataFrame({"x": [1.0, 2.0, 3.0]}, index=[10, 20, 30])
+        )
         self.assertEqual(list(result.index), [10, 20, 30])
-
-        test = pd.DataFrame({"x": [1.5]}, index=[99])
-        result = b.transform(test)
+        result = b.transform(pd.DataFrame({"x": [1.5]}, index=[99]))
         self.assertEqual(list(result.index), [99])
 
     # ------------------------------------------------------------------ #
-    #  Unique column name deduplication
+    #  dtype changes / column mismatch on transform
     # ------------------------------------------------------------------ #
-    def test_unique_column_name_deduplication(self):
-        """_ensure_unique_column_names should deduplicate colliding names."""
+    def test_transform_dtype_change_raises(self):
         b = StandardBinarizer()
-        names: set[str] = set()
-        first = b._ensure_unique_column_names(names, "col")
-        self.assertEqual(first, "col")
-        self.assertIn("col", names)
-        # Adding the same name again should still return without error
-        second = b._ensure_unique_column_names(names, "col")
-        # The set should have grown
-        self.assertGreater(len(names), 1)
-        self.assertEqual(second, "col_0")
+        b.fit_transform(pd.DataFrame({"x": [True, False]}))
+        with self.assertRaises(ValueError):
+            b.transform(pd.DataFrame({"x": pd.array(["a", "b"], dtype="string")}))
 
-    # ------------------------------------------------------------------ #
-    #  is_fitted state
-    # ------------------------------------------------------------------ #
-    def test_is_fitted_after_fit_transform(self):
-        b = StandardBinarizer()
-        self.assertFalse(b._is_fitted)
-        b.fit_transform(pd.DataFrame({"x": [1.0, 2.0]}))
-        self.assertTrue(b._is_fitted)
+    def test_transform_numeric_to_categorical_raises(self):
+        b = StandardBinarizer(num_bins=2)
+        b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
+        with self.assertRaises(ValueError):
+            b.transform(pd.DataFrame({"x": pd.Categorical(["a", "b", "c"])}))
 
-    # ------------------------------------------------------------------ #
-    #  Column mismatch on transform
-    # ------------------------------------------------------------------ #
     def test_transform_different_columns_raises(self):
         b = StandardBinarizer(num_bins=2)
         b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
-        with self.assertRaises(RuntimeError, msg="Original columns do not match"):
+        with self.assertRaises(RuntimeError):
             b.transform(pd.DataFrame({"y": [1.0, 2.0]}))
-
-    def test_transform_extra_column_raises(self):
-        b = StandardBinarizer(num_bins=2)
-        b.fit_transform(pd.DataFrame({"x": [1.0, 2.0]}))
-        with self.assertRaises(RuntimeError):
-            b.transform(pd.DataFrame({"x": [1.0], "z": [2.0]}))
-
-    def test_transform_missing_column_raises(self):
-        b = StandardBinarizer(num_bins=2)
-        b.fit_transform(pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]}))
-        with self.assertRaises(RuntimeError):
-            b.transform(pd.DataFrame({"a": [1.0]}))
 
     def test_transform_different_column_order_raises(self):
         b = StandardBinarizer(num_bins=2)
@@ -408,19 +372,35 @@ class TestStandardBinarizer(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             b.transform(pd.DataFrame({"b": [3.0], "a": [1.0]}))
 
-    def test_transform_same_columns_passes(self):
-        b = StandardBinarizer(num_bins=2)
-        b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
-        # Should not raise
-        result = b.transform(pd.DataFrame({"x": [1.5]}))
-        self.assertEqual(result.shape[0], 1)
+    def test_unsupported_dtype_fit_transform(self):
+        b = StandardBinarizer()
+        df = pd.DataFrame(
+            {"t": [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")]}
+        )
+        with self.assertRaises(ValueError):
+            b.fit_transform(df)
+
+    # ------------------------------------------------------------------ #
+    #  is_fitted state
+    # ------------------------------------------------------------------ #
+    def test_is_fitted_after_fit_transform(self):
+        b = StandardBinarizer()
+        self.assertFalse(b.is_fitted)
+        b.fit_transform(pd.DataFrame({"x": [1.0, 2.0]}))
+        self.assertTrue(b.is_fitted)
 
     # ------------------------------------------------------------------ #
     #  Doctests
     # ------------------------------------------------------------------ #
     def test_doctests(self):
-        result = doctest.testmod(hgp_lib.preprocessing.binarizer, verbose=False)
-        self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
+        for module in (
+            hgp_lib.preprocessing.binarizer,
+            hgp_lib.preprocessing.binning,
+            hgp_lib.preprocessing.sklearn_binarizer,
+            hgp_lib.preprocessing.warnings,
+        ):
+            result = doctest.testmod(module, verbose=False)
+            self.assertEqual(result.failed, 0, f"Doctests failed: {result}")
 
 
 if __name__ == "__main__":

--- a/tests/test_binarizer.py
+++ b/tests/test_binarizer.py
@@ -68,6 +68,7 @@ class TestStandardBinarizer(unittest.TestCase):
             b.fit_transform(df)
 
     def test_unsupported_dtype_transform(self):
+        # TODO: We should add a test in which the data type changes
         b = StandardBinarizer()
         train = pd.DataFrame({"x": [True, False]})
         b.fit_transform(train)

--- a/tests/test_binarizer.py
+++ b/tests/test_binarizer.py
@@ -19,11 +19,14 @@ from hgp_lib.preprocessing.warnings import (
     StringColumnWarning,
     UnseenNaNWarning,
 )
+from hgp_lib.utils.warnings import _emitted_messages
 
 
 class TestStandardBinarizer(unittest.TestCase):
     # Warnings deduplicate per process by message, so warning-asserting tests use
     # column names unique across the suite to stay independent of run order.
+    def setUp(self):
+        _emitted_messages.clear()
 
     # ------------------------------------------------------------------ #
     #  Validation
@@ -132,7 +135,7 @@ class TestStandardBinarizer(unittest.TestCase):
         b = StandardBinarizer()
         with self.assertWarns(HighCardinalityWarning):
             result = b.fit_transform(df)
-        self.assertEqual(result.shape, (3, 0))
+        self.assertEqual(result.shape, (3, 1))
         self.assertIn("id_fit", b._skipped_columns)
 
     def test_all_unique_categorical_skipped_on_transform(self):
@@ -140,7 +143,7 @@ class TestStandardBinarizer(unittest.TestCase):
         with self.assertWarns(HighCardinalityWarning):
             b.fit_transform(pd.DataFrame({"id_tr": pd.Categorical(["a", "b", "c"])}))
         result = b.transform(pd.DataFrame({"id_tr": pd.Categorical(["a", "a", "a"])}))
-        self.assertEqual(result.shape, (3, 0))
+        self.assertEqual(result.shape, (3, 1))
 
     # ------------------------------------------------------------------ #
     #  Numeric columns

--- a/tests/test_binarizer_benchmark.py
+++ b/tests/test_binarizer_benchmark.py
@@ -1,0 +1,83 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import KBinsDiscretizer
+
+from hgp_lib.benchmarkers import GPBenchmarker
+from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
+from hgp_lib.preprocessing import SklearnBinarizer, StandardBinarizer
+from hgp_lib.utils.metrics import fast_f1_score
+
+
+def _make_dataset(n: int = 60):
+    labels = np.array([False, True] * (n // 2))
+    rng = np.random.RandomState(0)
+    data = pd.DataFrame(
+        {
+            "f1": np.linspace(0.0, 1.0, n) + labels * 0.5,
+            "f2": rng.normal(size=n),
+        }
+    )
+    return data, labels
+
+
+def _run(binarizer):
+    data, labels = _make_dataset()
+    gp_config = BooleanGPConfig(score_fn=fast_f1_score)
+    trainer_config = TrainerConfig(
+        gp_config=gp_config, num_epochs=20, progress_bar=False
+    )
+    config = BenchmarkerConfig(
+        data=data,
+        labels=labels,
+        trainer_config=trainer_config,
+        binarizer=binarizer,
+        num_runs=1,
+        n_folds=2,
+        n_jobs=1,
+        show_run_progress=False,
+        show_fold_progress=False,
+        show_epoch_progress=False,
+    )
+    return GPBenchmarker(config).fit()
+
+
+class TestBenchmarkerBinarizers(unittest.TestCase):
+    def test_benchmarker_with_standard_binarizer(self):
+        result = _run(StandardBinarizer(num_bins=3))
+        self.assertEqual(len(result.test_scores), 1)
+        self.assertGreater(len(result.best_run.feature_names), 0)
+
+    def test_benchmarker_with_sklearn_kbins_binarizer(self):
+        binarizer = SklearnBinarizer(
+            KBinsDiscretizer(n_bins=3, encode="onehot-dense", strategy="uniform")
+        )
+        result = _run(binarizer)
+        self.assertEqual(len(result.test_scores), 1)
+        # Feature names come from the discretizer, one per bin per feature.
+        self.assertGreater(len(result.best_run.feature_names), 0)
+
+    def test_benchmarker_default_binarizer_is_standard(self):
+        data, labels = _make_dataset()
+        gp_config = BooleanGPConfig(score_fn=fast_f1_score)
+        trainer_config = TrainerConfig(
+            gp_config=gp_config, num_epochs=10, progress_bar=False
+        )
+        config = BenchmarkerConfig(
+            data=data,
+            labels=labels,
+            trainer_config=trainer_config,
+            num_runs=1,
+            n_folds=2,
+            n_jobs=1,
+            show_run_progress=False,
+            show_fold_progress=False,
+            show_epoch_progress=False,
+        )
+        benchmarker = GPBenchmarker(config)
+        self.assertIsInstance(benchmarker.config.binarizer, StandardBinarizer)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* [x] Refactored the binarization framework around a new `Binarizer` base class defining the `fit()`, `fit_transform()`, and `transform()` contract.
* [x] Introduced a pluggable `BinningStrategy` interface and extracted numerical binning logic from `StandardBinarizer`. Closes #87 providing the flexibility to use different binning providers. 
* [x] Added `SklearnBinarizer` to support scikit-learn discretizers such as `KBinsDiscretizer`.
* [x] Refactored `StandardBinarizer` into per-dtype fit/transform hooks, simplifying future extensions and maintenance.
* [x] Added support for `NaN` values by creating an additional binary feature indicating whether the original value was missing.
* [x] Fixed threshold computation for numerical columns by excluding `NaN` values before fitting the univariate decision tree. This resolves incorrect threshold detection in the presence of missing values. Fixes #88.
* [x] Added support for `string` and `object` columns by handling them as categorical features.
* [x] Added warnings for unsupported or unusual column types.
* [x] Added a warning when binarization produces no output features (empty binarization).
* [x] Improved input validation to ensure an exact dtype match between the DataFrames used during `fit()` and `transform()`. An exception is raised when column dtypes differ.
* [x] Updated `BenchmarkerConfig` to support any implementation of the `Binarizer` interface.
* [x] Added progress bar support during binarization.
* [x] Updated docstrings, tests, and documentation.