### PR TITLE
Enhancing usage implementing/fixing #93, #94, #95. Featuring `BooleanRuleClassifier` and easier feature_names retrieval. Fixed inconsistencies. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,21 @@ X, y = load_breast_cancer(return_X_y=True, as_frame=True)
 X_train, X_test, y_train, y_test = train_test_split(
     X, y, test_size=0.2, stratify=y, random_state=0
 )
+X_train, X_val, y_train, y_val = train_test_split(
+    X_train, y_train, test_size=0.25, stratify=y_train, random_state=0
+)
 
-config = TrainerConfig(gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=1000)
+config = TrainerConfig(
+    gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=1000, val_every=100
+)
 clf = BooleanRuleClassifier(config)  # StandardBinarizer by default; pass binarizer=... to customize
-clf.fit(X_train, y_train)
+clf.fit(X_train, y_train, X_val, y_val)  # validation data is binarized internally too
 
 predictions = clf.predict(X_test)  # raw data is binarized internally
 print(clf.format_rule())           # the evolved rule as plain logic
 ```
 
+Validation data is optional; when given, it is binarized with the same fitted binarizer and used to track a validation score during training.
 `clf.format_rule()` prints the rule with the binarized column names, so the model reads as plain logic.
 To binarize and train manually with `GPTrainer`, see [Training](https://fii-optim-lab.github.io/hgp-lib/guide/training/); the [Data Preparation](https://fii-optim-lab.github.io/hgp-lib/guide/data-preparation/) guide shows how to avoid leaking data between splits.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [Theory](https://fii-optim-lab.github.io/hgp-lib/theory/) for how the search
 ```bash
 pip install hgp-lib
 # or
-pip install hgp-lib[dev]
+pip install 'hgp-lib[dev]'
 ```
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -40,35 +40,33 @@ pip install 'hgp-lib[dev]'
 
 ## Quickstart
 
-Binarize the data, train a rule with `GPTrainer`, then use it to predict and print it as plain logic.
+`BooleanRuleClassifier` is the fastest way to train an interpretable rule end to end.
+It binarizes the raw data for you, evolves a rule, and applies the same binarization when predicting.
+The example below is fully runnable on the scikit-learn `breast_cancer` dataset.
 
 ```python
-from hgp_lib.preprocessing import StandardBinarizer
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-from hgp_lib.trainers import GPTrainer
+from hgp_lib.trainers import BooleanRuleClassifier
 from hgp_lib.utils.metrics import fast_f1_score
 
-binarizer = StandardBinarizer(num_bins=5)
-train_bin = binarizer.fit_transform(train_data, train_labels)
-test_bin = binarizer.transform(test_data)
-
-gp = BooleanGPConfig(
-    score_fn=fast_f1_score,
-    train_data=train_bin.to_numpy(),
-    train_labels=train_labels,
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
 )
-trainer = GPTrainer(TrainerConfig(gp_config=gp, num_epochs=1000))
-history = trainer.fit()
 
-rule = history.global_best_rule
-predictions = trainer.predict(test_bin.to_numpy())
-# Equivalent notation
-# predictions = rule.evaluate(test_bin.to_numpy())
-print(rule.to_str(binarizer.get_feature_names_out()))
+config = TrainerConfig(gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=1000)
+clf = BooleanRuleClassifier(config)  # StandardBinarizer by default; pass binarizer=... to customize
+clf.fit(X_train, y_train)
+
+predictions = clf.predict(X_test)  # raw data is binarized internally
+print(clf.format_rule())           # the evolved rule as plain logic
 ```
 
-`binarizer.get_feature_names_out()` returns the binarized column names in order, so the printed rule reads as plain logic (each literal index is replaced by its column name).
-The [Data Preparation](https://fii-optim-lab.github.io/hgp-lib/guide/data-preparation/) guide shows how to use `StandardBinarizer` without leaking data between splits.
+`clf.format_rule()` prints the rule with the binarized column names, so the model reads as plain logic.
+To binarize and train manually with `GPTrainer`, see [Training](https://fii-optim-lab.github.io/hgp-lib/guide/training/); the [Data Preparation](https://fii-optim-lab.github.io/hgp-lib/guide/data-preparation/) guide shows how to avoid leaking data between splits.
 
 ## Benchmarking
 
@@ -80,18 +78,18 @@ The benchmarker binarizes data internally, per fold, so you pass a raw `pandas.D
 
 ```python
 import numpy as np
-import pandas as pd
+from sklearn.datasets import load_breast_cancer
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.benchmarkers import GPBenchmarker
+from hgp_lib.utils.metrics import fast_f1_score
 
-data = pd.DataFrame(...)  # raw features (bool / categorical / numeric)
-labels = np.array(...)    # 1-D target array
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
 
-gp_config = BooleanGPConfig(score_fn=score_fn)
+gp_config = BooleanGPConfig(score_fn=fast_f1_score)
 trainer_config = TrainerConfig(gp_config=gp_config, num_epochs=1000, val_every=100)
 config = BenchmarkerConfig(
-    data=data,
-    labels=labels,
+    data=X,
+    labels=y.to_numpy(),
     trainer_config=trainer_config,
     num_runs=30,
     n_folds=5,
@@ -108,7 +106,7 @@ print(f"Test score: {np.mean(test_scores):.4f} ± {np.std(test_scores):.4f}")
 print(result.best_rule.to_str(result.best_run.feature_names))
 
 # sklearn-style predict on raw data (binarized internally with the best run's binarizer)
-predictions = benchmarker.predict(data)
+predictions = benchmarker.predict(X)
 ```
 
 See [Benchmarking](https://fii-optim-lab.github.io/hgp-lib/guide/benchmarking/) for scorer optimization, custom binarizers, and the aggregated result fields.

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The example below is fully runnable on the scikit-learn `breast_cancer` dataset.
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 
+from hgp_lib import BooleanRuleClassifier
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-from hgp_lib.trainers import BooleanRuleClassifier
 from hgp_lib.utils.metrics import fast_f1_score
 
 X, y = load_breast_cancer(return_X_y=True, as_frame=True)

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ rule = history.global_best_rule
 predictions = trainer.predict(test_bin.to_numpy())
 # Equivalent notation
 # predictions = rule.evaluate(test_bin.to_numpy())
-column_names = dict(enumerate(train_bin.columns))
-print(rule.to_str(column_names))
+print(rule.to_str(binarizer.get_feature_names_out()))
 ```
 
-The `column_names` map turns literal indices back into the binarized column names, so the printed rule reads as plain logic.
+`binarizer.get_feature_names_out()` returns the binarized column names in order, so the printed rule reads as plain logic (each literal index is replaced by its column name).
 The [Data Preparation](https://fii-optim-lab.github.io/hgp-lib/guide/data-preparation/) guide shows how to use `StandardBinarizer` without leaking data between splits.
 
 ## Benchmarking

--- a/docs/api/trainers.md
+++ b/docs/api/trainers.md
@@ -1,3 +1,5 @@
 # Trainers
 
 ::: hgp_lib.trainers.gp_trainer.GPTrainer
+
+::: hgp_lib.trainers.boolean_rule_classifier.BooleanRuleClassifier

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,30 +10,58 @@ pip install 'hgp-lib[dev]'
 
 ## A first run
 
-`hgp_lib` evolves boolean rules that classify tabular data. The fastest way to
-get a result is [`GPBenchmarker`](api/benchmarkers.md#hgp_lib.benchmarkers.gp_benchmarker.GPBenchmarker), which handles binarization, splitting, and
-aggregation for you. Pass a raw `pandas.DataFrame` and a scoring function.
+The fastest way to train an interpretable model is
+[`BooleanRuleClassifier`](api/trainers.md#hgp_lib.trainers.boolean_rule_classifier.BooleanRuleClassifier).
+It binarizes a raw `pandas.DataFrame` for you, evolves a rule, and applies the same
+binarization when predicting. The example runs as-is on the scikit-learn
+`breast_cancer` dataset.
+
+```python
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
+from hgp_lib.configs import BooleanGPConfig, TrainerConfig
+from hgp_lib.trainers import BooleanRuleClassifier
+from hgp_lib.utils.metrics import fast_f1_score
+
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
+)
+
+config = TrainerConfig(gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=1000)
+clf = BooleanRuleClassifier(config)  # StandardBinarizer by default; pass binarizer=... to customize
+clf.fit(X_train, y_train)
+
+predictions = clf.predict(X_test)  # raw data is binarized internally
+print(clf.format_rule())           # the evolved rule as plain logic
+```
+
+For a rigorous estimate over multiple runs and folds, use
+[`GPBenchmarker`](api/benchmarkers.md#hgp_lib.benchmarkers.gp_benchmarker.GPBenchmarker),
+which handles binarization, splitting, and aggregation for you:
 
 ```python
 import numpy as np
-import pandas as pd
+from sklearn.datasets import load_breast_cancer
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.benchmarkers import GPBenchmarker
+from hgp_lib.utils.metrics import fast_f1_score
 
-data = pd.DataFrame(...)  # raw features (bool / categorical / numeric)
-labels = np.array(...)    # 1-D target array
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
 
-gp_config = BooleanGPConfig(score_fn=my_score_fn)
+gp_config = BooleanGPConfig(score_fn=fast_f1_score)
 trainer_config = TrainerConfig(gp_config=gp_config, num_epochs=1000, val_every=100)
 config = BenchmarkerConfig(
-    data=data,
-    labels=labels,
+    data=X,
+    labels=y.to_numpy(),
     trainer_config=trainer_config,
     num_runs=30,
     n_folds=5,
     n_jobs=-1,
 )
 result = GPBenchmarker(config).fit()
+print(f"Mean test F1: {np.mean(result.test_scores):.3f}")
 print(result.best_rule.to_str(result.best_run.feature_names))
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 ```bash
 pip install hgp-lib
 # or
-pip install hgp-lib[dev]
+pip install 'hgp-lib[dev]'
 ```
 
 ## A first run

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,14 +28,21 @@ X, y = load_breast_cancer(return_X_y=True, as_frame=True)
 X_train, X_test, y_train, y_test = train_test_split(
     X, y, test_size=0.2, stratify=y, random_state=0
 )
+X_train, X_val, y_train, y_val = train_test_split(
+    X_train, y_train, test_size=0.25, stratify=y_train, random_state=0
+)
 
-config = TrainerConfig(gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=1000)
+config = TrainerConfig(
+    gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=1000, val_every=100
+)
 clf = BooleanRuleClassifier(config)  # StandardBinarizer by default; pass binarizer=... to customize
-clf.fit(X_train, y_train)
+clf.fit(X_train, y_train, X_val, y_val)  # validation data is binarized internally too
 
 predictions = clf.predict(X_test)  # raw data is binarized internally
 print(clf.format_rule())           # the evolved rule as plain logic
 ```
+
+Validation data is optional; when supplied it is binarized with the same fitted binarizer and used to track a validation score during training.
 
 For a rigorous estimate over multiple runs and folds, use
 [`GPBenchmarker`](api/benchmarkers.md#hgp_lib.benchmarkers.gp_benchmarker.GPBenchmarker),

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -20,8 +20,8 @@ binarization when predicting. The example runs as-is on the scikit-learn
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 
+from hgp_lib import BooleanRuleClassifier
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-from hgp_lib.trainers import BooleanRuleClassifier
 from hgp_lib.utils.metrics import fast_f1_score
 
 X, y = load_breast_cancer(return_X_y=True, as_frame=True)

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -88,13 +88,12 @@ def f1_score(y_true, y_pred, sample_weight=None):
 
 ```python
 import numpy as np
-import pandas as pd
+from sklearn.datasets import load_breast_cancer
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.utils.metrics import fast_f1_score
 
-data = pd.DataFrame(...)  # raw features as a DataFrame (bool / categorical / numeric)
-labels = np.array(...)    # 1-D target array
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)  # raw DataFrame + target
 
 # Nested configs: BooleanGPConfig -> TrainerConfig -> BenchmarkerConfig.
 # train_data/train_labels are not needed in gp_config here;
@@ -108,8 +107,8 @@ trainer_config = TrainerConfig(
     val_every=100,
 )
 config = BenchmarkerConfig(
-    data=data,
-    labels=labels,
+    data=X,
+    labels=y.to_numpy(),
     trainer_config=trainer_config,
     num_runs=30,
     test_size=0.2,
@@ -137,8 +136,8 @@ Pass a `pandas.DataFrame` with the same columns, order, and dtypes as the data u
 benchmarker = GPBenchmarker(config)
 benchmarker.fit()
 
-new_data = pd.DataFrame(...)  # same schema as the fitted data
-predictions = benchmarker.predict(new_data)  # 1-D boolean array
+# Same schema as the fitted data; here we reuse X from the example above.
+predictions = benchmarker.predict(X)  # 1-D boolean array
 ```
 
 The fitted binarizer is stored on [`RunResult.binarizer`](../api/metrics.md#hgp_lib.metrics.results.RunResult), so `predict` reproduces the exact encoding used during the best run.

--- a/docs/guide/benchmarking.md
+++ b/docs/guide/benchmarking.md
@@ -34,7 +34,7 @@ See [Binarization](binarization.md) for how the binarizer works and its paramete
 
 ## Feature names
 
-The [`RunResult`](../api/metrics.md#hgp_lib.metrics.results.RunResult) includes `feature_names`, a `Dict[int, str]` mapping from literal indices to the binarized column names.
+The [`RunResult`](../api/metrics.md#hgp_lib.metrics.results.RunResult) includes `feature_names`, a `list[str]` of the binarized column names in order, index-aligned so that `feature_names[i]` names the feature a literal references with index `i`.
 Use this to display rules in human-readable form:
 
 ```python

--- a/docs/guide/data-preparation.md
+++ b/docs/guide/data-preparation.md
@@ -17,9 +17,11 @@ Fit the binarizer on the training split and transform the rest.
 
 ```python
 from hgp_lib.preprocessing import StandardBinarizer
+from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 
-data, labels = ...  # pandas DataFrame + numpy array
+data, labels = load_breast_cancer(return_X_y=True, as_frame=True)
+labels = labels.to_numpy()
 
 train_data, test_data, train_labels, test_labels = train_test_split(
     data, labels, test_size=0.2, random_state=42, stratify=labels,

--- a/docs/guide/training.md
+++ b/docs/guide/training.md
@@ -92,11 +92,10 @@ history = GPTrainer(TrainerConfig(gp_config=gp, num_epochs=1000)).fit()
 
 rule = history.global_best_rule
 predictions = rule.evaluate(test_bin.to_numpy())
-column_names = dict(enumerate(train_bin.columns))
-print(rule.to_str(column_names))
+print(rule.to_str(binarizer.get_feature_names_out()))
 ```
 
-The `column_names` map turns the literal indices back into the binarized column names, so the printed rule reads as plain logic.
+`binarizer.get_feature_names_out()` returns the binarized column names in order, so the printed rule reads as plain logic (each literal index is replaced by its column name).
 
 ## Predicting with a fitted trainer
 

--- a/docs/guide/training.md
+++ b/docs/guide/training.md
@@ -14,20 +14,34 @@ This runs a training with default hyperparameters.
 Use [`BooleanGPConfig`](../api/configs.md#hgp_lib.configs.boolean_gp_config.BooleanGPConfig) and [`TrainerConfig`](../api/configs.md#hgp_lib.configs.trainer_config.TrainerConfig) to configure the run.
 
 ```python
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
+from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.trainers import GPTrainer
+from hgp_lib.utils.metrics import fast_f1_score
 
-score_fn = ...  # scoring function: (y_true, y_pred) -> float
-num_epochs = 1000
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+X_train, X_val, y_train, y_val = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
+)
+
+# Binarize once: fit on train, apply to validation (avoids leakage).
+binarizer = StandardBinarizer(num_bins=5)
+train_data = binarizer.fit_transform(X_train, y_train.to_numpy())
+val_data = binarizer.transform(X_val)
+train_labels = y_train.to_numpy()
+val_labels = y_val.to_numpy()
 
 gp_config = BooleanGPConfig(
     train_data=train_data.to_numpy(dtype=bool),
     train_labels=train_labels,
-    score_fn=score_fn,
+    score_fn=fast_f1_score,
 )
 config = TrainerConfig(
     gp_config=gp_config,
-    num_epochs=num_epochs,
+    num_epochs=1000,
     val_data=val_data.to_numpy(dtype=bool),
     val_labels=val_labels,
 )
@@ -41,14 +55,29 @@ Build a [`BooleanGPConfig`](../api/configs.md#hgp_lib.configs.boolean_gp_config.
 The trainer accepts only [`TrainerConfig`](../api/configs.md#hgp_lib.configs.trainer_config.TrainerConfig).
 See [Configuring HGP](configuring.md) and [Extending HGP](extending.md) for how to build the factories and components used below.
 
+This example reuses `train_data`, `val_data`, `train_labels`, and `val_labels` from the setup above.
+
 ```python
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.trainers import GPTrainer
+from hgp_lib.crossover import CrossoverExecutorFactory
+from hgp_lib.mutations import MutationExecutorFactory
+from hgp_lib.populations import PopulationGeneratorFactory
+from hgp_lib.selections import TournamentSelection
+from hgp_lib.utils.metrics import fast_f1_score
+
+population_factory = PopulationGeneratorFactory(population_size=100)
+mutation_factory = MutationExecutorFactory(mutation_p=0.1, operator_p=0.5)
+crossover_factory = CrossoverExecutorFactory(crossover_p=0.7)
+selection = TournamentSelection()
+
+def check_valid(rule):  # keep rules compact
+    return len(rule) <= 25
 
 gp_config = BooleanGPConfig(
     train_data=train_data.to_numpy(dtype=bool),
     train_labels=train_labels,
-    score_fn=score_fn,
+    score_fn=fast_f1_score,
     population_factory=population_factory,
     mutation_factory=mutation_factory,
     crossover_factory=crossover_factory,
@@ -59,7 +88,7 @@ gp_config = BooleanGPConfig(
 )
 config = TrainerConfig(
     gp_config=gp_config,
-    num_epochs=num_epochs,
+    num_epochs=1000,
     val_data=val_data.to_numpy(dtype=bool),
     val_labels=val_labels,
     val_every=100,
@@ -74,19 +103,27 @@ This example runs the full path on a single split.
 It binarizes the data once, trains a rule with [`GPTrainer`](../api/trainers.md#hgp_lib.trainers.gp_trainer.GPTrainer), predicts on the test set, and prints the rule as a readable expression.
 
 ```python
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.trainers import GPTrainer
 from hgp_lib.utils.metrics import fast_f1_score
 
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
+)
+
 binarizer = StandardBinarizer(num_bins=5)
-train_bin = binarizer.fit_transform(train_data, train_labels)
-test_bin = binarizer.transform(test_data)
+train_bin = binarizer.fit_transform(X_train, y_train.to_numpy())
+test_bin = binarizer.transform(X_test)
 
 gp = BooleanGPConfig(
     score_fn=fast_f1_score,
     train_data=train_bin.to_numpy(),
-    train_labels=train_labels,
+    train_labels=y_train.to_numpy(),
 )
 history = GPTrainer(TrainerConfig(gp_config=gp, num_epochs=1000)).fit()
 
@@ -96,12 +133,14 @@ print(rule.to_str(binarizer.get_feature_names_out()))
 ```
 
 `binarizer.get_feature_names_out()` returns the binarized column names in order, so the printed rule reads as plain logic (each literal index is replaced by its column name).
+To skip the manual binarization, [`BooleanRuleClassifier`](../api/trainers.md#hgp_lib.trainers.boolean_rule_classifier.BooleanRuleClassifier) does the same end-to-end path in a few lines (see [Getting Started](../getting-started.md)).
 
 ## Predicting with a fitted trainer
 
 After `fit`, the trainer exposes a scikit-learn style [`predict`](../api/trainers.md#hgp_lib.trainers.gp_trainer.GPTrainer.predict).
 It evaluates the best rule found during training, so a fitted [`GPTrainer`](../api/trainers.md#hgp_lib.trainers.gp_trainer.GPTrainer) can be used where an estimator is expected.
 The input must already be binarized (a boolean array) with the same feature layout as the training data.
+Continuing from the previous example (reusing `gp` and `test_bin`):
 
 ```python
 trainer = GPTrainer(TrainerConfig(gp_config=gp, num_epochs=1000))

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,10 +48,15 @@ X, y = load_breast_cancer(return_X_y=True, as_frame=True)
 X_train, X_test, y_train, y_test = train_test_split(
     X, y, test_size=0.2, stratify=y, random_state=0
 )
+X_train, X_val, y_train, y_val = train_test_split(
+    X_train, y_train, test_size=0.25, stratify=y_train, random_state=0
+)
 
-config = TrainerConfig(gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=500)
+config = TrainerConfig(
+    gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=500, val_every=50
+)
 clf = BooleanRuleClassifier(config)
-clf.fit(X_train, y_train)
+clf.fit(X_train, y_train, X_val, y_val)  # validation is binarized internally too
 
 predictions = clf.predict(X_test)
 print(clf.format_rule())

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,24 +32,29 @@ See [Interpretability](interpretability.md) for why this matters.
 
 ## Quick example
 
+Runs as-is on the scikit-learn `breast_cancer` dataset.
+[`BooleanRuleClassifier`](api/trainers.md#hgp_lib.trainers.boolean_rule_classifier.BooleanRuleClassifier)
+binarizes the raw data, evolves a rule, and applies the same binarization when predicting.
+
 ```python
-import numpy as np
-from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
+from sklearn.datasets import load_breast_cancer
+from sklearn.model_selection import train_test_split
+
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-from hgp_lib.trainers import GPTrainer
+from hgp_lib.trainers import BooleanRuleClassifier
+from hgp_lib.utils.metrics import fast_f1_score
 
-train_data = ...   # 2D boolean numpy array
-train_labels = ... # 1D integer numpy array
-
-config = TrainerConfig(
-    gp_config=BooleanGPConfig(
-        score_fn=accuracy_score,
-        train_data=train_data,
-        train_labels=train_labels,
-    ),
-    num_epochs=500,
+X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+X_train, X_test, y_train, y_test = train_test_split(
+    X, y, test_size=0.2, stratify=y, random_state=0
 )
-result = GPTrainer(config).fit()
+
+config = TrainerConfig(gp_config=BooleanGPConfig(score_fn=fast_f1_score), num_epochs=500)
+clf = BooleanRuleClassifier(config)
+clf.fit(X_train, y_train)
+
+predictions = clf.predict(X_test)
+print(clf.format_rule())
 ```
 
 ## How it works

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,8 @@ binarizes the raw data, evolves a rule, and applies the same binarization when p
 from sklearn.datasets import load_breast_cancer
 from sklearn.model_selection import train_test_split
 
+from hgp_lib import BooleanRuleClassifier
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-from hgp_lib.trainers import BooleanRuleClassifier
 from hgp_lib.utils.metrics import fast_f1_score
 
 X, y = load_breast_cancer(return_X_y=True, as_frame=True)

--- a/hgp_lib/__init__.py
+++ b/hgp_lib/__init__.py
@@ -1,3 +1,9 @@
 from .configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
+from .trainers import BooleanRuleClassifier
 
-__all__ = ["BooleanGPConfig", "TrainerConfig", "BenchmarkerConfig"]
+__all__ = [
+    "BooleanGPConfig",
+    "TrainerConfig",
+    "BenchmarkerConfig",
+    "BooleanRuleClassifier",
+]

--- a/hgp_lib/__init__.py
+++ b/hgp_lib/__init__.py
@@ -1,9 +1,12 @@
 from .configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
-from .trainers import BooleanRuleClassifier
+from .trainers import BooleanRuleClassifier, GPTrainer
+from .benchmarkers import GPBenchmarker
 
 __all__ = [
     "BooleanGPConfig",
     "TrainerConfig",
     "BenchmarkerConfig",
     "BooleanRuleClassifier",
+    "GPTrainer",
+    "GPBenchmarker",
 ]

--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -615,7 +615,7 @@ class BooleanGP:
             raise RuntimeError("No best rule available. Run at least one step first.")
 
         fn = self._original_score_fn if score_fn is None else score_fn
-        return float(fn(self.global_best_rule.evaluate(data), labels))
+        return float(fn(labels, self.global_best_rule.evaluate(data)))
 
     @property
     def original_score_fn(self):

--- a/hgp_lib/benchmarkers/gp_benchmarker.py
+++ b/hgp_lib/benchmarkers/gp_benchmarker.py
@@ -58,6 +58,7 @@ class GPBenchmarker:
             options. See `BenchmarkerConfig` for more details.
 
     Examples:
+        >>> from sklearn.metrics import accuracy_score
         >>> import numpy as np
         >>> import pandas as pd
         >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig, BenchmarkerConfig
@@ -68,8 +69,7 @@ class GPBenchmarker:
         ...     "f2": [False, True, True, False, False, True, True, False],
         ... })
         >>> labels = np.array([1, 0, 1, 0, 1, 0, 1, 0])
-        >>> def acc(t, p): return float((t == p).mean())
-        >>> gp_config = BooleanGPConfig(score_fn=acc, optimize_scorer=False)
+        >>> gp_config = BooleanGPConfig(score_fn=accuracy_score, optimize_scorer=False)
         >>> trainer_config = TrainerConfig(gp_config=gp_config, num_epochs=3, progress_bar=False)
         >>> config = BenchmarkerConfig(
         ...     data=data, labels=labels, trainer_config=trainer_config,
@@ -98,14 +98,14 @@ class GPBenchmarker:
             int: The number of parallel workers to use (always >= 1).
 
         Examples:
+            >>> from sklearn.metrics import accuracy_score
             >>> import numpy as np
             >>> import pandas as pd
             >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig, BenchmarkerConfig
             >>> from hgp_lib.benchmarkers import GPBenchmarker
             >>> data = pd.DataFrame({"f": [True, False, True, False, True, False, True, False]})
             >>> labels = np.array([1, 0, 1, 0, 1, 0, 1, 0])
-            >>> def acc(p, l): return float((p == l).mean())
-            >>> gp = BooleanGPConfig(score_fn=acc, optimize_scorer=False)
+            >>> gp = BooleanGPConfig(score_fn=accuracy_score, optimize_scorer=False)
             >>> tc = TrainerConfig(gp_config=gp, num_epochs=1, progress_bar=False)
             >>> cfg = BenchmarkerConfig(data=data, labels=labels, trainer_config=tc,
             ...     num_runs=3, n_folds=2, n_jobs=1)
@@ -222,6 +222,7 @@ class GPBenchmarker:
                 if the best run has no fitted binarizer to transform the raw data.
 
         Examples:
+            >>> from sklearn.metrics import accuracy_score
             >>> import numpy as np
             >>> import pandas as pd
             >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig, BenchmarkerConfig
@@ -231,8 +232,7 @@ class GPBenchmarker:
             ...     "f2": [False, True, True, False, False, True, True, False],
             ... })
             >>> labels = np.array([1, 0, 1, 0, 1, 0, 1, 0])
-            >>> def acc(p, l): return float((p == l).mean())
-            >>> gp_config = BooleanGPConfig(score_fn=acc, optimize_scorer=False)
+            >>> gp_config = BooleanGPConfig(score_fn=accuracy_score, optimize_scorer=False)
             >>> trainer_config = TrainerConfig(gp_config=gp_config, num_epochs=3, progress_bar=False)
             >>> config = BenchmarkerConfig(
             ...     data=data, labels=labels, trainer_config=trainer_config,

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -89,9 +89,7 @@ def execute_single_run(
         binarizer = deepcopy(config.binarizer)
         fold_train = binarizer.fit_transform(fold_train, fold_train_labels)
         binarizers.append(binarizer)
-        feature_names_per_binarizer.append(
-            {i: col for i, col in enumerate(fold_train.columns)}
-        )
+        feature_names_per_binarizer.append(binarizer.get_feature_names_out())
         fold_train = fold_train.to_numpy(dtype=bool)
 
         fold_val = binarizer.transform(train_data.iloc[val_idx]).to_numpy(dtype=bool)

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -145,7 +145,7 @@ def execute_single_run(
 
     test_pred = best_rule.evaluate(test_data)
 
-    test_score = float(test_score_fn(test_pred, test_labels))
+    test_score = float(test_score_fn(test_labels, test_pred))
 
     tp, fp, fn, tn = test_cm(test_pred, test_labels)
 

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -147,7 +147,7 @@ def execute_single_run(
 
     test_score = float(test_score_fn(test_labels, test_pred))
 
-    tp, fp, fn, tn = test_cm(test_pred, test_labels)
+    tp, fp, fn, tn = test_cm(test_labels, test_pred)
 
     send_progress(progress_queue, "run", 1)
 

--- a/hgp_lib/metrics/results.py
+++ b/hgp_lib/metrics/results.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import List, Dict, Optional
+from typing import List, Optional
 
 import numpy as np
 
@@ -29,8 +29,9 @@ class RunResult:
         test_fp (int): False positives on the test set.
         test_fn (int): False negatives on the test set.
         test_tn (int): True negatives on the test set.
-        feature_names (Dict[int, str]): Mapping from feature index to column name
-            (from the binarizer fitted on the best fold).
+        feature_names (List[str]): Output feature names in order, index-aligned so that
+            ``feature_names[i]`` is the column name for feature index ``i`` (from the
+            binarizer fitted on the best fold).
         binarizer (Binarizer | None): The binarizer fitted on the best fold, used to
             transform raw data before evaluating ``best_rule`` (e.g. in
             ``GPBenchmarker.predict``). Default: `None`.
@@ -44,7 +45,7 @@ class RunResult:
         >>> run = RunResult(
         ...     run_id=0, seed=42, best_fold_idx=0, folds=[fold],
         ...     test_score=0.85, test_tp=4, test_fp=1, test_fn=1, test_tn=4,
-        ...     feature_names={0: "age", 1: "income"},
+        ...     feature_names=["age", "income"],
         ... )
         >>> run.best_rule
         0
@@ -61,7 +62,7 @@ class RunResult:
     test_fp: int
     test_fn: int
     test_tn: int
-    feature_names: Dict[int, str]
+    feature_names: List[str]
     binarizer: Optional[Binarizer] = None
 
     @cached_property
@@ -81,7 +82,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=1, folds=[f0, f1],
             ...     test_score=0.9, test_tp=1, test_fp=0, test_fn=0, test_tn=1,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.best_fold is f1
             True
@@ -102,7 +103,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> str(run.best_rule)
             '5'
@@ -135,7 +136,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[f0, f1],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.fold_val_scores
             [0.7]
@@ -166,7 +167,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.fold_train_scores
             [0.8]
@@ -192,7 +193,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.mean_val_score
             0.0
@@ -223,7 +224,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.mean_train_score
             0.85
@@ -247,7 +248,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.train_confusion_matrix
             '[TP: 3, FP: 1, FN: 2, TN: 4]'
@@ -270,7 +271,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.val_confusion_matrix
             '[]'
@@ -294,7 +295,7 @@ class RunResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=5, test_fp=2, test_fn=1, test_tn=7,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> run.test_confusion_matrix
             '[TP: 5, FP: 2, FN: 1, TN: 7]'
@@ -332,12 +333,12 @@ class ExperimentResult:
         >>> r1 = RunResult(
         ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold_low],
         ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-        ...     feature_names={},
+        ...     feature_names=[],
         ... )
         >>> r2 = RunResult(
         ...     run_id=1, seed=1, best_fold_idx=0, folds=[fold_high],
         ...     test_score=0.9, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-        ...     feature_names={},
+        ...     feature_names=[],
         ... )
         >>> exp = ExperimentResult(runs=[r1, r2])
         >>> exp.test_scores
@@ -381,12 +382,12 @@ class ExperimentResult:
             >>> r1 = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[f_low],
             ...     test_score=0.7, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> r2 = RunResult(
             ...     run_id=1, seed=1, best_fold_idx=0, folds=[f_high],
             ...     test_score=0.9, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> ExperimentResult(runs=[r1, r2]).best_run.run_id
             1
@@ -422,7 +423,7 @@ class ExperimentResult:
             >>> run = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.8, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> str(ExperimentResult(runs=[run]).best_rule)
             '7'
@@ -444,7 +445,7 @@ class ExperimentResult:
             >>> r = RunResult(
             ...     run_id=0, seed=0, best_fold_idx=0, folds=[fold],
             ...     test_score=0.75, test_tp=0, test_fp=0, test_fn=0, test_tn=0,
-            ...     feature_names={},
+            ...     feature_names=[],
             ... )
             >>> ExperimentResult(runs=[r]).test_scores
             [0.75]

--- a/hgp_lib/populations/populations_factory.py
+++ b/hgp_lib/populations/populations_factory.py
@@ -28,6 +28,7 @@ class PopulationGeneratorFactory:
 
         Subclass to use custom strategies:
 
+        >>> from sklearn.metrics import accuracy_score
         >>> import numpy as np
         >>> from hgp_lib.populations import PopulationGeneratorFactory, BestLiteralStrategy
         >>> class MyFactory(PopulationGeneratorFactory):
@@ -39,8 +40,7 @@ class PopulationGeneratorFactory:
         >>> factory = MyFactory(population_size=20)
         >>> data = np.array([[True, False], [False, True]])
         >>> labels = np.array([1, 0])
-        >>> def acc(p, l): return float((p == l).mean())
-        >>> gen = factory.create(2, acc, data, labels)
+        >>> gen = factory.create(2, accuracy_score, data, labels)
         >>> len(gen.generate())
         20
     """

--- a/hgp_lib/populations/strategies.py
+++ b/hgp_lib/populations/strategies.py
@@ -203,14 +203,14 @@ class BestLiteralStrategy(PopulationStrategy):
 
             for i in feature_indices:
                 preds_pos = subset_data[:, i]
-                score_pos = self.score_fn(preds_pos, subset_labels)
+                score_pos = self.score_fn(subset_labels, preds_pos)
 
                 if score_pos > best_score:
                     best_score = score_pos
                     best_rule = Literal(value=i, negated=False)
 
                 preds_neg = ~preds_pos
-                score_neg = self.score_fn(preds_neg, subset_labels)
+                score_neg = self.score_fn(subset_labels, preds_neg)
 
                 if score_neg > best_score:
                     best_score = score_neg

--- a/hgp_lib/preprocessing/base.py
+++ b/hgp_lib/preprocessing/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Dict, List
 
 import numpy as np
 import pandas as pd
@@ -43,6 +43,16 @@ class Binarizer(ABC):
     _is_fitted: bool = False
 
     @property
+    def feature_names(self) -> Dict[int, str]:
+        if not self._is_fitted:
+            raise ValueError("Binarizer has not been fitted yet.")
+        return self._get_feature_names()
+
+    @abstractmethod
+    def _get_feature_names(self) -> Dict[int, str]:
+        pass
+
+    @property
     def is_fitted(self) -> bool:
         """Whether the binarizer has been fitted."""
         return self._is_fitted
@@ -55,9 +65,9 @@ class Binarizer(ABC):
         Learn the encoding from ``X`` (and optional labels ``y``) and return the
         transformed boolean ``DataFrame``.
         """
-        raise NotImplementedError()
+        pass
 
     @abstractmethod
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Apply the learned encoding to new data and return a boolean ``DataFrame``."""
-        raise NotImplementedError()
+        pass

--- a/hgp_lib/preprocessing/base.py
+++ b/hgp_lib/preprocessing/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Optional, Dict, List
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -20,6 +20,8 @@ class Binarizer(ABC):
         - ``transform(X)`` applies the learned encoding to new data and returns a
           boolean ``DataFrame`` with the same columns, in the same order, as the
           output of ``fit_transform``.
+        - ``get_feature_names_out()`` returns the output column names, in order, so a
+          literal's feature index maps to a readable name via ``feature_names[index]``.
         - ``is_fitted`` reports whether the binarizer has been fitted.
 
     Examples:
@@ -28,29 +30,24 @@ class Binarizer(ABC):
         >>> from hgp_lib.preprocessing.base import Binarizer
         >>> class PassThrough(Binarizer):
         ...     def fit_transform(self, X, y=None):
+        ...         self._columns = list(X.columns)
         ...         self._is_fitted = True
         ...         return X.astype(bool)
         ...     def transform(self, X):
         ...         return X.astype(bool)
+        ...     def get_feature_names_out(self):
+        ...         return list(self._columns)
         >>> b = PassThrough()
         >>> b.is_fitted
         False
-        >>> _ = b.fit_transform(pd.DataFrame({"x": [True, False]}))
+        >>> out = b.fit_transform(pd.DataFrame({"x": [True, False]}))
         >>> b.is_fitted
         True
+        >>> b.get_feature_names_out()
+        ['x']
     """
 
     _is_fitted: bool = False
-
-    @property
-    def feature_names(self) -> Dict[int, str]:
-        if not self._is_fitted:
-            raise ValueError("Binarizer has not been fitted yet.")
-        return self._get_feature_names()
-
-    @abstractmethod
-    def _get_feature_names(self) -> Dict[int, str]:
-        pass
 
     @property
     def is_fitted(self) -> bool:
@@ -70,4 +67,17 @@ class Binarizer(ABC):
     @abstractmethod
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Apply the learned encoding to new data and return a boolean ``DataFrame``."""
+        pass
+
+    @abstractmethod
+    def get_feature_names_out(self) -> List[str]:
+        """
+        Return the output feature (column) names in order.
+
+        The returned list is index-aligned with the boolean columns produced by
+        ``fit_transform`` / ``transform``, so ``feature_names[i]`` is the name of the
+        feature a rule references with ``Literal(value=i)``. Following the scikit-learn
+        convention, the names are returned as an ordered ``list[str]``. Implementations
+        should raise if called before the binarizer is fitted.
+        """
         pass

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -443,8 +443,8 @@ class StandardBinarizer(Binarizer):
         self, column_names: Set[str], new_column_name: str
     ) -> str:
         """
-        Register ``new_column_name`` in ``column_names``, appending a numeric suffix if
-        the name already exists to avoid collisions. The set is mutated in place.
+        Register ``new_column_name`` in ``column_names``, appending a numeric suffix if needed.
+        The set is mutated in place.
 
         Args:
             column_names (Set[str]):
@@ -464,23 +464,13 @@ class StandardBinarizer(Binarizer):
             >>> "col_1" in names
             True
         """
-        if new_column_name not in column_names:
-            column_names.add(new_column_name)
-            return new_column_name
-        for i in range(1_000):
-            version_i = f"{new_column_name}_{i}"
-            if version_i not in column_names:
-                column_names.add(version_i)
-                return version_i
-        # If we didn't find a unique column name by trying 1000 indices,
-        # We will use a random string extension until we find a string we didn't visit before
-        new_column_name = new_column_name + "_rand"
-        while True:
-            random_i = np.random.randint(len(column_names))
-            new_column_name = f"{new_column_name}_{random_i}"
-            if new_column_name not in column_names:
-                column_names.add(new_column_name)
-                return new_column_name
+        unique_name = new_column_name
+        counter = 0
+        while unique_name in column_names:
+            unique_name = f"{new_column_name}_{counter}"
+            counter += 1
+        column_names.add(unique_name)
+        return unique_name
 
     def _format_numeric_bin_name(self, column: str, left: float, right: float) -> str:
         """

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple, Dict
 
 import numpy as np
 import pandas as pd
@@ -108,6 +108,7 @@ class StandardBinarizer(Binarizer):
         self._skipped_columns: Set[str] = set()
         self._original_columns = None
         self._is_fitted = False
+        self._feature_names: Dict[int, str] = {}
 
     def _validate_params(
         self,
@@ -203,7 +204,11 @@ class StandardBinarizer(Binarizer):
 
         self._original_columns = X.columns
         self._is_fitted = True
+        self._feature_names = {i: k for i, k in enumerate(outputs.keys())}
         return pd.DataFrame(outputs, index=X.index)
+
+    def _get_feature_names(self) -> Dict[int, str]:
+        return self._feature_names
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Set, Tuple, Dict
+from typing import List, Optional, Set
 
 import numpy as np
 import pandas as pd
@@ -108,7 +108,7 @@ class StandardBinarizer(Binarizer):
         self._skipped_columns: Set[str] = set()
         self._original_columns = None
         self._is_fitted = False
-        self._feature_names: Dict[int, str] = {}
+        self._feature_names: List[str] = []
 
     def _validate_params(
         self,
@@ -204,11 +204,33 @@ class StandardBinarizer(Binarizer):
 
         self._original_columns = X.columns
         self._is_fitted = True
-        self._feature_names = {i: k for i, k in enumerate(outputs.keys())}
+        self._feature_names = [str(name) for name in outputs.keys()]
         return pd.DataFrame(outputs, index=X.index)
 
-    def _get_feature_names(self) -> Dict[int, str]:
-        return self._feature_names
+    def get_feature_names_out(self) -> List[str]:
+        """
+        Return the output column names in order (see :meth:`Binarizer.get_feature_names_out`).
+
+        Returns:
+            List[str]: The boolean output column names, index-aligned with the
+                columns produced by ``fit_transform`` / ``transform``.
+
+        Raises:
+            ValueError: If the binarizer has not been fitted yet.
+
+        Examples:
+            >>> import pandas as pd
+            >>> from hgp_lib.preprocessing import StandardBinarizer
+            >>> b = StandardBinarizer(num_bins=2)
+            >>> _ = b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}))
+            >>> b.get_feature_names_out()
+            ['x < 2.500', '2.500 <= x']
+        """
+        if not self._is_fitted:
+            raise ValueError(
+                "Binarizer must be fitted before calling get_feature_names_out"
+            )
+        return list(self._feature_names)
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """

--- a/hgp_lib/preprocessing/sklearn_binarizer.py
+++ b/hgp_lib/preprocessing/sklearn_binarizer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Dict
+from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -46,7 +46,7 @@ class SklearnBinarizer(Binarizer):
     ) -> pd.DataFrame:
         check_isinstance(X, pd.DataFrame)
         array = np.asarray(self.transformer.fit_transform(X, y))
-        self._columns = self.transformer.get_feature_names_out()
+        self._columns = self._resolve_columns(X, array.shape[1])
         self._is_fitted = True
         return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
 
@@ -57,5 +57,28 @@ class SklearnBinarizer(Binarizer):
         array = np.asarray(self.transformer.transform(X))
         return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
 
-    def _get_feature_names(self) -> Dict[int, str]:
-        return {i: x for i, x in enumerate(self._columns)}
+    def get_feature_names_out(self) -> List[str]:
+        """
+        Return the output column names in order (see :meth:`Binarizer.get_feature_names_out`).
+
+        Names come from the wrapped transformer's ``get_feature_names_out`` when
+        available, otherwise they are generated positionally.
+
+        Returns:
+            List[str]: The boolean output column names.
+
+        Raises:
+            ValueError: If the binarizer has not been fitted yet.
+        """
+        if not self._is_fitted:
+            raise ValueError(
+                "Binarizer must be fitted before calling get_feature_names_out"
+            )
+        return list(self._columns)
+
+    def _resolve_columns(self, X: pd.DataFrame, n_features: int) -> List[str]:
+        if hasattr(self.transformer, "get_feature_names_out"):
+            return [
+                str(c) for c in self.transformer.get_feature_names_out(list(X.columns))
+            ]
+        return [f"feature_{i}" for i in range(n_features)]

--- a/hgp_lib/preprocessing/sklearn_binarizer.py
+++ b/hgp_lib/preprocessing/sklearn_binarizer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import numpy as np
 import pandas as pd
@@ -46,7 +46,7 @@ class SklearnBinarizer(Binarizer):
     ) -> pd.DataFrame:
         check_isinstance(X, pd.DataFrame)
         array = np.asarray(self.transformer.fit_transform(X, y))
-        self._columns = self._feature_names(X, array.shape[1])
+        self._columns = self.transformer.get_feature_names_out()
         self._is_fitted = True
         return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
 
@@ -57,7 +57,5 @@ class SklearnBinarizer(Binarizer):
         array = np.asarray(self.transformer.transform(X))
         return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
 
-    def _feature_names(self, X: pd.DataFrame, n_features: int) -> List[str]:
-        if hasattr(self.transformer, "get_feature_names_out"):
-            return list(self.transformer.get_feature_names_out(list(X.columns)))
-        return [f"feature_{i}" for i in range(n_features)]
+    def _get_feature_names(self) -> Dict[int, str]:
+        return {i: x for i, x in enumerate(self._columns)}

--- a/hgp_lib/rules/literals.py
+++ b/hgp_lib/rules/literals.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Optional, Sequence
 
 
 from .rules import Rule
@@ -60,15 +60,16 @@ class Literal(Rule):
         return ~data[:, self.value] if self.negated else data[:, self.value]
 
     def to_str(
-        self, feature_names: Dict[int, str] | None = None, indent: bool = -1
+        self, feature_names: Sequence[str] | None = None, indent: int = -1
     ) -> str:
         """
         Returns a human-readable string representation of the literal. The literal can be replaced with the feature
         name if provided.
 
         Args:
-            feature_names (Dict[int, str] | None): The feature names that can be used to replace literal values when
-                provided. Default: `None`.
+            feature_names (Sequence[str] | None): Output feature names, index-aligned so that
+                ``feature_names[value]`` is the name of the feature this literal references.
+                When provided, the literal index is replaced by its name. Default: `None`.
             indent (int): Not used. Default: `-1`.
 
         Returns:
@@ -79,7 +80,7 @@ class Literal(Rule):
             '0'
             >>> str(Literal(value=0, negated=True))
             '~0'
-            >>> Literal(value=0, negated=True).to_str({0: "bad"})
+            >>> Literal(value=0, negated=True).to_str(["bad"])
             '~bad'
         """
         value = self.value

--- a/hgp_lib/rules/rules.py
+++ b/hgp_lib/rules/rules.py
@@ -1,6 +1,6 @@
 # Reimplementation based on https://github.com/fidelity/boolxai/blob/main/boolxai/rules/rule.py
 from abc import ABC, abstractmethod
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional, Sequence
 
 import numpy as np
 
@@ -122,15 +122,17 @@ class Rule(ABC):
         return result
 
     def to_str(
-        self, feature_names: Dict[int, str] | None = None, indent: int = -1
+        self, feature_names: Sequence[str] | None = None, indent: int = -1
     ) -> str:
         """
         Returns a human-readable string representation of this rule and replaces the literal values with the feature
         names if available.
 
         Args:
-            feature_names (Dict[int, str] | None): The feature names that can be used to replace literal values when
-                provided. Default: `None`.
+            feature_names (Sequence[str] | None): Output feature names, index-aligned so that
+                ``feature_names[value]`` is the name of the feature a literal references.
+                Typically obtained from ``Binarizer.get_feature_names_out()``. When provided,
+                literal indices are replaced by their names. Default: `None`.
             indent (int): The indentation level when printing the rules. If `-1`, no indentation is used.
                 For standard indentation, use `0`. Default: `-1`.
 
@@ -143,7 +145,7 @@ class Rule(ABC):
             'And(1, 2)'
             >>> str(And([Literal(value=1), Literal(value=2)], negated=True))
             '~And(1, 2)'
-            >>> And([Literal(value=1), Literal(value=2)], negated=True).to_str({1: "good", 2:"nice"})
+            >>> And([Literal(value=1), Literal(value=2)], negated=True).to_str(["a", "good", "nice"])
             '~And(good, nice)'
         """
         if indent == -1:

--- a/hgp_lib/trainers/__init__.py
+++ b/hgp_lib/trainers/__init__.py
@@ -1,3 +1,4 @@
 from .gp_trainer import GPTrainer
+from .boolean_rule_classifier import BooleanRuleClassifier
 
-__all__ = ["GPTrainer"]
+__all__ = ["GPTrainer", "BooleanRuleClassifier"]

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -130,11 +130,14 @@ class BooleanRuleClassifier:
             self.trainer_config.gp_config, train_data=train_bin, train_labels=y
         )
 
-        val_kwargs = {}
         if X_val is not None:
             check_isinstance(X_val, pd.DataFrame)
             val_bin = self.binarizer.transform(X_val).to_numpy(dtype=bool)
             val_kwargs = {"val_data": val_bin, "val_labels": np.asarray(y_val)}
+        else:
+            # No validation set here: clear any val_data from the config so a stale,
+            # un-binarized validation set can't leak into training.
+            val_kwargs = {"val_data": None, "val_labels": None}
 
         fit_config = replace(self.trainer_config, gp_config=gp_config, **val_kwargs)
 

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -35,8 +35,8 @@ class BooleanRuleClassifier:
 
     Examples:
         >>> from sklearn.datasets import load_breast_cancer
+        >>> from hgp_lib import BooleanRuleClassifier
         >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-        >>> from hgp_lib.trainers import BooleanRuleClassifier
         >>> from hgp_lib.utils.metrics import fast_f1_score
         >>> X, y = load_breast_cancer(return_X_y=True, as_frame=True)
         >>> config = TrainerConfig(

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -83,9 +83,9 @@ class BooleanRuleClassifier:
     def fit(
         self,
         X: pd.DataFrame,
-        y: np.ndarray,
+        y: "np.ndarray | pd.Series",
         X_val: Optional[pd.DataFrame] = None,
-        y_val: Optional[np.ndarray] = None,
+        y_val: "np.ndarray | pd.Series | None" = None,
     ) -> PopulationHistory:
         """
         Binarize raw features and evolve a Boolean rule on them.
@@ -97,17 +97,19 @@ class BooleanRuleClassifier:
         Optionally, a raw validation set ``(X_val, y_val)`` can be supplied. It is
         transformed with the *same* fitted binarizer (no leakage) and used to track a
         validation score during training (every ``val_every`` epochs, as configured in
-        the ``TrainerConfig``). When given, it overrides any ``val_data`` already set on
-        the trainer configuration.
+        the ``TrainerConfig``). The validation set passed here fully controls validation:
+        when supplied it overrides any ``val_data`` already set on the trainer
+        configuration, and when omitted any pre-existing ``val_data`` is cleared so no
+        stale (and un-binarized) validation set leaks in.
 
         Args:
             X (pd.DataFrame): Raw (non-binarized) training features. Columns may be
                 boolean, categorical, or numeric.
-            y (np.ndarray): Binary training labels, one per row of ``X``.
+            y (np.ndarray | pd.Series): Binary training labels, one per row of ``X``.
             X_val (pd.DataFrame | None): Optional raw validation features, with the same
                 schema as ``X``. Default: `None`.
-            y_val (np.ndarray | None): Optional validation labels. Must be provided if
-                and only if ``X_val`` is. Default: `None`.
+            y_val (np.ndarray | pd.Series | None): Optional validation labels. Must be
+                provided if and only if ``X_val`` is. Default: `None`.
 
         Returns:
             PopulationHistory: The training history, whose ``global_best_rule`` is the

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -1,0 +1,156 @@
+from dataclasses import replace
+from typing import List, Optional
+
+import numpy as np
+import pandas as pd
+
+from ..configs import TrainerConfig, validate_trainer_config
+from ..metrics import PopulationHistory
+from ..preprocessing import Binarizer, StandardBinarizer
+from ..rules import Rule
+from ..utils.validation import check_isinstance
+from .gp_trainer import GPTrainer
+
+
+class BooleanRuleClassifier:
+    """
+    End-to-end classifier that binarizes raw tabular data and evolves a Boolean rule.
+
+    This is the easiest way to go from a raw ``pandas.DataFrame`` to a trained,
+    human-readable rule. It owns a :class:`Binarizer` and a :class:`GPTrainer`:
+    ``fit`` binarizes the raw features (label-aware) and evolves a rule on them, and
+    ``predict`` binarizes new raw data with the same fitted binarizer before evaluating
+    the rule. It mirrors the scikit-learn estimator API (``fit``/``predict``) so it can
+    be dropped into places that expect an estimator.
+
+    Args:
+        trainer_config (TrainerConfig):
+            Training configuration (epochs, scorer, evolutionary operators, ...). Its
+            nested ``gp_config`` does not need ``train_data``/``train_labels``; they are
+            filled from the data passed to ``fit``.
+        binarizer (Binarizer | None):
+            Binarizer used to turn raw features into boolean columns. When ``None``
+            (default), a :class:`StandardBinarizer` with default settings is used. The
+            binarizer must not be already fitted.
+
+    Examples:
+        >>> from sklearn.datasets import load_breast_cancer
+        >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig
+        >>> from hgp_lib.trainers import BooleanRuleClassifier
+        >>> from hgp_lib.utils.metrics import fast_f1_score
+        >>> X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+        >>> config = TrainerConfig(
+        ...     gp_config=BooleanGPConfig(score_fn=fast_f1_score),
+        ...     num_epochs=10,
+        ...     progress_bar=False,
+        ... )
+        >>> clf = BooleanRuleClassifier(config)
+        >>> history = clf.fit(X, y)
+        >>> predictions = clf.predict(X)
+        >>> predictions.shape
+        (569,)
+        >>> len(clf.feature_names) > 0
+        True
+        >>> isinstance(clf.format_rule(), str)
+        True
+    """
+
+    def __init__(
+        self, trainer_config: TrainerConfig, binarizer: Optional[Binarizer] = None
+    ):
+        validate_trainer_config(trainer_config, require_data=False)
+        if binarizer is None:
+            binarizer = StandardBinarizer()
+        else:
+            check_isinstance(binarizer, Binarizer)
+            if binarizer.is_fitted:
+                raise ValueError(
+                    "binarizer must not be fitted before passing to BooleanRuleClassifier"
+                )
+
+        self.trainer_config = trainer_config
+        self.binarizer = binarizer
+        self._history: Optional[PopulationHistory] = None
+
+    def fit(self, X: pd.DataFrame, y: np.ndarray) -> PopulationHistory:
+        """
+        Binarize raw features and evolve a Boolean rule on them.
+
+        The binarizer is fitted on ``X`` (with labels ``y``, enabling supervised binning
+        of numeric columns) and the resulting boolean matrix is used to train a
+        :class:`GPTrainer`.
+
+        Args:
+            X (pd.DataFrame): Raw (non-binarized) features. Columns may be boolean,
+                categorical, or numeric.
+            y (np.ndarray): Binary target labels, one per row of ``X``.
+
+        Returns:
+            PopulationHistory: The training history, whose ``global_best_rule`` is the
+                rule used for prediction.
+
+        Raises:
+            TypeError: If ``X`` is not a ``pandas.DataFrame``.
+        """
+        check_isinstance(X, pd.DataFrame)
+        y = np.asarray(y)
+
+        train_bin = self.binarizer.fit_transform(X, y).to_numpy(dtype=bool)
+        gp_config = replace(
+            self.trainer_config.gp_config, train_data=train_bin, train_labels=y
+        )
+        fit_config = replace(self.trainer_config, gp_config=gp_config)
+
+        self._history = GPTrainer(fit_config).fit()
+        return self._history
+
+    def predict(self, X: pd.DataFrame) -> np.ndarray:
+        """
+        Predict labels for raw ``X`` using the evolved rule.
+
+        The raw features are binarized with the fitted binarizer, then the best rule
+        found during ``fit`` is evaluated on them. Must be called after ``fit``.
+
+        Args:
+            X (pd.DataFrame): Raw features with the same columns, in the same order and
+                dtypes, as the data used to fit.
+
+        Returns:
+            np.ndarray: 1-D boolean array with one prediction per input row.
+
+        Raises:
+            TypeError: If ``X`` is not a ``pandas.DataFrame``.
+            RuntimeError: If called before ``fit``.
+        """
+        check_isinstance(X, pd.DataFrame)
+        self._check_fitted("predict")
+        data = self.binarizer.transform(X).to_numpy(dtype=bool)
+        return self._history.global_best_rule.evaluate(data)
+
+    @property
+    def rule(self) -> Rule:
+        """The best rule found during ``fit``. Requires a fitted classifier."""
+        self._check_fitted("rule")
+        return self._history.global_best_rule
+
+    @property
+    def feature_names(self) -> List[str]:
+        """
+        The binarized feature names in order (from the fitted binarizer), so that
+        ``feature_names[i]`` names the feature a literal references with index ``i``.
+        """
+        self._check_fitted("feature_names")
+        return self.binarizer.get_feature_names_out()
+
+    def format_rule(self) -> str:
+        """
+        Return the evolved rule as a readable logical expression over the original
+        binarized feature names, e.g. ``Or(mean radius < 15.0, ~worst area < 880.0)``.
+        """
+        return self.rule.to_str(self.feature_names)
+
+    def _check_fitted(self, attr: str) -> None:
+        if self._history is None:
+            raise RuntimeError(
+                f"BooleanRuleClassifier must be fit before accessing '{attr}'"
+            )

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -35,21 +35,29 @@ class BooleanRuleClassifier:
 
     Examples:
         >>> from sklearn.datasets import load_breast_cancer
+        >>> from sklearn.model_selection import train_test_split
         >>> from hgp_lib import BooleanRuleClassifier
         >>> from hgp_lib.configs import BooleanGPConfig, TrainerConfig
         >>> from hgp_lib.utils.metrics import fast_f1_score
         >>> X, y = load_breast_cancer(return_X_y=True, as_frame=True)
+        >>> X_train, X_test, y_train, y_test = train_test_split(
+        ...     X, y, test_size=0.2, stratify=y, random_state=0
+        ... )
+        >>> X_train, X_val, y_train, y_val = train_test_split(
+        ...     X_train, y_train, test_size=0.25, stratify=y_train, random_state=0
+        ... )
         >>> config = TrainerConfig(
         ...     gp_config=BooleanGPConfig(score_fn=fast_f1_score),
         ...     num_epochs=10,
+        ...     val_every=5,
         ...     progress_bar=False,
         ... )
         >>> clf = BooleanRuleClassifier(config)
-        >>> history = clf.fit(X, y)
-        >>> predictions = clf.predict(X)
+        >>> history = clf.fit(X_train, y_train, X_val, y_val)
+        >>> predictions = clf.predict(X_test)
         >>> predictions.shape
-        (569,)
-        >>> len(clf.feature_names) > 0
+        (114,)
+        >>> history.best_val_score is not None
         True
         >>> isinstance(clf.format_rule(), str)
         True
@@ -72,7 +80,13 @@ class BooleanRuleClassifier:
         self.binarizer = binarizer
         self._history: Optional[PopulationHistory] = None
 
-    def fit(self, X: pd.DataFrame, y: np.ndarray) -> PopulationHistory:
+    def fit(
+        self,
+        X: pd.DataFrame,
+        y: np.ndarray,
+        X_val: Optional[pd.DataFrame] = None,
+        y_val: Optional[np.ndarray] = None,
+    ) -> PopulationHistory:
         """
         Binarize raw features and evolve a Boolean rule on them.
 
@@ -80,26 +94,47 @@ class BooleanRuleClassifier:
         of numeric columns) and the resulting boolean matrix is used to train a
         :class:`GPTrainer`.
 
+        Optionally, a raw validation set ``(X_val, y_val)`` can be supplied. It is
+        transformed with the *same* fitted binarizer (no leakage) and used to track a
+        validation score during training (every ``val_every`` epochs, as configured in
+        the ``TrainerConfig``). When given, it overrides any ``val_data`` already set on
+        the trainer configuration.
+
         Args:
-            X (pd.DataFrame): Raw (non-binarized) features. Columns may be boolean,
-                categorical, or numeric.
-            y (np.ndarray): Binary target labels, one per row of ``X``.
+            X (pd.DataFrame): Raw (non-binarized) training features. Columns may be
+                boolean, categorical, or numeric.
+            y (np.ndarray): Binary training labels, one per row of ``X``.
+            X_val (pd.DataFrame | None): Optional raw validation features, with the same
+                schema as ``X``. Default: `None`.
+            y_val (np.ndarray | None): Optional validation labels. Must be provided if
+                and only if ``X_val`` is. Default: `None`.
 
         Returns:
             PopulationHistory: The training history, whose ``global_best_rule`` is the
-                rule used for prediction.
+                rule used for prediction. When validation data is supplied,
+                ``history.best_val_score`` reports the best validation score.
 
         Raises:
-            TypeError: If ``X`` is not a ``pandas.DataFrame``.
+            TypeError: If ``X`` (or ``X_val``, when given) is not a ``pandas.DataFrame``.
+            ValueError: If exactly one of ``X_val`` / ``y_val`` is provided.
         """
         check_isinstance(X, pd.DataFrame)
+        if (X_val is None) != (y_val is None):
+            raise ValueError("X_val and y_val must both be provided or both be None")
         y = np.asarray(y)
 
         train_bin = self.binarizer.fit_transform(X, y).to_numpy(dtype=bool)
         gp_config = replace(
             self.trainer_config.gp_config, train_data=train_bin, train_labels=y
         )
-        fit_config = replace(self.trainer_config, gp_config=gp_config)
+
+        val_kwargs = {}
+        if X_val is not None:
+            check_isinstance(X_val, pd.DataFrame)
+            val_bin = self.binarizer.transform(X_val).to_numpy(dtype=bool)
+            val_kwargs = {"val_data": val_bin, "val_labels": np.asarray(y_val)}
+
+        fit_config = replace(self.trainer_config, gp_config=gp_config, **val_kwargs)
 
         self._history = GPTrainer(fit_config).fit()
         return self._history

--- a/hgp_lib/trainers/gp_trainer.py
+++ b/hgp_lib/trainers/gp_trainer.py
@@ -126,13 +126,13 @@ class GPTrainer:
             self.progress_callback(remaining_epochs)
 
         tp, fp, fn, tn = self.gp_algo.train_cm(
-            self.gp_algo.global_best_rule.evaluate(self.gp_algo.train_data),
             self.gp_algo.train_labels,
+            self.gp_algo.global_best_rule.evaluate(self.gp_algo.train_data),
         )
         val_tp, val_fp, val_fn, val_tn = None, None, None, None
         if self.val_data is not None:
             val_tp, val_fp, val_fn, val_tn = self.val_cm(
-                self.gp_algo.global_best_rule.evaluate(self.val_data), self.val_labels
+                self.val_labels, self.gp_algo.global_best_rule.evaluate(self.val_data)
             )
         return PopulationHistory(
             generations=parent_generations,

--- a/hgp_lib/utils/metrics.py
+++ b/hgp_lib/utils/metrics.py
@@ -13,16 +13,16 @@ _warned_scorers: Set[int] = set()
 
 
 def confusion_matrix(
-    y_pred: np.ndarray, y_true: np.ndarray, sample_weight: np.ndarray | None = None
+    y_true: np.ndarray, y_pred: np.ndarray, sample_weight: np.ndarray | None = None
 ) -> Tuple[int, int, int, int]:
     """
-    Compute confusion matrix values from boolean prediction and label arrays.
+    Compute confusion matrix values from boolean label and prediction arrays.
 
     Args:
-        y_pred (np.ndarray):
-            Boolean predictions.
         y_true (np.ndarray):
             Boolean ground-truth labels.
+        y_pred (np.ndarray):
+            Boolean predictions.
         sample_weight (np.ndarray | None):
             Optional per-sample weights. Default: `None`.
 
@@ -32,9 +32,9 @@ def confusion_matrix(
     Examples:
         >>> import numpy as np
         >>> from hgp_lib.utils.metrics import confusion_matrix
-        >>> y_pred = np.array([True, True, False, False])
         >>> y_true = np.array([True, False, True, False])
-        >>> confusion_matrix(y_pred, y_true)
+        >>> y_pred = np.array([True, True, False, False])
+        >>> confusion_matrix(y_true, y_pred)
         (1, 1, 1, 1)
     """
     if sample_weight is None:
@@ -211,15 +211,40 @@ def transform_duplicates_to_sample_weight(data: ndarray, labels: ndarray):
 
 
 class SampleWeightScorer:
-    # TODO: Add documentation
+    """
+    Adapter that binds a fixed ``sample_weight`` to a scorer.
+
+    Wraps a scorer of the form ``scorer(y_true, y_pred, sample_weight=...)`` and exposes
+    a two-argument callable ``scorer(y_true, y_pred)`` that injects the stored weights.
+    It is used by :func:`optimize_scorers_for_data` after duplicate rows are collapsed
+    into per-row weights, so the wrapped scorer returns the same value it would on the
+    original, un-deduplicated data.
+
+    Args:
+        scorer (Callable):
+            A scorer accepting ``(y_true, y_pred, sample_weight=...)`` and returning a
+            float, following the library's ``(y_true, y_pred)`` argument order.
+        sample_weight (ndarray):
+            Per-row weights bound to every call.
+
+    Examples:
+        >>> import numpy as np
+        >>> from hgp_lib.utils.metrics import SampleWeightScorer, fast_f1_score
+        >>> weighted = SampleWeightScorer(fast_f1_score, np.array([2, 1, 1]))
+        >>> y_true = np.array([True, False, True])
+        >>> y_pred = np.array([True, False, False])
+        >>> round(weighted(y_true, y_pred), 3)
+        0.8
+    """
+
     def __init__(
         self, scorer: Callable[[ndarray, ndarray], Any], sample_weight: ndarray
     ):
         self.scorer = scorer
         self.sample_weight = sample_weight
 
-    def __call__(self, data: ndarray, labels: ndarray):
-        return self.scorer(data, labels, sample_weight=self.sample_weight)
+    def __call__(self, y_true: ndarray, y_pred: ndarray):
+        return self.scorer(y_true, y_pred, sample_weight=self.sample_weight)
 
 
 def optimize_scorers_for_data(

--- a/hgp_lib/utils/metrics.py
+++ b/hgp_lib/utils/metrics.py
@@ -272,10 +272,10 @@ def optimize_scorers_for_data(
     Examples:
         >>> import numpy as np
         >>> from hgp_lib.utils.metrics import optimize_scorers_for_data
-        >>> def acc(p, l, sample_weight=None): return float((p == l).mean())
+        >>> from sklearn.metrics import accuracy_score
         >>> data = np.array([[1, 0], [1, 0], [0, 1]])
         >>> labels = np.array([1, 1, 0])
-        >>> opt_acc, opt_data, opt_labels = optimize_scorers_for_data(acc, data=data, labels=labels)
+        >>> opt_acc, opt_data, opt_labels = optimize_scorers_for_data(accuracy_score, data=data, labels=labels)
         >>> len(opt_data) <= len(data)
         True
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hgp-lib"
-version = "1.0.1"
+version = "1.1.0"
 requires-python = ">=3.10"
 description = "hgp-lib: Hierarchical Genetic Programming Library for Generating Boolean Rules from Tabular Data"
 readme = "README.md"

--- a/tests/test_binarizer.py
+++ b/tests/test_binarizer.py
@@ -387,6 +387,21 @@ class TestStandardBinarizer(unittest.TestCase):
         b.fit_transform(pd.DataFrame({"x": [1.0, 2.0]}))
         self.assertTrue(b.is_fitted)
 
+    # ------------------------------------------------------------------ #
+    #  get_feature_names_out
+    # ------------------------------------------------------------------ #
+    def test_get_feature_names_out_matches_columns(self):
+        b = StandardBinarizer(num_bins=2)
+        result = b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0, 4.0]}))
+        names = b.get_feature_names_out()
+        self.assertEqual(names, list(result.columns))
+        self.assertTrue(all(isinstance(n, str) for n in names))
+
+    def test_get_feature_names_out_before_fit_raises(self):
+        b = StandardBinarizer()
+        with self.assertRaises(ValueError):
+            b.get_feature_names_out()
+
 
 class TestSklearnBinarizer(unittest.TestCase):
     def test_transform_before_fit_raises(self):
@@ -413,7 +428,30 @@ class TestSklearnBinarizer(unittest.TestCase):
         b = SklearnBinarizer(_NoNamesTransformer())
         out = b.fit_transform(pd.DataFrame({"x": [0.0, 1.0]}))
         self.assertEqual(list(out.columns), ["feature_0", "feature_1"])
+        self.assertEqual(b.get_feature_names_out(), ["feature_0", "feature_1"])
         self.assertTrue(out.to_numpy().dtype == bool)
+
+    def test_get_feature_names_out_matches_columns(self):
+        from sklearn.preprocessing import KBinsDiscretizer
+        from hgp_lib.preprocessing import SklearnBinarizer
+
+        b = SklearnBinarizer(
+            KBinsDiscretizer(n_bins=2, encode="onehot-dense", strategy="uniform")
+        )
+        result = b.fit_transform(pd.DataFrame({"x": [0.0, 1.0, 2.0, 3.0]}))
+        names = b.get_feature_names_out()
+        self.assertEqual(names, list(result.columns))
+        self.assertTrue(all(isinstance(n, str) for n in names))
+
+    def test_get_feature_names_out_before_fit_raises(self):
+        from sklearn.preprocessing import KBinsDiscretizer
+        from hgp_lib.preprocessing import SklearnBinarizer
+
+        b = SklearnBinarizer(
+            KBinsDiscretizer(n_bins=2, encode="onehot-dense", strategy="uniform")
+        )
+        with self.assertRaises(ValueError):
+            b.get_feature_names_out()
 
 
 if __name__ == "__main__":

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -515,5 +515,57 @@ class TestBooleanGP(unittest.TestCase):
         self.assertEqual(gp.best_not_improved_epochs, 2)
 
 
+class TestScoreFnArgumentOrder(unittest.TestCase):
+    """Locks the ``score_fn(y_true, y_pred)`` argument order used by the engine.
+
+    Uses an order-sensitive precision score so that a future accidental swap back to
+    ``(y_pred, y_true)`` is caught (the built-in symmetric metrics would not reveal it).
+    """
+
+    @staticmethod
+    def _precision(y_true, y_pred):
+        y_true = np.asarray(y_true, dtype=bool)
+        y_pred = np.asarray(y_pred, dtype=bool)
+        denom = int(y_pred.sum())
+        return int((y_true & y_pred).sum()) / denom if denom else 0.0
+
+    def _make_gp(self, seen):
+        def spy(y_true, y_pred):
+            seen.append((np.asarray(y_true).copy(), np.asarray(y_pred).copy()))
+            return self._precision(y_true, y_pred)
+
+        train_data = np.array(
+            [[True, False], [False, True], [True, True], [False, False]]
+        )
+        train_labels = np.array([1, 0, 1, 0])
+        gp = BooleanGP(
+            BooleanGPConfig(
+                score_fn=spy,
+                train_data=train_data,
+                train_labels=train_labels,
+                optimize_scorer=False,
+            )
+        )
+        return gp, train_data, train_labels
+
+    def test_population_scoring_passes_labels_first(self):
+        seen = []
+        gp, _, train_labels = self._make_gp(seen)
+        gp.step()
+        self.assertTrue(seen)
+        for y_true, _ in seen:
+            np.testing.assert_array_equal(y_true, train_labels)
+
+    def test_evaluate_best_passes_labels_first(self):
+        seen = []
+        gp, train_data, train_labels = self._make_gp(seen)
+        gp.step()
+        seen.clear()
+        gp.evaluate_best(train_data, train_labels, gp.score_fn)
+        y_true, y_pred = seen[-1]
+        np.testing.assert_array_equal(y_true, train_labels)
+        np.testing.assert_array_equal(y_pred, gp.global_best_rule.evaluate(train_data))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_boolean_rule_classifier.py
+++ b/tests/test_boolean_rule_classifier.py
@@ -7,9 +7,9 @@ import pandas as pd
 
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.metrics import PopulationHistory
+from hgp_lib import BooleanRuleClassifier
 from hgp_lib.preprocessing import StandardBinarizer, SklearnBinarizer
 from hgp_lib.rules import Rule
-from hgp_lib.trainers import BooleanRuleClassifier
 from hgp_lib.utils.metrics import fast_f1_score
 
 

--- a/tests/test_boolean_rule_classifier.py
+++ b/tests/test_boolean_rule_classifier.py
@@ -77,6 +77,24 @@ class TestBooleanRuleClassifier(unittest.TestCase):
         preds = clf.predict(self.data.iloc[:5])
         self.assertEqual(preds.shape, (5,))
 
+    def test_fit_with_validation_data_tracks_val_score(self):
+        clf = BooleanRuleClassifier(self._make_config(val_every=1))
+        history = clf.fit(
+            self.data.iloc[:30],
+            self.labels[:30],
+            self.data.iloc[30:],
+            self.labels[30:],
+        )
+        self.assertIsNotNone(history.best_val_score)
+        self.assertEqual(clf.predict(self.data.iloc[30:]).shape, (10,))
+
+    def test_fit_requires_both_val_args(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        with self.assertRaises(ValueError):
+            clf.fit(self.data, self.labels, X_val=self.data)
+        with self.assertRaises(ValueError):
+            clf.fit(self.data, self.labels, y_val=self.labels)
+
     def test_fit_requires_dataframe(self):
         clf = BooleanRuleClassifier(self._make_config())
         with self.assertRaises(TypeError):

--- a/tests/test_boolean_rule_classifier.py
+++ b/tests/test_boolean_rule_classifier.py
@@ -1,0 +1,132 @@
+"""Tests for BooleanRuleClassifier: the binarize-and-train pipeline."""
+
+import unittest
+
+import numpy as np
+import pandas as pd
+
+from hgp_lib.configs import BooleanGPConfig, TrainerConfig
+from hgp_lib.metrics import PopulationHistory
+from hgp_lib.preprocessing import StandardBinarizer, SklearnBinarizer
+from hgp_lib.rules import Rule
+from hgp_lib.trainers import BooleanRuleClassifier
+from hgp_lib.utils.metrics import fast_f1_score
+
+
+class TestBooleanRuleClassifier(unittest.TestCase):
+    def setUp(self):
+        rng = np.random.default_rng(0)
+        self.data = pd.DataFrame(
+            {
+                "num": rng.normal(size=40),
+                "flag": rng.integers(0, 2, size=40).astype(bool),
+            }
+        )
+        self.labels = rng.integers(0, 2, size=40)
+
+    def _make_config(self, **kwargs):
+        defaults = dict(
+            gp_config=BooleanGPConfig(score_fn=fast_f1_score),
+            num_epochs=10,
+            progress_bar=False,
+        )
+        defaults.update(kwargs)
+        return TrainerConfig(**defaults)
+
+    # ------------------------------------------------------------------ #
+    #  Construction
+    # ------------------------------------------------------------------ #
+    def test_default_binarizer_is_standard(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        self.assertIsInstance(clf.binarizer, StandardBinarizer)
+
+    def test_custom_binarizer_is_used(self):
+        from sklearn.preprocessing import KBinsDiscretizer
+
+        binarizer = SklearnBinarizer(
+            KBinsDiscretizer(n_bins=3, encode="onehot-dense", strategy="uniform")
+        )
+        clf = BooleanRuleClassifier(self._make_config(), binarizer=binarizer)
+        self.assertIs(clf.binarizer, binarizer)
+
+    def test_fitted_binarizer_rejected(self):
+        binarizer = StandardBinarizer()
+        binarizer.fit_transform(self.data)
+        with self.assertRaises(ValueError):
+            BooleanRuleClassifier(self._make_config(), binarizer=binarizer)
+
+    # ------------------------------------------------------------------ #
+    #  fit / predict
+    # ------------------------------------------------------------------ #
+    def test_fit_returns_history(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        history = clf.fit(self.data, self.labels)
+        self.assertIsInstance(history, PopulationHistory)
+        self.assertIsInstance(history.global_best_rule, Rule)
+
+    def test_predict_shape_and_dtype(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        clf.fit(self.data, self.labels)
+        preds = clf.predict(self.data)
+        self.assertEqual(preds.shape, (len(self.data),))
+        self.assertTrue(preds.dtype == bool)
+
+    def test_predict_on_new_rows(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        clf.fit(self.data, self.labels)
+        preds = clf.predict(self.data.iloc[:5])
+        self.assertEqual(preds.shape, (5,))
+
+    def test_fit_requires_dataframe(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        with self.assertRaises(TypeError):
+            clf.fit(self.data.to_numpy(), self.labels)
+
+    def test_predict_requires_dataframe(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        clf.fit(self.data, self.labels)
+        with self.assertRaises(TypeError):
+            clf.predict(self.data.to_numpy())
+
+    # ------------------------------------------------------------------ #
+    #  Introspection
+    # ------------------------------------------------------------------ #
+    def test_feature_names_match_binarizer(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        clf.fit(self.data, self.labels)
+        self.assertEqual(clf.feature_names, clf.binarizer.get_feature_names_out())
+        self.assertTrue(all(isinstance(name, str) for name in clf.feature_names))
+
+    def test_rule_is_global_best(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        history = clf.fit(self.data, self.labels)
+        self.assertIs(clf.rule, history.global_best_rule)
+
+    def test_format_rule_is_readable_string(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        clf.fit(self.data, self.labels)
+        formatted = clf.format_rule()
+        self.assertIsInstance(formatted, str)
+        self.assertGreater(len(formatted), 0)
+
+    # ------------------------------------------------------------------ #
+    #  Guardrails before fit
+    # ------------------------------------------------------------------ #
+    def test_predict_before_fit_raises(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        with self.assertRaises(RuntimeError):
+            clf.predict(self.data)
+
+    def test_rule_before_fit_raises(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        with self.assertRaises(RuntimeError):
+            _ = clf.rule
+
+    def test_feature_names_before_fit_raises(self):
+        clf = BooleanRuleClassifier(self._make_config())
+        with self.assertRaises(RuntimeError):
+            _ = clf.feature_names
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -254,9 +254,8 @@ class TestGPBenchmarker(unittest.TestCase):
         self.assertEqual(run.run_id, 0)
         self.assertEqual(len(run.folds), 2)
         self.assertIsInstance(run.test_score, float)
-        self.assertIsInstance(run.feature_names, dict)
-        for idx, name in run.feature_names.items():
-            self.assertIsInstance(idx, int)
+        self.assertIsInstance(run.feature_names, list)
+        for name in run.feature_names:
             self.assertIsInstance(name, str)
 
     def test_fit_confusion_matrix_fields(self):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -60,7 +60,7 @@ class _Helpers:
             test_fp=1,
             test_fn=1,
             test_tn=4,
-            feature_names={0: "col_a", 1: "col_b"},
+            feature_names=["col_a", "col_b"],
         )
         defaults.update(kwargs)
         return RunResult(**defaults)
@@ -192,7 +192,8 @@ class TestRunResult(unittest.TestCase, _Helpers):
     #  feature_names
     # ------------------------------------------------------------------ #
     def test_feature_names(self):
-        run = self.make_run(feature_names={0: "age", 1: "income"})
+        run = self.make_run(feature_names=["age", "income"])
+        self.assertEqual(run.feature_names, ["age", "income"])
         self.assertEqual(run.feature_names[0], "age")
         self.assertEqual(run.feature_names[1], "income")
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -33,7 +33,7 @@ class TestRules(unittest.TestCase):
         self.assertIn("\t", multiline)
         self.assertNotIn("\n", single_line)
         # Named features are still substituted in the indented form.
-        named = rule.to_str({0: "a", 1: "b"}, indent=0)
+        named = rule.to_str(["a", "b"], indent=0)
         self.assertIn("a", named)
         self.assertIn("b", named)
 

--- a/tests/test_utils_metrics.py
+++ b/tests/test_utils_metrics.py
@@ -19,7 +19,7 @@ class TestConfusionMatrix(unittest.TestCase):
     def test_basic(self):
         y_pred = np.array([True, True, False, False])
         y_true = np.array([True, False, True, False])
-        tp, fp, fn, tn = confusion_matrix(y_pred, y_true)
+        tp, fp, fn, tn = confusion_matrix(y_true, y_pred)
         self.assertEqual((tp, fp, fn, tn), (1, 1, 1, 1))
 
     def test_all_correct(self):
@@ -33,32 +33,32 @@ class TestConfusionMatrix(unittest.TestCase):
     def test_all_wrong(self):
         y_pred = np.array([True, False])
         y_true = np.array([False, True])
-        tp, fp, fn, tn = confusion_matrix(y_pred, y_true)
+        tp, fp, fn, tn = confusion_matrix(y_true, y_pred)
         self.assertEqual((tp, fp, fn, tn), (0, 1, 1, 0))
 
     def test_all_positive(self):
         y_pred = np.array([True, True, True])
         y_true = np.array([True, True, True])
-        tp, fp, fn, tn = confusion_matrix(y_pred, y_true)
+        tp, fp, fn, tn = confusion_matrix(y_true, y_pred)
         self.assertEqual((tp, fp, fn, tn), (3, 0, 0, 0))
 
     def test_all_negative(self):
         y_pred = np.array([False, False])
         y_true = np.array([False, False])
-        tp, fp, fn, tn = confusion_matrix(y_pred, y_true)
+        tp, fp, fn, tn = confusion_matrix(y_true, y_pred)
         self.assertEqual((tp, fp, fn, tn), (0, 0, 0, 2))
 
     def test_sum_equals_total(self):
         y_pred = np.array([True, False, True, True, False])
         y_true = np.array([False, False, True, False, True])
-        tp, fp, fn, tn = confusion_matrix(y_pred, y_true)
+        tp, fp, fn, tn = confusion_matrix(y_true, y_pred)
         self.assertEqual(tp + fp + fn + tn, len(y_pred))
 
     def test_with_sample_weight(self):
         y_pred = np.array([True, True, False])
         y_true = np.array([True, False, False])
         sw = np.array([2, 3, 1])
-        tp, fp, fn, tn = confusion_matrix(y_pred, y_true, sample_weight=sw)
+        tp, fp, fn, tn = confusion_matrix(y_true, y_pred, sample_weight=sw)
         self.assertEqual(tp, 2)
         self.assertEqual(fp, 3)
         self.assertEqual(fn, 0)


### PR DESCRIPTION
* Aligned the argument ordering of all scorer functions (y_true, y_pred). Fixed usage of `scorer_fn` and `confusion_matrix`. Added tests to catch regressions for #93. 
* Changed the type of `feature_names` argument accepted by rules from `Dict` to `List`. Added `get_feature_names` function to `Binarizer`s (Fixes #94). 
* Created `BooleanRuleClassifier` that combines training with binarization, providing easier integration and out-of-the-box usage of `hgp_lib`. Closes #95.
* Simplified function that ensure binned column names are unique.
* Updated documentation. Made all code snippets runnable, using the breast_cancer dataset as an example. 
* Updated tests.
* Bumping version.