### PR TITLE
Applied ruff 0.16 fixes

### DIFF
--- a/hgp_lib/__init__.py
+++ b/hgp_lib/__init__.py
@@ -1,12 +1,12 @@
+from .benchmarkers import GPBenchmarker
 from .configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from .trainers import BooleanRuleClassifier, GPTrainer
-from .benchmarkers import GPBenchmarker
 
 __all__ = [
-    "BooleanGPConfig",
-    "TrainerConfig",
     "BenchmarkerConfig",
+    "BooleanGPConfig",
     "BooleanRuleClassifier",
-    "GPTrainer",
     "GPBenchmarker",
+    "GPTrainer",
+    "TrainerConfig",
 ]

--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -1,9 +1,10 @@
+from collections.abc import Callable
 from dataclasses import replace
-from typing import Callable, List
 
 import numpy as np
-from hgp_lib.utils.metrics import confusion_matrix
 from numpy import ndarray
+
+from hgp_lib.utils.metrics import confusion_matrix
 
 from ..configs import BooleanGPConfig, validate_gp_config
 from ..metrics import GenerationMetrics
@@ -110,10 +111,10 @@ class BooleanGP:
         self._epoch = -1
 
         self.config = config
-        self.child_populations: List["BooleanGP"] = []
+        self.child_populations: list[BooleanGP] = []
         self.feature_mapping: dict[int, int] | None = None
         self._transfer_size: int = 0
-        self.parent_rule_indices: List[int] = []
+        self.parent_rule_indices: list[int] = []
 
         if config.max_depth > current_depth:
             self._create_child_populations()
@@ -270,7 +271,7 @@ class BooleanGP:
 
         return self._new_generation(scores, children_metrics)
 
-    def _get_top_k_rules(self) -> List[Rule]:
+    def _get_top_k_rules(self) -> list[Rule]:
         """Retrieve the top-K rules for transfer to the parent population.
 
         Returns the first `_top_k` rules from the population, which are expected
@@ -379,7 +380,7 @@ class BooleanGP:
         return child_feedbacks
 
     def _compute_regularized_scores(
-        self, scores: ndarray, complexities: List[int]
+        self, scores: ndarray, complexities: list[int]
     ) -> ndarray:
         """
         Compute regularized scores: ``score - complexity_penalty * ln(complexity)``.
@@ -421,7 +422,7 @@ class BooleanGP:
         return scores - self.complexity_penalty * np.log(complexities)
 
     def _new_generation(
-        self, scores: ndarray, children_metrics: List[GenerationMetrics]
+        self, scores: ndarray, children_metrics: list[GenerationMetrics]
     ) -> GenerationMetrics:
         """
         Creates a new generation by selecting individuals and optionally regenerating the population.

--- a/hgp_lib/benchmarkers/gp_benchmarker.py
+++ b/hgp_lib/benchmarkers/gp_benchmarker.py
@@ -1,7 +1,6 @@
 import contextlib
 import multiprocessing
 import os
-from typing import List
 
 import numpy as np
 import pandas as pd
@@ -9,10 +8,9 @@ from tqdm import tqdm
 
 from ..configs import BenchmarkerConfig, validate_benchmarker_config
 from ..metrics import ExperimentResult, RunResult
-
+from ..preprocessing import StandardBinarizer
 from .progress import ProgressConfig, ProgressListener
 from .runner import execute_single_run, single_run_wrapper
-from ..preprocessing import StandardBinarizer
 
 
 @contextlib.contextmanager
@@ -119,7 +117,7 @@ class GPBenchmarker:
 
     def _run_sequential(self) -> ExperimentResult:
         """Run all benchmark runs sequentially with nested progress bars."""
-        run_results: List[RunResult] = []
+        run_results: list[RunResult] = []
 
         if self.config.show_run_progress:
             self.config.trainer_config.leave_progress_bar = False

--- a/hgp_lib/benchmarkers/progress.py
+++ b/hgp_lib/benchmarkers/progress.py
@@ -163,9 +163,7 @@ class ProgressListener:
                 self._pbar_exp.close()
 
 
-def send_progress(
-    progress_queue: Queue | None, msg_type: str, count: int = 1
-) -> None:
+def send_progress(progress_queue: Queue | None, msg_type: str, count: int = 1) -> None:
     """
     Send a progress update to the listener queue.
 

--- a/hgp_lib/benchmarkers/progress.py
+++ b/hgp_lib/benchmarkers/progress.py
@@ -163,7 +163,7 @@ class ProgressListener:
                 self._pbar_exp.close()
 
 
-# "Queue | None" because Type[Queue] is <method>.. 
+# "Queue | None" because Type[Queue] is <method>..
 def send_progress(
     progress_queue: "Queue | None", msg_type: str, count: int = 1
 ) -> None:

--- a/hgp_lib/benchmarkers/progress.py
+++ b/hgp_lib/benchmarkers/progress.py
@@ -9,10 +9,9 @@ a multiprocessing queue.
 import queue
 import threading
 from multiprocessing import Queue
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from tqdm import tqdm
-
 
 # Sentinel value to signal listener shutdown
 _SHUTDOWN_SENTINEL = ("__shutdown__", 0)
@@ -165,7 +164,7 @@ class ProgressListener:
 
 
 def send_progress(
-    progress_queue: Optional[Queue], msg_type: str, count: int = 1
+    progress_queue: Queue | None, msg_type: str, count: int = 1
 ) -> None:
     """
     Send a progress update to the listener queue.
@@ -195,7 +194,7 @@ def send_progress(
 
 class ProgressSender:
     # TODO: Join Progress Sender with send_progress and keep only ProgressSender
-    def __init__(self, progress_queue: Optional[Queue], msg_type: str):
+    def __init__(self, progress_queue: Queue | None, msg_type: str):
         self.progress_queue = progress_queue
         self.msg_type = msg_type
 

--- a/hgp_lib/benchmarkers/progress.py
+++ b/hgp_lib/benchmarkers/progress.py
@@ -163,6 +163,7 @@ class ProgressListener:
                 self._pbar_exp.close()
 
 
+# "Queue | None" because Type[Queue] is <method>.. 
 def send_progress(
     progress_queue: "Queue | None", msg_type: str, count: int = 1
 ) -> None:

--- a/hgp_lib/benchmarkers/progress.py
+++ b/hgp_lib/benchmarkers/progress.py
@@ -6,9 +6,9 @@ thread that aggregates progress updates from multiple worker processes via
 a multiprocessing queue.
 """
 
-import queue
 import threading
 from multiprocessing import Queue
+from queue import Empty
 from typing import NamedTuple
 
 from tqdm import tqdm
@@ -138,7 +138,7 @@ class ProgressListener:
 
                 try:
                     msg, count = self.queue.get(timeout=_QUEUE_TIMEOUT_SECONDS)
-                except queue.Empty:
+                except Empty:
                     # Timeout - loop back to check stop_event and continue waiting
                     continue
 
@@ -163,7 +163,9 @@ class ProgressListener:
                 self._pbar_exp.close()
 
 
-def send_progress(progress_queue: Queue | None, msg_type: str, count: int = 1) -> None:
+def send_progress(
+    progress_queue: "Queue | None", msg_type: str, count: int = 1
+) -> None:
     """
     Send a progress update to the listener queue.
 
@@ -192,7 +194,7 @@ def send_progress(progress_queue: Queue | None, msg_type: str, count: int = 1) -
 
 class ProgressSender:
     # TODO: Join Progress Sender with send_progress and keep only ProgressSender
-    def __init__(self, progress_queue: Queue | None, msg_type: str):
+    def __init__(self, progress_queue: "Queue | None", msg_type: str):
         self.progress_queue = progress_queue
         self.msg_type = msg_type
 

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -2,24 +2,23 @@ import random
 from copy import deepcopy
 from dataclasses import replace
 from multiprocessing import Queue
-from typing import List, Optional, Tuple
 
 import numpy as np
 from sklearn.model_selection import StratifiedKFold, train_test_split
 from tqdm import tqdm
 
-from .progress import send_progress, ProgressSender
 from ..configs import BenchmarkerConfig
 from ..metrics import PopulationHistory, RunResult
 from ..trainers import GPTrainer
-from ..utils.metrics import optimize_scorers_for_data, confusion_matrix
+from ..utils.metrics import confusion_matrix, optimize_scorers_for_data
+from .progress import ProgressSender, send_progress
 
 
 def execute_single_run(
     run_id: int,
     seed: int,
     config: BenchmarkerConfig,
-    progress_queue: Optional[Queue] = None,
+    progress_queue: Queue | None = None,
 ) -> RunResult:
     """
     Execute one benchmark run: stratified train/test split, per-fold binarization,
@@ -70,7 +69,7 @@ def execute_single_run(
 
     skf = StratifiedKFold(n_splits=config.n_folds, shuffle=True, random_state=seed)
 
-    folds: List[PopulationHistory] = []
+    folds: list[PopulationHistory] = []
     binarizers = []
     feature_names_per_binarizer = []
 
@@ -167,7 +166,7 @@ def execute_single_run(
 
 
 def single_run_wrapper(
-    args: Tuple[int, int, BenchmarkerConfig, Optional[Queue]],
+    args: tuple[int, int, BenchmarkerConfig, Queue | None],
 ) -> RunResult:
     """
     Picklable wrapper for multiprocessing Pool.

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -18,7 +18,7 @@ def execute_single_run(
     run_id: int,
     seed: int,
     config: BenchmarkerConfig,
-    progress_queue: Queue | None = None,
+    progress_queue: "Queue | None" = None,
 ) -> RunResult:
     """
     Execute one benchmark run: stratified train/test split, per-fold binarization,
@@ -166,7 +166,7 @@ def execute_single_run(
 
 
 def single_run_wrapper(
-    args: tuple[int, int, BenchmarkerConfig, Queue | None],
+    args: tuple[int, int, BenchmarkerConfig, "Queue | None"],
 ) -> RunResult:
     """
     Picklable wrapper for multiprocessing Pool.

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -14,6 +14,7 @@ from ..utils.metrics import confusion_matrix, optimize_scorers_for_data
 from .progress import ProgressSender, send_progress
 
 
+# "Queue | None" because Type[Queue] is <method>..
 def execute_single_run(
     run_id: int,
     seed: int,

--- a/hgp_lib/configs/__init__.py
+++ b/hgp_lib/configs/__init__.py
@@ -3,10 +3,10 @@ from .boolean_gp_config import BooleanGPConfig, validate_gp_config
 from .trainer_config import TrainerConfig, validate_trainer_config
 
 __all__ = [
-    "BooleanGPConfig",
-    "validate_gp_config",
-    "TrainerConfig",
-    "validate_trainer_config",
     "BenchmarkerConfig",
+    "BooleanGPConfig",
+    "TrainerConfig",
     "validate_benchmarker_config",
+    "validate_gp_config",
+    "validate_trainer_config",
 ]

--- a/hgp_lib/configs/benchmarker_config.py
+++ b/hgp_lib/configs/benchmarker_config.py
@@ -142,4 +142,4 @@ def validate_benchmarker_config(config: BenchmarkerConfig) -> None:
     if config.n_folds < 2:
         raise ValueError(f"n_folds must be at least 2, is {config.n_folds}")
 
-    setattr(config, "_validated", True)
+    config._validated = True

--- a/hgp_lib/configs/boolean_gp_config.py
+++ b/hgp_lib/configs/boolean_gp_config.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Callable
 
 from numpy import ndarray
 
@@ -7,7 +7,7 @@ from ..crossover import CrossoverExecutorFactory
 from ..mutations.mutation_factory import MutationExecutorFactory
 from ..populations import SamplingStrategy
 from ..populations.populations_factory import PopulationGeneratorFactory
-from ..rules import Rule, Literal
+from ..rules import Literal, Rule
 from ..selections import BaseSelection
 from ..utils.validation import check_isinstance, check_X_y, validate_callable
 
@@ -209,6 +209,6 @@ def validate_gp_config(config: BooleanGPConfig, require_data: bool = True) -> No
         )
 
     if require_data:
-        setattr(config, "_validated_with_data", True)
+        config._validated_with_data = True
     else:
-        setattr(config, "_validated_without_data", True)
+        config._validated_without_data = True

--- a/hgp_lib/configs/trainer_config.py
+++ b/hgp_lib/configs/trainer_config.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from numpy import ndarray
 
@@ -110,6 +110,6 @@ def validate_trainer_config(config: TrainerConfig, require_data: bool = True) ->
         )
 
     if require_data:
-        setattr(config, "_validated_with_data", True)
+        config._validated_with_data = True
     else:
-        setattr(config, "_validated_without_data", True)
+        config._validated_without_data = True

--- a/hgp_lib/crossover/crossover_executor.py
+++ b/hgp_lib/crossover/crossover_executor.py
@@ -1,9 +1,9 @@
-from typing import Callable, List, Sequence, Tuple
+from collections.abc import Callable, Sequence
 
 import numpy as np
 
 from ..rules import Rule
-from ..rules.utils import deep_swap, apply_feature_mapping, select_crossover_point
+from ..rules.utils import apply_feature_mapping, deep_swap, select_crossover_point
 
 
 class CrossoverExecutor:
@@ -69,8 +69,8 @@ class CrossoverExecutor:
         self.operator_p: float = operator_p
 
     def apply(
-        self, rules: List[Rule], feature_mappings: List[dict | None] | None = None
-    ) -> Tuple[List[Rule], List[int]]:
+        self, rules: list[Rule], feature_mappings: list[dict | None] | None = None
+    ) -> tuple[list[Rule], list[int]]:
         """
         Applies crossover to the provided list of rules and returns children with parent tracking.
 

--- a/hgp_lib/crossover/crossover_factory.py
+++ b/hgp_lib/crossover/crossover_factory.py
@@ -1,8 +1,9 @@
-from typing import Callable
+from collections.abc import Callable
 
-from .crossover_executor import CrossoverExecutor
 from hgp_lib.rules import Rule
+
 from ..utils.validation import check_isinstance
+from .crossover_executor import CrossoverExecutor
 
 
 class CrossoverExecutorFactory:

--- a/hgp_lib/metrics/__init__.py
+++ b/hgp_lib/metrics/__init__.py
@@ -12,8 +12,8 @@ from .history import PopulationHistory
 from .results import ExperimentResult, RunResult
 
 __all__ = [
+    "ExperimentResult",
     "GenerationMetrics",
     "PopulationHistory",
     "RunResult",
-    "ExperimentResult",
 ]

--- a/hgp_lib/metrics/core.py
+++ b/hgp_lib/metrics/core.py
@@ -1,7 +1,7 @@
 """Core metrics dataclasses for generation-level metrics."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 from ..rules import Rule
 

--- a/hgp_lib/metrics/history.py
+++ b/hgp_lib/metrics/history.py
@@ -2,8 +2,6 @@
 
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import List
-
 
 from ..rules import Rule
 from .core import GenerationMetrics
@@ -54,7 +52,7 @@ class PopulationHistory:
     val_fp: int | None = None
     val_fn: int | None = None
     val_tn: int | None = None
-    generations: List[GenerationMetrics] = field(default_factory=list)
+    generations: list[GenerationMetrics] = field(default_factory=list)
 
     def __len__(self) -> int:
         return len(self.generations)

--- a/hgp_lib/metrics/results.py
+++ b/hgp_lib/metrics/results.py
@@ -2,13 +2,12 @@
 
 from dataclasses import dataclass
 from functools import cached_property
-from typing import List, Optional
 
 import numpy as np
 
-from . import PopulationHistory
 from ..preprocessing.base import Binarizer
 from ..rules import Rule
+from . import PopulationHistory
 
 
 @dataclass
@@ -56,14 +55,14 @@ class RunResult:
     run_id: int
     seed: int
     best_fold_idx: int
-    folds: List[PopulationHistory]
+    folds: list[PopulationHistory]
     test_score: float
     test_tp: int
     test_fp: int
     test_fn: int
     test_tn: int
-    feature_names: List[str]
-    binarizer: Optional[Binarizer] = None
+    feature_names: list[str]
+    binarizer: Binarizer | None = None
 
     @cached_property
     def best_fold(self) -> PopulationHistory:
@@ -111,7 +110,7 @@ class RunResult:
         return self.best_fold.global_best_rule
 
     @cached_property
-    def fold_val_scores(self) -> List[float]:
+    def fold_val_scores(self) -> list[float]:
         """
         Best validation score from each fold (folds without validation are excluded).
 
@@ -148,7 +147,7 @@ class RunResult:
         ]
 
     @cached_property
-    def fold_train_scores(self) -> List[float]:
+    def fold_train_scores(self) -> list[float]:
         """
         Best training score from each fold (folds without generations are excluded).
 
@@ -347,7 +346,7 @@ class ExperimentResult:
         1
     """
 
-    runs: List[RunResult]
+    runs: list[RunResult]
 
     @cached_property
     def best_run(self) -> RunResult:

--- a/hgp_lib/mutations/__init__.py
+++ b/hgp_lib/mutations/__init__.py
@@ -15,18 +15,15 @@ from .operator_mutations import (
 from .utils import MutationError
 
 __all__ = [
-    "MutationExecutor",
-    "MutationExecutorFactory",
+    "AddLiteral",
+    "DeleteMutation",
     "Mutation",
     "MutationError",
-    # Literal and operator mutations
-    "DeleteMutation",
+    "MutationExecutor",
+    "MutationExecutorFactory",
     "NegateMutation",
-    # Literal mutations
-    "ReplaceLiteral",
     "PromoteLiteral",
-    # Operator mutations
     "RemoveIntermediateOperator",
+    "ReplaceLiteral",
     "ReplaceOperator",
-    "AddLiteral",
 ]

--- a/hgp_lib/mutations/__init__.py
+++ b/hgp_lib/mutations/__init__.py
@@ -2,17 +2,17 @@ from .base_mutation import Mutation
 from .literal_mutations import (
     DeleteMutation,
     NegateMutation,
-    ReplaceLiteral,
     PromoteLiteral,
-)
-from .operator_mutations import (
-    RemoveIntermediateOperator,
-    ReplaceOperator,
-    AddLiteral,
+    ReplaceLiteral,
 )
 from .mutation_executor import MutationExecutor
-from .utils import MutationError
 from .mutation_factory import MutationExecutorFactory
+from .operator_mutations import (
+    AddLiteral,
+    RemoveIntermediateOperator,
+    ReplaceOperator,
+)
+from .utils import MutationError
 
 __all__ = [
     "MutationExecutor",

--- a/hgp_lib/mutations/base_mutation.py
+++ b/hgp_lib/mutations/base_mutation.py
@@ -69,4 +69,3 @@ class Mutation(ABC):
             >>> rule
             ~0
         """
-        pass

--- a/hgp_lib/mutations/literal_mutations.py
+++ b/hgp_lib/mutations/literal_mutations.py
@@ -1,12 +1,11 @@
 import random
-from typing import Type, Tuple
 
 import numpy as np
 
+from ..rules import And, Literal, Or, Rule
+from ..rules.utils import _create_unsafe_rule
 from .base_mutation import Mutation
 from .utils import MutationError
-from ..rules import Rule, Or, And, Literal
-from ..rules.utils import _create_unsafe_rule
 
 
 class DeleteMutation(Mutation):
@@ -266,7 +265,7 @@ class PromoteLiteral(Mutation):
     """
 
     def __init__(
-        self, num_literals: int, operator_types: Tuple[Type[Rule], ...] = (Or, And)
+        self, num_literals: int, operator_types: tuple[type[Rule], ...] = (Or, And)
     ):
         super().__init__(is_literal_mutation=True, is_operator_mutation=False)
 

--- a/hgp_lib/mutations/mutation_executor.py
+++ b/hgp_lib/mutations/mutation_executor.py
@@ -1,12 +1,12 @@
 import random
-from typing import Callable, Tuple, List
+from collections.abc import Callable
 
 import numpy as np
 
+from ..rules import Literal, Rule
+from ..rules.utils import select_crossover_point
 from .base_mutation import Mutation
 from .utils import MutationError
-from ..rules import Rule, Literal
-from ..rules.utils import select_crossover_point
 
 
 class MutationExecutor:
@@ -58,8 +58,8 @@ class MutationExecutor:
 
     def __init__(
         self,
-        literal_mutations: Tuple[Mutation, ...],
-        operator_mutations: Tuple[Mutation, ...],
+        literal_mutations: tuple[Mutation, ...],
+        operator_mutations: tuple[Mutation, ...],
         mutation_p: float = 0.1,
         check_valid: Callable[[Rule], bool] | None = None,
         num_tries: int = 1,
@@ -72,13 +72,13 @@ class MutationExecutor:
         # literal_mutations was checked
         # operator_mutations was checked
         self.mutation_p: float = mutation_p
-        self.literal_mutations: Tuple[Mutation, ...] = literal_mutations
-        self.operator_mutations: Tuple[Mutation, ...] = operator_mutations
+        self.literal_mutations: tuple[Mutation, ...] = literal_mutations
+        self.operator_mutations: tuple[Mutation, ...] = operator_mutations
         self.check_valid: Callable[[Rule], bool] | None = check_valid
         self.num_tries: int = num_tries
         self.operator_p: float = operator_p
 
-    def apply(self, rules: List[Rule]):
+    def apply(self, rules: list[Rule]):
         """
         Mutates the provided list of rules in place.
 

--- a/hgp_lib/mutations/mutation_factory.py
+++ b/hgp_lib/mutations/mutation_factory.py
@@ -1,5 +1,11 @@
-from typing import Callable, Sequence, Tuple, Type
+from collections.abc import Callable, Sequence
 
+from ..rules import And, Or, Rule
+from ..utils.validation import (
+    check_isinstance,
+    validate_num_literals,
+    validate_operator_types,
+)
 from .base_mutation import Mutation
 from .literal_mutations import (
     DeleteMutation,
@@ -7,14 +13,8 @@ from .literal_mutations import (
     PromoteLiteral,
     ReplaceLiteral,
 )
-from .operator_mutations import AddLiteral, RemoveIntermediateOperator, ReplaceOperator
-from ..rules import And, Or, Rule
 from .mutation_executor import MutationExecutor
-from ..utils.validation import (
-    check_isinstance,
-    validate_num_literals,
-    validate_operator_types,
-)
+from .operator_mutations import AddLiteral, RemoveIntermediateOperator, ReplaceOperator
 
 
 class MutationExecutorFactory:
@@ -62,7 +62,7 @@ class MutationExecutorFactory:
         mutation_p: float = 0.1,
         num_tries: int = 1,
         operator_p: float = 0.5,
-        operator_types: Sequence[Type[Rule]] = (Or, And),
+        operator_types: Sequence[type[Rule]] = (Or, And),
     ):
         check_isinstance(mutation_p, float)
         if mutation_p < 0.0 or mutation_p > 1.0:
@@ -82,9 +82,9 @@ class MutationExecutorFactory:
         self.mutation_p = mutation_p
         self.num_tries = num_tries
         self.operator_p = operator_p
-        self.operator_types: Tuple[Type[Rule], ...] = tuple(operator_types)
+        self.operator_types: tuple[type[Rule], ...] = tuple(operator_types)
 
-    def create_literal_mutations(self, num_literals: int) -> Tuple[Mutation, ...]:
+    def create_literal_mutations(self, num_literals: int) -> tuple[Mutation, ...]:
         """
         Create the set of standard literal-level mutations. Override this method to use custom literal mutations.
 
@@ -109,7 +109,7 @@ class MutationExecutorFactory:
             PromoteLiteral(num_literals, self.operator_types),
         )
 
-    def create_operator_mutations(self, num_literals: int) -> Tuple[Mutation, ...]:
+    def create_operator_mutations(self, num_literals: int) -> tuple[Mutation, ...]:
         """
         Create the set of standard operator-level mutations. Override this method to use custom operator mutations.
 
@@ -136,11 +136,11 @@ class MutationExecutorFactory:
 
     @staticmethod
     def _validate_mutations(
-        literal_mutations: Tuple[Mutation, ...],
-        operator_mutations: Tuple[Mutation, ...],
+        literal_mutations: tuple[Mutation, ...],
+        operator_mutations: tuple[Mutation, ...],
     ):
-        check_isinstance(literal_mutations, Tuple)
-        check_isinstance(operator_mutations, Tuple)
+        check_isinstance(literal_mutations, tuple)
+        check_isinstance(operator_mutations, tuple)
 
         if len(literal_mutations) == 0:
             raise ValueError("literal_mutations must be a non-empty Tuple")

--- a/hgp_lib/mutations/operator_mutations.py
+++ b/hgp_lib/mutations/operator_mutations.py
@@ -1,11 +1,9 @@
 import random
-from typing import Tuple, Type
 
-
+from ..rules import And, Literal, Or, Rule
+from ..rules.utils import _create_unsafe_rule
 from .base_mutation import Mutation
 from .utils import MutationError
-from ..rules import Rule, Or, And, Literal
-from ..rules.utils import _create_unsafe_rule
 
 
 class RemoveIntermediateOperator(Mutation):
@@ -113,7 +111,7 @@ class ReplaceOperator(Mutation):
         Or(0, 1)
     """
 
-    def __init__(self, operator_types: Tuple[Type[Rule], ...] = (Or, And)):
+    def __init__(self, operator_types: tuple[type[Rule], ...] = (Or, And)):
         super().__init__(is_literal_mutation=False, is_operator_mutation=True)
 
         # operator_types was validated

--- a/hgp_lib/populations/__init__.py
+++ b/hgp_lib/populations/__init__.py
@@ -1,24 +1,24 @@
 from .base_strategy import PopulationStrategy
-from .strategies import RandomStrategy, BestLiteralStrategy
 from .generator import PopulationGenerator
 from .populations_factory import PopulationGeneratorFactory
 from .sampling import (
-    SamplingResult,
-    SamplingStrategy,
+    CombinedSamplingStrategy,
     FeatureSamplingStrategy,
     InstanceSamplingStrategy,
-    CombinedSamplingStrategy,
+    SamplingResult,
+    SamplingStrategy,
 )
+from .strategies import BestLiteralStrategy, RandomStrategy
 
 __all__ = [
+    "BestLiteralStrategy",
+    "CombinedSamplingStrategy",
+    "FeatureSamplingStrategy",
+    "InstanceSamplingStrategy",
     "PopulationGenerator",
     "PopulationGeneratorFactory",
     "PopulationStrategy",
     "RandomStrategy",
-    "BestLiteralStrategy",
     "SamplingResult",
     "SamplingStrategy",
-    "FeatureSamplingStrategy",
-    "InstanceSamplingStrategy",
-    "CombinedSamplingStrategy",
 ]

--- a/hgp_lib/populations/base_strategy.py
+++ b/hgp_lib/populations/base_strategy.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List
 
 from ..rules import Rule
 
@@ -13,7 +12,7 @@ class PopulationStrategy(ABC):
     """
 
     @abstractmethod
-    def generate(self, n: int) -> List[Rule]:
+    def generate(self, n: int) -> list[Rule]:
         """
         Generates n rules according to the strategy.
 
@@ -23,4 +22,3 @@ class PopulationStrategy(ABC):
         Returns:
             List[Rule]: A list of newly generated rule instances.
         """
-        pass

--- a/hgp_lib/populations/generator.py
+++ b/hgp_lib/populations/generator.py
@@ -1,10 +1,10 @@
-from typing import Sequence, List
+from collections.abc import Sequence
 
 import numpy as np
 
-from .base_strategy import PopulationStrategy
 from ..rules import Rule
 from ..utils.validation import check_isinstance
+from .base_strategy import PopulationStrategy
 
 
 class PopulationGenerator:
@@ -83,7 +83,7 @@ class PopulationGenerator:
         pvals = [w / sum_weights for w in pvals]
         return np.random.multinomial(self.population_size, pvals)
 
-    def generate(self) -> List[Rule]:
+    def generate(self) -> list[Rule]:
         """
         Generates the full population of rules.
 

--- a/hgp_lib/populations/populations_factory.py
+++ b/hgp_lib/populations/populations_factory.py
@@ -1,11 +1,11 @@
-from typing import Callable, List
+from collections.abc import Callable
 
 import numpy as np
 
+from ..utils.validation import check_isinstance
+from .base_strategy import PopulationStrategy
 from .generator import PopulationGenerator
 from .strategies import RandomStrategy
-from .base_strategy import PopulationStrategy
-from ..utils.validation import check_isinstance
 
 
 class PopulationGeneratorFactory:
@@ -59,7 +59,7 @@ class PopulationGeneratorFactory:
         score_fn: Callable[[np.ndarray, np.ndarray], float],
         train_data: np.ndarray,
         train_labels: np.ndarray,
-    ) -> List[PopulationStrategy]:
+    ) -> list[PopulationStrategy]:
         """
         Create the list of strategies for the generator.
 

--- a/hgp_lib/populations/sampling.py
+++ b/hgp_lib/populations/sampling.py
@@ -7,7 +7,6 @@ data and features when creating child populations in hierarchical GP.
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from math import ceil
-from typing import Dict, List
 
 import numpy as np
 from numpy import ndarray
@@ -44,7 +43,7 @@ class SamplingResult:
     labels: ndarray
     feature_indices: ndarray
     instance_indices: ndarray | None
-    feature_mapping: Dict[int, int] | None
+    feature_mapping: dict[int, int] | None
 
 
 class SamplingStrategy(ABC):
@@ -137,7 +136,7 @@ class SamplingStrategy(ABC):
         data: ndarray,
         labels: ndarray,
         num_children: int,
-    ) -> List[SamplingResult]:
+    ) -> list[SamplingResult]:
         """Sample data and/or features for child populations.
 
         Args:
@@ -148,7 +147,6 @@ class SamplingStrategy(ABC):
         Returns:
             List of SamplingResult, one per child (exactly `num_children` elements).
         """
-        pass
 
 
 class FeatureSamplingStrategy(SamplingStrategy):
@@ -192,7 +190,7 @@ class FeatureSamplingStrategy(SamplingStrategy):
         data: ndarray,
         labels: ndarray,
         num_children: int,
-    ) -> List[SamplingResult]:
+    ) -> list[SamplingResult]:
         """Sample features for child populations.
 
         Args:
@@ -256,7 +254,7 @@ class InstanceSamplingStrategy(SamplingStrategy):
         data: ndarray,
         labels: ndarray,
         num_children: int,
-    ) -> List[SamplingResult]:
+    ) -> list[SamplingResult]:
         """Sample instances for child populations.
 
         Args:
@@ -331,7 +329,7 @@ class CombinedSamplingStrategy(SamplingStrategy):
         data: ndarray,
         labels: ndarray,
         num_children: int,
-    ) -> List[SamplingResult]:
+    ) -> list[SamplingResult]:
         """Sample both features and instances for all children at once.
 
         Args:

--- a/hgp_lib/populations/strategies.py
+++ b/hgp_lib/populations/strategies.py
@@ -1,15 +1,16 @@
+from collections.abc import Callable, Sequence
 from math import ceil
-from typing import Sequence, Type, Callable, List
+
 import numpy as np
 
-from .base_strategy import PopulationStrategy
-from ..rules import Rule, Literal, And, Or
+from ..rules import And, Literal, Or, Rule
 from ..utils.validation import (
-    validate_num_literals,
-    validate_operator_types,
     check_X_y,
     validate_callable,
+    validate_num_literals,
+    validate_operator_types,
 )
+from .base_strategy import PopulationStrategy
 
 
 class RandomStrategy(PopulationStrategy):
@@ -34,7 +35,7 @@ class RandomStrategy(PopulationStrategy):
     """
 
     def __init__(
-        self, num_literals: int, operator_types: Sequence[Type[Rule]] = (Or, And)
+        self, num_literals: int, operator_types: Sequence[type[Rule]] = (Or, And)
     ):
         validate_num_literals(num_literals)
         validate_operator_types(operator_types)
@@ -42,7 +43,7 @@ class RandomStrategy(PopulationStrategy):
         self.num_literals = num_literals
         self.operator_types = operator_types
 
-    def generate(self, n: int) -> List[Rule]:
+    def generate(self, n: int) -> list[Rule]:
         """
         Generates n rules with a random operator and two random literals.
 
@@ -131,8 +132,8 @@ class BestLiteralStrategy(PopulationStrategy):
         score_fn: Callable[[np.ndarray, np.ndarray], float],
         train_data: np.ndarray,
         train_labels: np.ndarray,
-        sample_size: int | float | None = None,
-        feature_size: int | float | None = None,
+        sample_size: float | None = None,
+        feature_size: float | None = None,
     ):
         validate_num_literals(num_literals)
         validate_callable(score_fn)
@@ -152,7 +153,7 @@ class BestLiteralStrategy(PopulationStrategy):
         self._sample_count = self._resolve_size(sample_size, len(train_data))
         self._feature_count = self._resolve_size(feature_size, num_literals)
 
-    def _resolve_size(self, size: int | float | None, total: int) -> int:
+    def _resolve_size(self, size: float | None, total: int) -> int:
         if size is None:
             return total
         if isinstance(size, float):
@@ -167,7 +168,7 @@ class BestLiteralStrategy(PopulationStrategy):
             return size
         raise TypeError(f"size must be int, float or None, got {type(size)}")
 
-    def generate(self, n: int) -> List[Rule]:
+    def generate(self, n: int) -> list[Rule]:
         """
         Generates n literal rules that perform best on random data/feature subsets.
 

--- a/hgp_lib/preprocessing/__init__.py
+++ b/hgp_lib/preprocessing/__init__.py
@@ -1,28 +1,28 @@
 from .base import Binarizer
 from .binarizer import StandardBinarizer
-from .sklearn_binarizer import SklearnBinarizer
 from .binning import BinningStrategy, QuantileBinning, SupervisedTreeBinning
+from .sklearn_binarizer import SklearnBinarizer
 from .utils import is_categorical_like, load_data
 from .warnings import (
     BinarizerWarning,
+    EmptyBinarizationWarning,
     HighCardinalityWarning,
     StringColumnWarning,
     UnseenNaNWarning,
-    EmptyBinarizationWarning,
 )
 
 __all__ = [
     "Binarizer",
-    "StandardBinarizer",
-    "SklearnBinarizer",
+    "BinarizerWarning",
     "BinningStrategy",
+    "EmptyBinarizationWarning",
+    "HighCardinalityWarning",
     "QuantileBinning",
+    "SklearnBinarizer",
+    "StandardBinarizer",
+    "StringColumnWarning",
     "SupervisedTreeBinning",
+    "UnseenNaNWarning",
     "is_categorical_like",
     "load_data",
-    "BinarizerWarning",
-    "HighCardinalityWarning",
-    "StringColumnWarning",
-    "UnseenNaNWarning",
-    "EmptyBinarizationWarning",
 ]

--- a/hgp_lib/preprocessing/base.py
+++ b/hgp_lib/preprocessing/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -56,21 +55,19 @@ class Binarizer(ABC):
 
     @abstractmethod
     def fit_transform(
-        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+        self, X: pd.DataFrame, y: np.ndarray | None = None
     ) -> pd.DataFrame:
         """
         Learn the encoding from ``X`` (and optional labels ``y``) and return the
         transformed boolean ``DataFrame``.
         """
-        pass
 
     @abstractmethod
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Apply the learned encoding to new data and return a boolean ``DataFrame``."""
-        pass
 
     @abstractmethod
-    def get_feature_names_out(self) -> List[str]:
+    def get_feature_names_out(self) -> list[str]:
         """
         Return the output feature (column) names in order.
 
@@ -80,4 +77,3 @@ class Binarizer(ABC):
         convention, the names are returned as an ordered ``list[str]``. Implementations
         should raise if called before the binarizer is fitted.
         """
-        pass

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -1,4 +1,3 @@
-from typing import List, Optional, Set
 
 import numpy as np
 import pandas as pd
@@ -12,10 +11,10 @@ from .base import Binarizer
 from .binning import BinningStrategy, QuantileBinning, SupervisedTreeBinning
 from .utils import is_categorical_like
 from .warnings import (
+    EmptyBinarizationWarning,
     HighCardinalityWarning,
     StringColumnWarning,
     UnseenNaNWarning,
-    EmptyBinarizationWarning,
 )
 
 
@@ -85,9 +84,9 @@ class StandardBinarizer(Binarizer):
     def __init__(
         self,
         num_bins: int = 5,
-        column_strategy: Optional[dict[str, int]] = None,
+        column_strategy: dict[str, int] | None = None,
         precision: int = 3,
-        numeric_binning: Optional[BinningStrategy] = None,
+        numeric_binning: BinningStrategy | None = None,
         progress_bar: bool = True,
         leave_progress_bar: bool = False,
     ):
@@ -104,18 +103,18 @@ class StandardBinarizer(Binarizer):
         self._numerical_bins: dict = {}
         self._original_column_dtypes: dict = {}
         self._output_names: dict = {}
-        self._na_columns: Set[str] = set()
-        self._skipped_columns: Set[str] = set()
+        self._na_columns: set[str] = set()
+        self._skipped_columns: set[str] = set()
         self._original_columns = None
         self._is_fitted = False
-        self._feature_names: List[str] = []
+        self._feature_names: list[str] = []
 
     def _validate_params(
         self,
         num_bins: int,
-        column_strategy: Optional[dict[str, int]],
+        column_strategy: dict[str, int] | None,
         precision: int,
-        numeric_binning: Optional[BinningStrategy],
+        numeric_binning: BinningStrategy | None,
     ) -> None:
         check_isinstance(num_bins, int)
         if num_bins < 2:
@@ -138,7 +137,7 @@ class StandardBinarizer(Binarizer):
             check_isinstance(numeric_binning, BinningStrategy)
 
     def fit_transform(
-        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+        self, X: pd.DataFrame, y: np.ndarray | None = None
     ) -> pd.DataFrame:
         """
         Learn the binarisation mapping from ``X`` (and optionally ``y``) and return the
@@ -173,7 +172,7 @@ class StandardBinarizer(Binarizer):
         self._reset_state()
 
         outputs: dict = {}
-        used_names: Set[str] = set()
+        used_names: set[str] = set()
 
         for column in tqdm(
             X.columns,
@@ -191,7 +190,7 @@ class StandardBinarizer(Binarizer):
 
             pieces.extend(self._fit_column(column, series, y, nan_mask))
 
-            names: List[str] = []
+            names: list[str] = []
             for base_name, values in pieces:
                 name = self._ensure_unique_column_names(used_names, base_name)
                 outputs[name] = values
@@ -204,10 +203,10 @@ class StandardBinarizer(Binarizer):
 
         self._original_columns = X.columns
         self._is_fitted = True
-        self._feature_names = [str(name) for name in outputs.keys()]
+        self._feature_names = [str(name) for name in outputs]
         return pd.DataFrame(outputs, index=X.index)
 
-    def get_feature_names_out(self) -> List[str]:
+    def get_feature_names_out(self) -> list[str]:
         """
         Return the output column names in order (see :meth:`Binarizer.get_feature_names_out`).
 
@@ -279,7 +278,7 @@ class StandardBinarizer(Binarizer):
         ):
             series = X[column]
             names = self._output_names[column]
-            values_list: List[np.ndarray] = []
+            values_list: list[np.ndarray] = []
 
             nan_mask = series.isna().to_numpy()
             if column in self._na_columns:
@@ -308,7 +307,7 @@ class StandardBinarizer(Binarizer):
         self,
         column: str,
         series: pd.Series,
-        y: Optional[np.ndarray],
+        y: np.ndarray | None,
         nan_mask: np.ndarray,
     ):
         """Dispatch a single column to the matching dtype hook and record its dtype."""
@@ -352,7 +351,7 @@ class StandardBinarizer(Binarizer):
         self,
         column: str,
         series: pd.Series,
-        y: Optional[np.ndarray],
+        y: np.ndarray | None,
         nan_mask: np.ndarray,
     ):
         """Bin a numeric column and one-hot encode the bins."""
@@ -380,7 +379,7 @@ class StandardBinarizer(Binarizer):
             for i in range(len(edges) - 1)
         ]
 
-    def _transform_column(self, column: str, series: pd.Series) -> List[np.ndarray]:
+    def _transform_column(self, column: str, series: pd.Series) -> list[np.ndarray]:
         """Apply the learned encoding for a single column, verifying its dtype."""
         expected = self._original_column_dtypes[column]
         actual = self._infer_kind(column, series)
@@ -395,24 +394,24 @@ class StandardBinarizer(Binarizer):
             return self._transform_categorical(column, series)
         return self._transform_numeric(column, series)
 
-    def _transform_boolean(self, series: pd.Series) -> List[np.ndarray]:
+    def _transform_boolean(self, series: pd.Series) -> list[np.ndarray]:
         return [series.to_numpy(dtype=bool)]
 
     def _transform_categorical(
         self, column: str, series: pd.Series
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         return [
             (series == value).to_numpy() for value in self._categorical_values[column]
         ]
 
-    def _transform_numeric(self, column: str, series: pd.Series) -> List[np.ndarray]:
+    def _transform_numeric(self, column: str, series: pd.Series) -> list[np.ndarray]:
         edges = self._numerical_bins[column]
         binned = pd.cut(
             series.to_numpy(), bins=edges, labels=False, include_lowest=True
         )
         return [binned == i for i in range(len(edges) - 1)]
 
-    def _resolve_numeric_binning(self, y: Optional[np.ndarray]) -> BinningStrategy:
+    def _resolve_numeric_binning(self, y: np.ndarray | None) -> BinningStrategy:
         """Pick the numeric binning strategy: the configured one, or a default by ``y``."""
         if self.numeric_binning is not None:
             return self.numeric_binning
@@ -440,7 +439,7 @@ class StandardBinarizer(Binarizer):
         self._is_fitted = False
 
     def _ensure_unique_column_names(
-        self, column_names: Set[str], new_column_name: str
+        self, column_names: set[str], new_column_name: str
     ) -> str:
         """
         Register ``new_column_name`` in ``column_names``, appending a numeric suffix if needed.

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype

--- a/hgp_lib/preprocessing/binning.py
+++ b/hgp_lib/preprocessing/binning.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import Optional
 
 import numpy as np
 from sklearn.tree import DecisionTreeClassifier
@@ -25,7 +24,7 @@ class BinningStrategy(ABC):
 
     @abstractmethod
     def compute_edges(
-        self, values: np.ndarray, y: Optional[np.ndarray], n_bins: int
+        self, values: np.ndarray, y: np.ndarray | None, n_bins: int
     ) -> np.ndarray:
         """
         Compute sorted bin edges for a single numeric feature.
@@ -60,7 +59,7 @@ class QuantileBinning(BinningStrategy):
     """
 
     def compute_edges(
-        self, values: np.ndarray, y: Optional[np.ndarray], n_bins: int
+        self, values: np.ndarray, y: np.ndarray | None, n_bins: int
     ) -> np.ndarray:
         if len(np.unique(values)) <= 1:
             return np.array([-np.inf, np.inf])
@@ -91,7 +90,7 @@ class SupervisedTreeBinning(BinningStrategy):
     """
 
     def compute_edges(
-        self, values: np.ndarray, y: Optional[np.ndarray], n_bins: int
+        self, values: np.ndarray, y: np.ndarray | None, n_bins: int
     ) -> np.ndarray:
         if y is None:
             raise ValueError("SupervisedTreeBinning requires labels y")

--- a/hgp_lib/preprocessing/sklearn_binarizer.py
+++ b/hgp_lib/preprocessing/sklearn_binarizer.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import pandas as pd
 

--- a/hgp_lib/preprocessing/sklearn_binarizer.py
+++ b/hgp_lib/preprocessing/sklearn_binarizer.py
@@ -1,4 +1,3 @@
-from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -38,11 +37,11 @@ class SklearnBinarizer(Binarizer):
 
     def __init__(self, transformer):
         self.transformer = transformer
-        self._columns: Optional[List[str]] = None
+        self._columns: list[str] | None = None
         self._is_fitted = False
 
     def fit_transform(
-        self, X: pd.DataFrame, y: Optional[np.ndarray] = None
+        self, X: pd.DataFrame, y: np.ndarray | None = None
     ) -> pd.DataFrame:
         check_isinstance(X, pd.DataFrame)
         array = np.asarray(self.transformer.fit_transform(X, y))
@@ -57,7 +56,7 @@ class SklearnBinarizer(Binarizer):
         array = np.asarray(self.transformer.transform(X))
         return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
 
-    def get_feature_names_out(self) -> List[str]:
+    def get_feature_names_out(self) -> list[str]:
         """
         Return the output column names in order (see :meth:`Binarizer.get_feature_names_out`).
 
@@ -76,7 +75,7 @@ class SklearnBinarizer(Binarizer):
             )
         return list(self._columns)
 
-    def _resolve_columns(self, X: pd.DataFrame, n_features: int) -> List[str]:
+    def _resolve_columns(self, X: pd.DataFrame, n_features: int) -> list[str]:
         if hasattr(self.transformer, "get_feature_names_out"):
             return [
                 str(c) for c in self.transformer.get_feature_names_out(list(X.columns))

--- a/hgp_lib/preprocessing/utils.py
+++ b/hgp_lib/preprocessing/utils.py
@@ -1,10 +1,9 @@
 import logging
-from typing import Tuple
+from pathlib import Path
 
 import pandas as pd
 from numpy import ndarray
 from pandas.api.types import is_object_dtype, is_string_dtype
-from pathlib import Path
 
 
 def is_categorical_like(column: pd.Series) -> bool:
@@ -40,7 +39,7 @@ def is_categorical_like(column: pd.Series) -> bool:
     )
 
 
-def load_data(data_path: str) -> Tuple[pd.DataFrame, ndarray]:
+def load_data(data_path: str) -> tuple[pd.DataFrame, ndarray]:
     """
     Load features and labels from a CSV or HDF file.
 

--- a/hgp_lib/rules/__init__.py
+++ b/hgp_lib/rules/__init__.py
@@ -1,13 +1,13 @@
 import os
 
+from . import utils
 from .literals import Literal
 from .rules import Rule
-from . import utils
 
 if os.getenv("HGP_LOW_MEMORY", "0") == "1":
-    from .low_memory_operators import Or, And
+    from .low_memory_operators import And, Or
 else:
-    from .operators import Or, And
+    from .operators import And, Or
 
-__all__ = ["Literal", "Rule", "Or", "And", "utils", "operators", "low_memory_operators"]
+__all__ = ["And", "Literal", "Or", "Rule", "low_memory_operators", "operators", "utils"]
 # TODO: Provide support for both torch and numpy

--- a/hgp_lib/rules/literals.py
+++ b/hgp_lib/rules/literals.py
@@ -1,5 +1,5 @@
-from typing import Optional, Sequence
-
+from collections.abc import Sequence
+from typing import Optional
 
 from .rules import Rule
 

--- a/hgp_lib/rules/low_memory_operators.py
+++ b/hgp_lib/rules/low_memory_operators.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from .rules import Rule
 
-
 # TODO: Add some performance tests comparing operator implementations
 
 

--- a/hgp_lib/rules/rules.py
+++ b/hgp_lib/rules/rules.py
@@ -1,6 +1,7 @@
 # Reimplementation based on https://github.com/fidelity/boolxai/blob/main/boolxai/rules/rule.py
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Sequence
+from collections.abc import Sequence
+from typing import Optional
 
 import numpy as np
 
@@ -44,13 +45,13 @@ class Rule(ABC):
         And(0, Or(~1, 2), 3)
     """
 
-    __slots__ = ("subrules", "parent", "value", "negated")
+    __slots__ = ("negated", "parent", "subrules", "value")
 
     def __init__(
         self,
-        subrules: Optional[List["Rule"]] = None,
+        subrules: list["Rule"] | None = None,
         parent: Optional["Rule"] = None,
-        value: Optional[int] = None,
+        value: int | None = None,
         negated: bool = False,
         copy_subrules: bool = True,
     ):
@@ -240,9 +241,8 @@ class Rule(ABC):
         Notes:
             Concrete subclasses (`And`, `Or`, `Literal`, etc.) must implement this.
         """
-        pass
 
-    def apply_feature_mapping(self, feature_mapping: Dict[int, int]):
+    def apply_feature_mapping(self, feature_mapping: dict[int, int]):
         """
         Applies a feature mapping to this rule and all its subrules in-place.
 

--- a/hgp_lib/rules/utils.py
+++ b/hgp_lib/rules/utils.py
@@ -1,8 +1,7 @@
 import random
-from typing import Dict, Type, List
 
-from .rules import Rule
 from .literals import Literal
+from .rules import Rule
 
 
 def is_operator(op: Rule) -> bool:
@@ -27,7 +26,7 @@ def is_operator(op: Rule) -> bool:
     return isinstance(op, Rule) and not isinstance(op, Literal)
 
 
-def is_operator_type(t: Type[Rule]) -> bool:
+def is_operator_type(t: type[Rule]) -> bool:
     """
     Check whether a type is an operator class (a ``Rule`` subclass that is not ``Literal``).
 
@@ -110,7 +109,7 @@ def deep_swap(node_a: Rule, node_b: Rule) -> None:
     replace_with_rule(node_b, copy_node_a)
 
 
-def apply_feature_mapping(rule: Rule, feature_mapping: Dict[int, int] | None) -> Rule:
+def apply_feature_mapping(rule: Rule, feature_mapping: dict[int, int] | None) -> Rule:
     """
     Creates a copy of a rule with feature indices remapped according to the provided mapping.
 
@@ -205,7 +204,7 @@ def select_crossover_point(rule: Rule, operator_p: float = 0.9) -> Rule:
 
 
 def _create_unsafe_rule(
-    rule_type: Type[Rule], subrules: List[Rule], parent: Rule, value: int, negated: bool
+    rule_type: type[Rule], subrules: list[Rule], parent: Rule, value: int, negated: bool
 ) -> Rule:
     """
     Creates a new rule while skipping subrules assignment and constructor validation. To be used internally.

--- a/hgp_lib/selections/base_selection.py
+++ b/hgp_lib/selections/base_selection.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Sequence, Tuple
+from collections.abc import Sequence
 
 import numpy as np
 from numpy import ndarray
@@ -42,7 +42,7 @@ class BaseSelection(ABC):
         rules: Sequence[Rule],
         scores: np.ndarray | Sequence[float],
         n_select: int,
-    ) -> Tuple[List[Rule], ndarray]:
+    ) -> tuple[list[Rule], ndarray]:
         """
         Selects `n_select` rules from the population based on their fitness scores.
 
@@ -84,4 +84,3 @@ class BaseSelection(ABC):
             >>> selected_rules
             [1, 2]
         """
-        pass

--- a/hgp_lib/selections/roulette_selection.py
+++ b/hgp_lib/selections/roulette_selection.py
@@ -1,4 +1,4 @@
-from typing import List, Sequence, Tuple
+from collections.abc import Sequence
 
 import numpy as np
 from numpy import ndarray
@@ -40,7 +40,7 @@ class RouletteSelection(BaseSelection):
         rules: Sequence[Rule],
         scores: np.ndarray | Sequence[float],
         n_select: int,
-    ) -> Tuple[List[Rule], ndarray]:
+    ) -> tuple[list[Rule], ndarray]:
         """
         Selects `n_select` rules using roulette wheel (fitness-proportionate) selection.
 

--- a/hgp_lib/selections/tournament_selection.py
+++ b/hgp_lib/selections/tournament_selection.py
@@ -1,11 +1,11 @@
-from typing import List, Sequence, Tuple
+from collections.abc import Sequence
 
 import numpy as np
 from numpy import ndarray
 
-from .base_selection import BaseSelection
 from ..rules import Rule
 from ..utils.validation import check_isinstance
+from .base_selection import BaseSelection
 
 
 class TournamentSelection(BaseSelection):
@@ -75,7 +75,7 @@ class TournamentSelection(BaseSelection):
         rules: Sequence[Rule],
         scores: np.ndarray | Sequence[float],
         n_select: int,
-    ) -> Tuple[List[Rule], ndarray]:
+    ) -> tuple[list[Rule], ndarray]:
         """
         Selects `n_select` rules using tournament selection.
 

--- a/hgp_lib/trainers/__init__.py
+++ b/hgp_lib/trainers/__init__.py
@@ -1,4 +1,4 @@
-from .gp_trainer import GPTrainer
 from .boolean_rule_classifier import BooleanRuleClassifier
+from .gp_trainer import GPTrainer
 
-__all__ = ["GPTrainer", "BooleanRuleClassifier"]
+__all__ = ["BooleanRuleClassifier", "GPTrainer"]

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -1,5 +1,4 @@
 from dataclasses import replace
-from typing import List, Optional
 
 import numpy as np
 import pandas as pd
@@ -64,7 +63,7 @@ class BooleanRuleClassifier:
     """
 
     def __init__(
-        self, trainer_config: TrainerConfig, binarizer: Optional[Binarizer] = None
+        self, trainer_config: TrainerConfig, binarizer: Binarizer | None = None
     ):
         validate_trainer_config(trainer_config, require_data=False)
         if binarizer is None:
@@ -78,13 +77,13 @@ class BooleanRuleClassifier:
 
         self.trainer_config = trainer_config
         self.binarizer = binarizer
-        self._history: Optional[PopulationHistory] = None
+        self._history: PopulationHistory | None = None
 
     def fit(
         self,
         X: pd.DataFrame,
         y: "np.ndarray | pd.Series",
-        X_val: Optional[pd.DataFrame] = None,
+        X_val: pd.DataFrame | None = None,
         y_val: "np.ndarray | pd.Series | None" = None,
     ) -> PopulationHistory:
         """
@@ -174,7 +173,7 @@ class BooleanRuleClassifier:
         return self._history.global_best_rule
 
     @property
-    def feature_names(self) -> List[str]:
+    def feature_names(self) -> list[str]:
         """
         The binarized feature names in order (from the fitted binarizer), so that
         ``feature_names[i]`` names the feature a literal references with index ``i``.

--- a/hgp_lib/trainers/gp_trainer.py
+++ b/hgp_lib/trainers/gp_trainer.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from tqdm import tqdm
 

--- a/hgp_lib/trainers/gp_trainer.py
+++ b/hgp_lib/trainers/gp_trainer.py
@@ -1,4 +1,3 @@
-from typing import List
 
 import numpy as np
 from tqdm import tqdm
@@ -81,7 +80,7 @@ class GPTrainer:
         Returns:
             HierarchicalHistory: History with parent and child population metrics.
         """
-        parent_generations: List[GenerationMetrics] = []
+        parent_generations: list[GenerationMetrics] = []
         val_score = 0.0
 
         with tqdm(

--- a/hgp_lib/utils/metrics.py
+++ b/hgp_lib/utils/metrics.py
@@ -1,20 +1,20 @@
 import inspect
 import warnings
-from typing import Callable, Set, Tuple, Any
+from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 from numpy import ndarray
 
 from hgp_lib.utils.validation import validate_callable
 
-
 # Track scorers that have already been warned about missing sample_weight support
-_warned_scorers: Set[int] = set()
+_warned_scorers: set[int] = set()
 
 
 def confusion_matrix(
     y_true: np.ndarray, y_pred: np.ndarray, sample_weight: np.ndarray | None = None
-) -> Tuple[int, int, int, int]:
+) -> tuple[int, int, int, int]:
     """
     Compute confusion matrix values from boolean label and prediction arrays.
 

--- a/hgp_lib/utils/validation.py
+++ b/hgp_lib/utils/validation.py
@@ -1,5 +1,7 @@
 import inspect
-from typing import Sequence, Tuple, Type, Callable, Any
+from collections.abc import Callable, Sequence
+from typing import Any
+
 import numpy as np
 import pandas as pd
 
@@ -77,7 +79,7 @@ def validate_callable(maybe_callable: Callable, error_message: str | None = None
         raise TypeError(error_message)
 
 
-def check_isinstance(value: Any, expected_type: Type | Tuple[Type, ...]):
+def check_isinstance(value: Any, expected_type: type | tuple[type, ...]):
     """
     Check that a value is an instance of expected type(s).
 
@@ -133,7 +135,7 @@ def validate_num_literals(num_literals: int):
         )
 
 
-def validate_operator_types(operator_types: Sequence[Type[Rule]]):
+def validate_operator_types(operator_types: Sequence[type[Rule]]):
     """
     Validate ``operator_types`` parameter.
 
@@ -166,7 +168,7 @@ def validate_operator_types(operator_types: Sequence[Type[Rule]]):
 def check_X_y(
     X: np.ndarray | pd.DataFrame,
     y: np.ndarray,
-    x_type: Type[np.ndarray] | Type[pd.DataFrame] = np.ndarray,
+    x_type: type[np.ndarray] | type[pd.DataFrame] = np.ndarray,
 ):
     """
     Validate input data and labels.

--- a/hgp_lib/utils/warnings.py
+++ b/hgp_lib/utils/warnings.py
@@ -1,8 +1,7 @@
 import warnings
-from typing import Set
 
 # Messages of warnings already emitted in this process, used to deduplicate.
-_emitted_messages: Set[str] = set()
+_emitted_messages: set[str] = set()
 
 
 def warn_once(warning: Warning) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
     "mkdocs-bibtex",
     "pytest",
     "flake8",
-    "ruff==0.15.22",
+    "ruff",
     "seaborn",
     "tables",
     "prettytable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dev = [
     "matplotlib",
 ]
 [tool.ruff]
-exclude = [".venv"]
+exclude = [".venv", "docs", "README.md"]
 
 [tool.coverage.run]
 source = ["hgp_lib"]

--- a/scripts/hypertuning/search_space.py
+++ b/scripts/hypertuning/search_space.py
@@ -22,12 +22,12 @@ Fixed params (plain scalar)::
 """
 
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import yaml
 
 
-def _parse_entry(raw: Any) -> Tuple[tuple, dict]:
+def _parse_entry(raw: Any) -> tuple[tuple, dict]:
     """
     Parse a single YAML entry into ``(args, kwargs)``.
 
@@ -49,7 +49,7 @@ def _parse_entry(raw: Any) -> Tuple[tuple, dict]:
 
 def load_search_space(
     config_path: str | Path,
-) -> Dict[str, Tuple[tuple, dict]]:
+) -> dict[str, tuple[tuple, dict]]:
     """
     Load a YAML search-space config.
 

--- a/scripts/optuna_hypertuning.py
+++ b/scripts/optuna_hypertuning.py
@@ -11,21 +11,24 @@ import logging
 import os
 import traceback
 import warnings
+from collections.abc import Callable
 from multiprocessing import freeze_support
 from pathlib import Path
-from typing import Any, Callable, Dict
+from typing import Any
 
 import numpy as np
 import optuna
 import pandas as pd
+from hypertuning import load_search_space
 from numpy import ndarray
 from optuna.artifacts import FileSystemArtifactStore
 from optuna.trial import TrialState
+from preprocess.pmlb_preprocess import save_pmlb_data
+from visualization.optuna import store_trial_attributes, upload_trial_artifacts
 
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.crossover import CrossoverExecutorFactory
-from visualization.optuna import store_trial_attributes, upload_trial_artifacts
 from hgp_lib.mutations import MutationExecutorFactory
 from hgp_lib.populations import (
     CombinedSamplingStrategy,
@@ -38,9 +41,6 @@ from hgp_lib.selections import RouletteSelection, TournamentSelection
 from hgp_lib.utils.metrics import fast_f1_score
 from hgp_lib.utils.validation import ComplexityCheck
 
-from hypertuning import load_search_space
-from preprocess.pmlb_preprocess import save_pmlb_data
-
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
@@ -48,8 +48,8 @@ logger = logging.getLogger(__name__)
 
 
 def suggest_hyperparameters(
-    trial: optuna.Trial, config: Dict[str, Any]
-) -> Dict[str, Any]:
+    trial: optuna.Trial, config: dict[str, Any]
+) -> dict[str, Any]:
     """Suggest hyperparameters using ranges from ``config``.
 
     ``config`` maps parameter names to ``(args, kwargs)`` tuples as returned
@@ -196,7 +196,7 @@ def suggest_hyperparameters(
 
 
 def build_config(
-    params: Dict[str, Any],
+    params: dict[str, Any],
     data: pd.DataFrame,
     labels: ndarray,
     score_fn: Callable,
@@ -293,7 +293,7 @@ def create_objective(
     n_runs: int,
     n_folds: int,
     artifact_store: FileSystemArtifactStore,
-    hp_config: Dict[str, Any],
+    hp_config: dict[str, Any],
     verbose: bool = False,
 ) -> Callable[[optuna.Trial], float]:
     """Create the Optuna objective function."""

--- a/scripts/optuna_hypertuning.py
+++ b/scripts/optuna_hypertuning.py
@@ -306,7 +306,7 @@ def create_objective(
                 params, data, labels, fast_f1_score, n_jobs, n_runs, n_folds, verbose
             )
             result = GPBenchmarker(config).fit()
-        except Exception:
+        except Exception:  # noqa BLE001
             logger.error(f"Trial {trial.number} failed: {traceback.format_exc()}")
             raise optuna.TrialPruned()
 
@@ -346,7 +346,7 @@ def main(args: argparse.Namespace) -> None:
         try:
             save_pmlb_data(data_path.stem, str(data_path.parent))
         except FileNotFoundError:
-            logging.error(f"Dataset {data_path.stem} not found in PMLB")
+            logger.error(f"Dataset {data_path.stem} not found in PMLB")
             traceback.print_exc()
             return
     data, labels = load_data(args.data_path)

--- a/scripts/plot_radar.py
+++ b/scripts/plot_radar.py
@@ -91,7 +91,7 @@ def plot_radar_performance(series, output_path):
     angles = np.linspace(0, 2 * np.pi, N, endpoint=False).tolist()
     angles_closed = angles + angles[:1]
 
-    fig, ax = plt.subplots(figsize=(14, 14), subplot_kw={"projection": "polar"})
+    _fig, ax = plt.subplots(figsize=(14, 14), subplot_kw={"projection": "polar"})
     ax.set_ylim(0, 1)
 
     for clf_name in clf_names:

--- a/scripts/preprocess/pmlb_preprocess.py
+++ b/scripts/preprocess/pmlb_preprocess.py
@@ -1,6 +1,5 @@
-import os
-
 import argparse
+import os
 
 
 def save_pmlb_data(name: str, data_path: str):

--- a/scripts/profile_trainer.py
+++ b/scripts/profile_trainer.py
@@ -21,11 +21,10 @@ Adjust population and feature sampling:
     python scripts/profile_trainer.py --data_path data/PaySim.hdf --max_depth 1 --num_child_populations 5 --feature_fraction 0.5
 """
 
-from prettytable import PrettyTable
 import argparse
 import gc
-from typing import Dict, Tuple
 
+from prettytable import PrettyTable
 from sklearn.model_selection import train_test_split
 from timed_decorator.builder import create_timed_decorator, get_timed_decorator
 
@@ -55,7 +54,7 @@ from hgp_lib.utils import ComplexityCheck
 from hgp_lib.utils.metrics import fast_f1_score
 
 
-def preprocess_data(data_path: str, num_bins: int = 5) -> Tuple:
+def preprocess_data(data_path: str, num_bins: int = 5) -> tuple:
     """
     Load and preprocess data for training.
 
@@ -134,7 +133,7 @@ def preprocess_data(data_path: str, num_bins: int = 5) -> Tuple:
     )
 
 
-def setup_timing() -> Dict:
+def setup_timing() -> dict:
     measurements = {}
     create_timed_decorator(
         "GPTimer",
@@ -214,7 +213,7 @@ def apply_timing_decorators() -> None:
     PopulationGenerator.generate = decorator(PopulationGenerator.generate)
 
 
-def print_timing_results(measurements: Dict, args: argparse.Namespace) -> None:
+def print_timing_results(measurements: dict, args: argparse.Namespace) -> None:
     print("\n" + "=" * 80)
     print("TIMING RESULTS")
     print("=" * 80)

--- a/scripts/run_on_pmlb.py
+++ b/scripts/run_on_pmlb.py
@@ -1,29 +1,26 @@
 import argparse
+import os
 import random
 import subprocess
 import sys
-import os
 from concurrent.futures import ProcessPoolExecutor
 from multiprocessing import freeze_support
 from time import sleep
 
-import pandas as pd
 import numpy as np
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.model_selection import train_test_split, StratifiedKFold
-from sklearn.metrics import f1_score
-
-from hgp_lib.preprocessing import load_data, StandardBinarizer
-from hgp_lib.benchmarkers import GPBenchmarker
-from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
-from hgp_lib.utils.metrics import fast_f1_score
+import pandas as pd
 from preprocess.pmlb_preprocess import save_pmlb_data
+from sklearn.compose import make_column_selector, make_column_transformer
+from sklearn.metrics import f1_score
+from sklearn.model_selection import StratifiedKFold, train_test_split
+from sklearn.preprocessing import KBinsDiscretizer, OneHotEncoder
+from sklearn.tree import DecisionTreeClassifier
 from tqdm.contrib.concurrent import process_map
 
-
-from sklearn.compose import make_column_transformer
-from sklearn.preprocessing import KBinsDiscretizer, OneHotEncoder
-from sklearn.compose import make_column_selector
+from hgp_lib.benchmarkers import GPBenchmarker
+from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
+from hgp_lib.preprocessing import StandardBinarizer, load_data
+from hgp_lib.utils.metrics import fast_f1_score
 
 
 def get_binary_classification_datasets():

--- a/scripts/run_on_pmlb.py
+++ b/scripts/run_on_pmlb.py
@@ -60,20 +60,20 @@ def run_sklearn_benchmark(
     n_runs: int = 30,
     n_folds: int = 5,
     data_dir: str = "data",
-    max_leaf_nodes: int = None,
+    max_leaf_nodes: int | None = None,
     binarizer_type: str = "standard",
 ) -> dict:
     data_path = f"{data_dir}/{dataset_name}.hdf"
     if not os.path.isfile(data_path):
         try:
             save_pmlb_data(dataset_name, data_dir)
-        except Exception as e:
+        except Exception as e:  # noqa BLE001
             print(f"Failed to load {dataset_name}: {e}")
             return None
 
     try:
         data, labels = load_data(data_path)
-    except Exception as e:
+    except Exception as e:  # noqa BLE001
         print(f"Failed to read {dataset_name}: {e}")
         return None
 
@@ -194,13 +194,13 @@ def run_gp_default_benchmark(
     if not os.path.isfile(data_path):
         try:
             save_pmlb_data(dataset_name, data_dir)
-        except Exception as e:
+        except Exception as e:  # noqa BLE001
             print(f"Failed to load {dataset_name}: {e}")
             return None
 
     try:
         data, labels = load_data(data_path)
-    except Exception as e:
+    except Exception as e:  # noqa BLE001
         print(f"Failed to read {dataset_name}: {e}")
         return None
 

--- a/scripts/visualization/optuna.py
+++ b/scripts/visualization/optuna.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import tempfile
+import traceback
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -136,8 +137,8 @@ def upload_trial_artifacts(
                     artifact_store=artifact_store,
                 )
 
-            except Exception as e:
+            except Exception as e:  # noqa BLE001
                 logger.warning(
-                    f"Trial {trial.number}: Failed to generate {plot_name}: {e}"
+                    f"Trial {trial.number}: Failed to generate {plot_name}: {e} - {traceback.format_exc()}"
                 )
                 continue

--- a/scripts/visualization/optuna.py
+++ b/scripts/visualization/optuna.py
@@ -1,22 +1,19 @@
 import logging
-
-import numpy as np
-import optuna
-
 import os
 import tempfile
 
 import matplotlib
-
 import matplotlib.pyplot as plt
-
+import numpy as np
+import optuna
 from optuna.artifacts import upload_artifact
 
 from hgp_lib.metrics.results import ExperimentResult
+
 from .plots import (
-    plot_experiment_boxplots,
-    plot_best_fold_generations,
     plot_all_folds_val_scores,
+    plot_best_fold_generations,
+    plot_experiment_boxplots,
     plot_population_bands,
 )
 

--- a/tests/test_binarizer.py
+++ b/tests/test_binarizer.py
@@ -406,6 +406,7 @@ class TestStandardBinarizer(unittest.TestCase):
 class TestSklearnBinarizer(unittest.TestCase):
     def test_transform_before_fit_raises(self):
         from sklearn.preprocessing import KBinsDiscretizer
+
         from hgp_lib.preprocessing import SklearnBinarizer
 
         b = SklearnBinarizer(
@@ -433,6 +434,7 @@ class TestSklearnBinarizer(unittest.TestCase):
 
     def test_get_feature_names_out_matches_columns(self):
         from sklearn.preprocessing import KBinsDiscretizer
+
         from hgp_lib.preprocessing import SklearnBinarizer
 
         b = SklearnBinarizer(
@@ -445,6 +447,7 @@ class TestSklearnBinarizer(unittest.TestCase):
 
     def test_get_feature_names_out_before_fit_raises(self):
         from sklearn.preprocessing import KBinsDiscretizer
+
         from hgp_lib.preprocessing import SklearnBinarizer
 
         b = SklearnBinarizer(

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -35,13 +35,13 @@ class TestBooleanGP(unittest.TestCase):
         self.score_fn = accuracy_score
 
     def _make_config(self, **kwargs):
-        defaults = dict(
-            score_fn=self.score_fn,
-            train_data=self.train_data,
-            train_labels=self.train_labels,
-            population_factory=PopulationGeneratorFactory(population_size=10),
-            optimize_scorer=False,
-        )
+        defaults = {
+            "score_fn": self.score_fn,
+            "train_data": self.train_data,
+            "train_labels": self.train_labels,
+            "population_factory": PopulationGeneratorFactory(population_size=10),
+            "optimize_scorer": False,
+        }
         defaults.update(kwargs)
         return BooleanGPConfig(**defaults)
 
@@ -49,37 +49,48 @@ class TestBooleanGP(unittest.TestCase):
     #  Validation
     # ------------------------------------------------------------------ #
     def test_boolean_gp_validation(self):
-        with self.subTest("score_fn must be callable"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(score_fn="not callable"))
+        with self.subTest("score_fn must be callable"), self.assertRaises(TypeError):
+            BooleanGP(self._make_config(score_fn="not callable"))
 
-        with self.subTest("population_factory must be PopulationGeneratorFactory"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(population_factory="not factory"))
+        with (
+            self.subTest("population_factory must be PopulationGeneratorFactory"),
+            self.assertRaises(TypeError),
+        ):
+            BooleanGP(self._make_config(population_factory="not factory"))
 
-        with self.subTest("mutation_factory must be MutationExecutorFactory"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(mutation_factory="not factory"))
+        with (
+            self.subTest("mutation_factory must be MutationExecutorFactory"),
+            self.assertRaises(TypeError),
+        ):
+            BooleanGP(self._make_config(mutation_factory="not factory"))
 
-        with self.subTest("crossover_executor must be CrossoverExecutor"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(crossover_executor="not executor"))
+        with (
+            self.subTest("crossover_executor must be CrossoverExecutor"),
+            self.assertRaises(TypeError),
+        ):
+            BooleanGP(self._make_config(crossover_executor="not executor"))
 
-        with self.subTest("selection must be BaseSelection"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(selection="not selection"))
+        with (
+            self.subTest("selection must be BaseSelection"),
+            self.assertRaises(TypeError),
+        ):
+            BooleanGP(self._make_config(selection="not selection"))
 
-        with self.subTest("regeneration must be bool"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(regeneration=1))
+        with self.subTest("regeneration must be bool"), self.assertRaises(TypeError):
+            BooleanGP(self._make_config(regeneration=1))
 
-        with self.subTest("regeneration_patience must be int"):
-            with self.assertRaises(TypeError):
-                BooleanGP(self._make_config(regeneration_patience=1.5))
+        with (
+            self.subTest("regeneration_patience must be int"),
+            self.assertRaises(TypeError),
+        ):
+            BooleanGP(self._make_config(regeneration_patience=1.5))
 
-        with self.subTest(
-            "regeneration_patience must be positive when regeneration=True"
-        ), self.assertRaises(ValueError):
+        with (
+            self.subTest(
+                "regeneration_patience must be positive when regeneration=True"
+            ),
+            self.assertRaises(ValueError),
+        ):
             BooleanGP(self._make_config(regeneration=True, regeneration_patience=0))
 
     # ------------------------------------------------------------------ #
@@ -401,13 +412,13 @@ class TestBooleanGP(unittest.TestCase):
     #  Hierarchical GP
     # ------------------------------------------------------------------ #
     def _make_hierarchical_config(self, **kwargs):
-        defaults = dict(
-            population_factory=PopulationGeneratorFactory(population_size=20),
-            max_depth=1,
-            num_child_populations=2,
-            sampling_strategy=FeatureSamplingStrategy(),
-            top_k_transfer=5,
-        )
+        defaults = {
+            "population_factory": PopulationGeneratorFactory(population_size=20),
+            "max_depth": 1,
+            "num_child_populations": 2,
+            "sampling_strategy": FeatureSamplingStrategy(),
+            "top_k_transfer": 5,
+        }
         defaults.update(kwargs)
         return self._make_config(**defaults)
 

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -1,16 +1,16 @@
-import unittest
 import random
-from typing import Sequence
+import unittest
+from collections.abc import Sequence
 
 import numpy as np
-from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 from hgp_lib.algorithms import BooleanGP
 from hgp_lib.configs import BooleanGPConfig
 from hgp_lib.crossover import CrossoverExecutor, CrossoverExecutorFactory
-from hgp_lib.populations import PopulationGeneratorFactory, FeatureSamplingStrategy
-from hgp_lib.rules import Rule, Literal
-from hgp_lib.selections import TournamentSelection, RouletteSelection
+from hgp_lib.populations import FeatureSamplingStrategy, PopulationGeneratorFactory
+from hgp_lib.rules import Literal, Rule
+from hgp_lib.selections import RouletteSelection, TournamentSelection
+from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 
 class TestBooleanGP(unittest.TestCase):
@@ -79,9 +79,8 @@ class TestBooleanGP(unittest.TestCase):
 
         with self.subTest(
             "regeneration_patience must be positive when regeneration=True"
-        ):
-            with self.assertRaises(ValueError):
-                BooleanGP(self._make_config(regeneration=True, regeneration_patience=0))
+        ), self.assertRaises(ValueError):
+            BooleanGP(self._make_config(regeneration=True, regeneration_patience=0))
 
     # ------------------------------------------------------------------ #
     #  Initialization

--- a/tests/test_boolean_rule_classifier.py
+++ b/tests/test_boolean_rule_classifier.py
@@ -5,10 +5,10 @@ import unittest
 import numpy as np
 import pandas as pd
 
+from hgp_lib import BooleanRuleClassifier
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.metrics import PopulationHistory
-from hgp_lib import BooleanRuleClassifier
-from hgp_lib.preprocessing import StandardBinarizer, SklearnBinarizer
+from hgp_lib.preprocessing import SklearnBinarizer, StandardBinarizer
 from hgp_lib.rules import Rule
 from hgp_lib.utils.metrics import fast_f1_score
 

--- a/tests/test_boolean_rule_classifier.py
+++ b/tests/test_boolean_rule_classifier.py
@@ -25,11 +25,11 @@ class TestBooleanRuleClassifier(unittest.TestCase):
         self.labels = rng.integers(0, 2, size=40)
 
     def _make_config(self, **kwargs):
-        defaults = dict(
-            gp_config=BooleanGPConfig(score_fn=fast_f1_score),
-            num_epochs=10,
-            progress_bar=False,
-        )
+        defaults = {
+            "gp_config": BooleanGPConfig(score_fn=fast_f1_score),
+            "num_epochs": 10,
+            "progress_bar": False,
+        }
         defaults.update(kwargs)
         return TrainerConfig(**defaults)
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -236,12 +236,12 @@ class TestBenchmarkerConfig(unittest.TestCase):
         self.trainer_config = TrainerConfig(gp_config=self.gp_config, num_epochs=5)
 
     def _make_config(self, **kwargs):
-        defaults = dict(
-            data=self.data,
-            labels=self.labels,
-            trainer_config=self.trainer_config,
-            n_folds=2,
-        )
+        defaults = {
+            "data": self.data,
+            "labels": self.labels,
+            "trainer_config": self.trainer_config,
+            "n_folds": 2,
+        }
         defaults.update(kwargs)
         return BenchmarkerConfig(**defaults)
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -4,7 +4,6 @@ import unittest
 
 import numpy as np
 import pandas as pd
-from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 from hgp_lib.configs import (
     BenchmarkerConfig,
@@ -19,6 +18,7 @@ from hgp_lib.mutations import MutationExecutorFactory
 from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.populations.sampling import FeatureSamplingStrategy
 from hgp_lib.preprocessing import StandardBinarizer
+from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 
 class TestBooleanGPConfig(unittest.TestCase):
@@ -331,8 +331,8 @@ class TestComplexityCheck(unittest.TestCase):
     """Tests for complexity_check helper function."""
 
     def test_complexity_check_accepts_small_rules(self):
+        from hgp_lib.rules import And, Literal, Or
         from hgp_lib.utils import ComplexityCheck
-        from hgp_lib.rules import Literal, And, Or
 
         check = ComplexityCheck(5)
         self.assertTrue(check(Literal(value=0)))  # len=1
@@ -342,8 +342,8 @@ class TestComplexityCheck(unittest.TestCase):
         )  # len=5
 
     def test_complexity_check_rejects_large_rules(self):
+        from hgp_lib.rules import And, Literal, Or
         from hgp_lib.utils import ComplexityCheck
-        from hgp_lib.rules import Literal, And, Or
 
         check = ComplexityCheck(3)
         self.assertFalse(

--- a/tests/test_crossover.py
+++ b/tests/test_crossover.py
@@ -1,17 +1,16 @@
-import unittest
 import random
+import unittest
 
 import numpy as np
 
 from hgp_lib.crossover import CrossoverExecutor, CrossoverExecutorFactory
-from hgp_lib.rules import Rule, Literal, And, Or
+from hgp_lib.rules import And, Literal, Or, Rule
 
 
 class TestCrossoverExecutor(unittest.TestCase):
     def test_crossover_executor_validation(self):
-        with self.subTest("crossover_p type"):
-            with self.assertRaises(TypeError):
-                CrossoverExecutorFactory(crossover_p=1)  # int instead of float
+        with self.subTest("crossover_p type"), self.assertRaises(TypeError):
+            CrossoverExecutorFactory(crossover_p=1)  # int instead of float
 
         with self.subTest("crossover_p bounds"):
             with self.assertRaises(ValueError):

--- a/tests/test_crossover.py
+++ b/tests/test_crossover.py
@@ -18,17 +18,17 @@ class TestCrossoverExecutor(unittest.TestCase):
             with self.assertRaises(ValueError):
                 CrossoverExecutorFactory(crossover_p=-0.1)
 
-        with self.subTest("crossover_strategy invalid"):
-            with self.assertRaises(ValueError):
-                CrossoverExecutorFactory(crossover_strategy="invalid")
+        with self.subTest("crossover_strategy invalid"), self.assertRaises(ValueError):
+            CrossoverExecutorFactory(crossover_strategy="invalid")
 
-        with self.subTest("num_tries requires check_valid"):
-            with self.assertRaises(ValueError):
-                CrossoverExecutorFactory(num_tries=2).create()
+        with (
+            self.subTest("num_tries requires check_valid"),
+            self.assertRaises(ValueError),
+        ):
+            CrossoverExecutorFactory(num_tries=2).create()
 
-        with self.subTest("num_tries must be positive"):
-            with self.assertRaises(ValueError):
-                CrossoverExecutorFactory(num_tries=0)
+        with self.subTest("num_tries must be positive"), self.assertRaises(ValueError):
+            CrossoverExecutorFactory(num_tries=0)
 
     def test_operator_p_validation(self):
         """Test that operator_p outside [0.0, 1.0] raises ValueError."""

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -1,13 +1,12 @@
 import io
 import queue
-import unittest
 import random
+import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from multiprocessing import Queue
 
 import numpy as np
 import pandas as pd
-from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.benchmarkers.runner import execute_single_run, single_run_wrapper
@@ -19,6 +18,7 @@ from hgp_lib.populations import PopulationGeneratorFactory
 from hgp_lib.preprocessing import StandardBinarizer
 from hgp_lib.rules import Rule
 from hgp_lib.selections import RouletteSelection
+from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 
 class TestGPBenchmarker(unittest.TestCase):
@@ -130,13 +130,11 @@ class TestGPBenchmarker(unittest.TestCase):
             with self.assertRaises(ValueError):
                 GPBenchmarker(self._make_config(n_folds=1))
 
-        with self.subTest("data must be 2D"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(data=pd.DataFrame(np.array([1, 2, 3]))))
+        with self.subTest("data must be 2D"), self.assertRaises(ValueError):
+            GPBenchmarker(self._make_config(data=pd.DataFrame(np.array([1, 2, 3]))))
 
-        with self.subTest("labels must be 1D"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(labels=np.array([[1, 0], [1, 0]])))
+        with self.subTest("labels must be 1D"), self.assertRaises(ValueError):
+            GPBenchmarker(self._make_config(labels=np.array([[1, 0], [1, 0]])))
 
         with self.subTest("population_factory type"):
             with self.assertRaises(TypeError):
@@ -158,15 +156,14 @@ class TestGPBenchmarker(unittest.TestCase):
                     )
                 )
 
-        with self.subTest("selection type"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(
-                    self._make_config(
-                        trainer_config=self._make_trainer_config(
-                            gp_config=self._make_gp_config(selection="bad")
-                        )
+        with self.subTest("selection type"), self.assertRaises(TypeError):
+            GPBenchmarker(
+                self._make_config(
+                    trainer_config=self._make_trainer_config(
+                        gp_config=self._make_gp_config(selection="bad")
                     )
                 )
+            )
 
     # ------------------------------------------------------------------ #
     #  Initialization

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -45,30 +45,33 @@ class TestGPBenchmarker(unittest.TestCase):
         self.score_fn = accuracy_score
 
     def _make_gp_config(self, **kwargs):
-        defaults = dict(score_fn=self.score_fn, optimize_scorer=False)
+        defaults = {"score_fn": self.score_fn, "optimize_scorer": False}
         defaults.update(kwargs)
         return BooleanGPConfig(**defaults)
 
     def _make_trainer_config(self, gp_config=None, **kwargs):
         if gp_config is None:
             gp_config = self._make_gp_config()
-        defaults = dict(
-            gp_config=gp_config, num_epochs=5, val_every=1, progress_bar=False
-        )
+        defaults = {
+            "gp_config": gp_config,
+            "num_epochs": 5,
+            "val_every": 1,
+            "progress_bar": False,
+        }
         defaults.update(kwargs)
         return TrainerConfig(**defaults)
 
     def _make_config(self, trainer_config=None, **kwargs):
         if trainer_config is None:
             trainer_config = self._make_trainer_config()
-        defaults = dict(
-            data=self.data,
-            labels=self.labels,
-            trainer_config=trainer_config,
-            num_runs=2,
-            n_folds=2,
-            n_jobs=1,
-        )
+        defaults = {
+            "data": self.data,
+            "labels": self.labels,
+            "trainer_config": trainer_config,
+            "num_runs": 2,
+            "n_folds": 2,
+            "n_jobs": 1,
+        }
         defaults.update(kwargs)
         return BenchmarkerConfig(**defaults)
 
@@ -76,59 +79,58 @@ class TestGPBenchmarker(unittest.TestCase):
     #  Validation
     # ------------------------------------------------------------------ #
     def test_benchmarker_validation(self):
-        with self.subTest("score_fn must be callable"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(
-                    self._make_config(
-                        trainer_config=self._make_trainer_config(
-                            gp_config=self._make_gp_config(score_fn="not callable")
-                        )
+        with self.subTest("score_fn must be callable"), self.assertRaises(TypeError):
+            GPBenchmarker(
+                self._make_config(
+                    trainer_config=self._make_trainer_config(
+                        gp_config=self._make_gp_config(score_fn="not callable")
                     )
                 )
+            )
 
-        with self.subTest("num_epochs must be int"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(
-                    self._make_config(
-                        trainer_config=self._make_trainer_config(num_epochs=5.0)
-                    )
+        with self.subTest("num_epochs must be int"), self.assertRaises(TypeError):
+            GPBenchmarker(
+                self._make_config(
+                    trainer_config=self._make_trainer_config(num_epochs=5.0)
                 )
+            )
 
-        with self.subTest("num_epochs must be positive"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(
-                    self._make_config(
-                        trainer_config=self._make_trainer_config(num_epochs=0)
-                    )
+        with self.subTest("num_epochs must be positive"), self.assertRaises(ValueError):
+            GPBenchmarker(
+                self._make_config(
+                    trainer_config=self._make_trainer_config(num_epochs=0)
                 )
+            )
 
-        with self.subTest("data must be a DataFrame"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(self._make_config(data="not a dataframe"))
+        with self.subTest("data must be a DataFrame"), self.assertRaises(TypeError):
+            GPBenchmarker(self._make_config(data="not a dataframe"))
 
-        with self.subTest("labels must be ndarray"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(self._make_config(labels="not array"))
+        with self.subTest("labels must be ndarray"), self.assertRaises(TypeError):
+            GPBenchmarker(self._make_config(labels="not array"))
 
-        with self.subTest("labels length must match data rows"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(labels=np.array([1, 0])))
+        with (
+            self.subTest("labels length must match data rows"),
+            self.assertRaises(ValueError),
+        ):
+            GPBenchmarker(self._make_config(labels=np.array([1, 0])))
 
-        with self.subTest("num_runs must be positive"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(num_runs=0))
+        with self.subTest("num_runs must be positive"), self.assertRaises(ValueError):
+            GPBenchmarker(self._make_config(num_runs=0))
 
-        with self.subTest("test_size must be in (0, 1) — low"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(test_size=0.0))
+        with (
+            self.subTest("test_size must be in (0, 1) — low"),
+            self.assertRaises(ValueError),
+        ):
+            GPBenchmarker(self._make_config(test_size=0.0))
 
-        with self.subTest("test_size must be in (0, 1) — high"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(test_size=1.0))
+        with (
+            self.subTest("test_size must be in (0, 1) — high"),
+            self.assertRaises(ValueError),
+        ):
+            GPBenchmarker(self._make_config(test_size=1.0))
 
-        with self.subTest("n_folds must be at least 2"):
-            with self.assertRaises(ValueError):
-                GPBenchmarker(self._make_config(n_folds=1))
+        with self.subTest("n_folds must be at least 2"), self.assertRaises(ValueError):
+            GPBenchmarker(self._make_config(n_folds=1))
 
         with self.subTest("data must be 2D"), self.assertRaises(ValueError):
             GPBenchmarker(self._make_config(data=pd.DataFrame(np.array([1, 2, 3]))))
@@ -136,25 +138,23 @@ class TestGPBenchmarker(unittest.TestCase):
         with self.subTest("labels must be 1D"), self.assertRaises(ValueError):
             GPBenchmarker(self._make_config(labels=np.array([[1, 0], [1, 0]])))
 
-        with self.subTest("population_factory type"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(
-                    self._make_config(
-                        trainer_config=self._make_trainer_config(
-                            gp_config=self._make_gp_config(population_factory="bad")
-                        )
+        with self.subTest("population_factory type"), self.assertRaises(TypeError):
+            GPBenchmarker(
+                self._make_config(
+                    trainer_config=self._make_trainer_config(
+                        gp_config=self._make_gp_config(population_factory="bad")
                     )
                 )
+            )
 
-        with self.subTest("mutation_factory type"):
-            with self.assertRaises(TypeError):
-                GPBenchmarker(
-                    self._make_config(
-                        trainer_config=self._make_trainer_config(
-                            gp_config=self._make_gp_config(mutation_factory="bad")
-                        )
+        with self.subTest("mutation_factory type"), self.assertRaises(TypeError):
+            GPBenchmarker(
+                self._make_config(
+                    trainer_config=self._make_trainer_config(
+                        gp_config=self._make_gp_config(mutation_factory="bad")
                     )
                 )
+            )
 
         with self.subTest("selection type"), self.assertRaises(TypeError):
             GPBenchmarker(
@@ -316,11 +316,11 @@ class TestGPBenchmarker(unittest.TestCase):
         self.assertTrue(len(readable) > 0)
 
     def test_reproducibility_with_seed(self):
-        cfg_kwargs = dict(
-            trainer_config=self._make_trainer_config(num_epochs=2),
-            n_jobs=1,
-            base_seed=12345,
-        )
+        cfg_kwargs = {
+            "trainer_config": self._make_trainer_config(num_epochs=2),
+            "n_jobs": 1,
+            "base_seed": 12345,
+        }
         r1 = GPBenchmarker(self._make_config(**cfg_kwargs)).fit()
         r2 = GPBenchmarker(self._make_config(**cfg_kwargs)).fit()
         self.assertEqual(

--- a/tests/test_gp_trainer.py
+++ b/tests/test_gp_trainer.py
@@ -1,16 +1,16 @@
-import unittest
 import random
+import unittest
 
 import numpy as np
-from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
-from hgp_lib.trainers import GPTrainer
 from hgp_lib.crossover import CrossoverExecutor, CrossoverExecutorFactory
-from hgp_lib.metrics import PopulationHistory, GenerationMetrics
+from hgp_lib.metrics import GenerationMetrics, PopulationHistory
 from hgp_lib.populations import PopulationGeneratorFactory
-from hgp_lib.selections import RouletteSelection, TournamentSelection
 from hgp_lib.rules import Rule
+from hgp_lib.selections import RouletteSelection, TournamentSelection
+from hgp_lib.trainers import GPTrainer
+from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 
 class TestGPTrainer(unittest.TestCase):

--- a/tests/test_gp_trainer.py
+++ b/tests/test_gp_trainer.py
@@ -38,79 +38,77 @@ class TestGPTrainer(unittest.TestCase):
         self.score_fn = accuracy_score
 
     def _make_gp_config(self, **kwargs):
-        defaults = dict(
-            score_fn=self.score_fn,
-            train_data=self.train_data,
-            train_labels=self.train_labels,
-            optimize_scorer=False,
-        )
+        defaults = {
+            "score_fn": self.score_fn,
+            "train_data": self.train_data,
+            "train_labels": self.train_labels,
+            "optimize_scorer": False,
+        }
         defaults.update(kwargs)
         return BooleanGPConfig(**defaults)
 
     def _make_trainer_config(self, gp_config=None, **kwargs):
         if gp_config is None:
             gp_config = self._make_gp_config()
-        defaults = dict(
-            gp_config=gp_config,
-            num_epochs=10,
-            progress_bar=False,
-        )
+        defaults = {
+            "gp_config": gp_config,
+            "num_epochs": 10,
+            "progress_bar": False,
+        }
         defaults.update(kwargs)
         return TrainerConfig(**defaults)
 
     def test_gp_trainer_validation(self):
-        with self.subTest("score_fn must be callable"):
-            with self.assertRaises(TypeError):
-                gp_config = self._make_gp_config(score_fn="not callable")
-                config = self._make_trainer_config(gp_config=gp_config)
-                GPTrainer(config)
+        with self.subTest("score_fn must be callable"), self.assertRaises(TypeError):
+            gp_config = self._make_gp_config(score_fn="not callable")
+            config = self._make_trainer_config(gp_config=gp_config)
+            GPTrainer(config)
 
-        with self.subTest("num_epochs must be int"):
-            with self.assertRaises(TypeError):
-                config = self._make_trainer_config(num_epochs=10.5)
-                GPTrainer(config)
+        with self.subTest("num_epochs must be int"), self.assertRaises(TypeError):
+            config = self._make_trainer_config(num_epochs=10.5)
+            GPTrainer(config)
 
-        with self.subTest("num_epochs must be positive"):
-            with self.assertRaises(ValueError):
-                config = self._make_trainer_config(num_epochs=0)
-                GPTrainer(config)
+        with self.subTest("num_epochs must be positive"), self.assertRaises(ValueError):
+            config = self._make_trainer_config(num_epochs=0)
+            GPTrainer(config)
 
-        with self.subTest("train_data must be ndarray"):
-            with self.assertRaises(TypeError):
-                gp_config = self._make_gp_config(train_data="not array")
-                config = self._make_trainer_config(gp_config=gp_config)
-                GPTrainer(config)
+        with self.subTest("train_data must be ndarray"), self.assertRaises(TypeError):
+            gp_config = self._make_gp_config(train_data="not array")
+            config = self._make_trainer_config(gp_config=gp_config)
+            GPTrainer(config)
 
-        with self.subTest("train_labels must be ndarray"):
-            with self.assertRaises(TypeError):
-                gp_config = self._make_gp_config(train_labels="not array")
-                config = self._make_trainer_config(gp_config=gp_config)
-                GPTrainer(config)
+        with self.subTest("train_labels must be ndarray"), self.assertRaises(TypeError):
+            gp_config = self._make_gp_config(train_labels="not array")
+            config = self._make_trainer_config(gp_config=gp_config)
+            GPTrainer(config)
 
-        with self.subTest("train_labels length must match train_data rows"):
-            with self.assertRaises(ValueError):
-                gp_config = self._make_gp_config(train_labels=np.array([1, 0]))
-                config = self._make_trainer_config(gp_config=gp_config)
-                GPTrainer(config)
+        with (
+            self.subTest("train_labels length must match train_data rows"),
+            self.assertRaises(ValueError),
+        ):
+            gp_config = self._make_gp_config(train_labels=np.array([1, 0]))
+            config = self._make_trainer_config(gp_config=gp_config)
+            GPTrainer(config)
 
-        with self.subTest("val_data and val_labels must both be provided or both None"):
-            with self.assertRaises(ValueError):
-                config = self._make_trainer_config(
-                    val_data=self.val_data, val_labels=None
-                )
-                GPTrainer(config)
+        with (
+            self.subTest("val_data and val_labels must both be provided or both None"),
+            self.assertRaises(ValueError),
+        ):
+            config = self._make_trainer_config(val_data=self.val_data, val_labels=None)
+            GPTrainer(config)
 
-        with self.subTest("val_labels length must match val_data rows"):
-            with self.assertRaises(ValueError):
-                config = self._make_trainer_config(
-                    val_data=self.val_data, val_labels=np.array([1])
-                )
-                GPTrainer(config)
+        with (
+            self.subTest("val_labels length must match val_data rows"),
+            self.assertRaises(ValueError),
+        ):
+            config = self._make_trainer_config(
+                val_data=self.val_data, val_labels=np.array([1])
+            )
+            GPTrainer(config)
 
-        with self.subTest("val_every must be positive"):
-            with self.assertRaises(ValueError):
-                config = self._make_trainer_config(val_every=0)
-                GPTrainer(config)
+        with self.subTest("val_every must be positive"), self.assertRaises(ValueError):
+            config = self._make_trainer_config(val_every=0)
+            GPTrainer(config)
 
     def test_gp_trainer_init(self):
         config = self._make_trainer_config()

--- a/tests/test_hierarchical_gp.py
+++ b/tests/test_hierarchical_gp.py
@@ -465,7 +465,7 @@ class TestBooleanGPSamplingIntegration(unittest.TestCase):
                 self.assertEqual(set(child.feature_mapping.keys()), expected_keys)
 
                 # All mapped values should be valid parent feature indices
-                for child_idx, parent_idx in child.feature_mapping.items():
+                for parent_idx in child.feature_mapping.values():
                     self.assertGreaterEqual(parent_idx, 0)
                     self.assertLess(parent_idx, num_features)
 

--- a/tests/test_hierarchical_gp.py
+++ b/tests/test_hierarchical_gp.py
@@ -3,15 +3,15 @@
 import unittest
 
 import numpy as np
-from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 from hgp_lib.algorithms import BooleanGP
 from hgp_lib.configs import BooleanGPConfig
 from hgp_lib.populations import (
+    CombinedSamplingStrategy,
     FeatureSamplingStrategy,
     InstanceSamplingStrategy,
-    CombinedSamplingStrategy,
 )
+from hgp_lib.utils.metrics import fast_accuracy_score as accuracy_score
 
 
 class TestSamplingStrategies(unittest.TestCase):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -22,13 +22,13 @@ class TestPopulationHistory(unittest.TestCase):
         return g
 
     def _make_history(self, generations=None, **kwargs):
-        defaults = dict(
-            global_best_rule=Literal(value=0),
-            tp=0,
-            fp=0,
-            fn=0,
-            tn=0,
-        )
+        defaults = {
+            "global_best_rule": Literal(value=0),
+            "tp": 0,
+            "fp": 0,
+            "fn": 0,
+            "tn": 0,
+        }
         defaults.update(kwargs)
         if generations is not None:
             defaults["generations"] = generations

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -3,8 +3,8 @@
 import unittest
 from dataclasses import replace
 
-from hgp_lib.metrics.history import PopulationHistory
 from hgp_lib.metrics.core import GenerationMetrics
+from hgp_lib.metrics.history import PopulationHistory
 from hgp_lib.rules import Literal
 
 

--- a/tests/test_literal_mutations.py
+++ b/tests/test_literal_mutations.py
@@ -6,12 +6,12 @@ import numpy as np
 
 from hgp_lib.mutations import (
     DeleteMutation,
-    NegateMutation,
-    ReplaceLiteral,
-    PromoteLiteral,
     MutationError,
+    NegateMutation,
+    PromoteLiteral,
+    ReplaceLiteral,
 )
-from hgp_lib.rules import Literal, And, Or
+from hgp_lib.rules import And, Literal, Or
 
 
 class TestDeleteMutation(unittest.TestCase):

--- a/tests/test_metrics_core.py
+++ b/tests/test_metrics_core.py
@@ -4,7 +4,7 @@ import unittest
 from dataclasses import replace
 
 from hgp_lib.metrics.core import GenerationMetrics
-from hgp_lib.rules import Literal, And
+from hgp_lib.rules import And, Literal
 
 
 class TestGenerationMetrics(unittest.TestCase):

--- a/tests/test_metrics_core.py
+++ b/tests/test_metrics_core.py
@@ -9,13 +9,13 @@ from hgp_lib.rules import And, Literal
 
 class TestGenerationMetrics(unittest.TestCase):
     def _make(self, **kwargs):
-        defaults = dict(
-            best_idx=0,
-            best_rule=Literal(value=0),
-            train_scores=[0.8],
-            complexities=[1],
-            child_population_generation_metrics=[],
-        )
+        defaults = {
+            "best_idx": 0,
+            "best_rule": Literal(value=0),
+            "train_scores": [0.8],
+            "complexities": [1],
+            "child_population_generation_metrics": [],
+        }
         defaults.update(kwargs)
         return GenerationMetrics.from_population(**defaults)
 

--- a/tests/test_mutation_executor.py
+++ b/tests/test_mutation_executor.py
@@ -3,8 +3,8 @@
 import unittest
 from unittest.mock import patch
 
-from hgp_lib.mutations import Mutation, MutationExecutor, NegateMutation, MutationError
-from hgp_lib.rules import Rule, Literal, And
+from hgp_lib.mutations import Mutation, MutationError, MutationExecutor, NegateMutation
+from hgp_lib.rules import And, Literal, Rule
 
 
 def _fake_select_first(rule, operator_p=0.9):

--- a/tests/test_mutation_factory.py
+++ b/tests/test_mutation_factory.py
@@ -78,7 +78,7 @@ class TestMutationExecutorFactory(unittest.TestCase):
     def test_literal_mutations_empty_raises(self):
         class Empty(MutationExecutorFactory):
             def create_literal_mutations(self, num_literals):
-                return tuple()
+                return ()
 
         with self.assertRaises(ValueError):
             Empty().create(5)
@@ -86,7 +86,7 @@ class TestMutationExecutorFactory(unittest.TestCase):
     def test_operator_mutations_empty_raises(self):
         class Empty(MutationExecutorFactory):
             def create_operator_mutations(self, num_literals):
-                return tuple()
+                return ()
 
         with self.assertRaises(ValueError):
             Empty().create(5)

--- a/tests/test_operator_mutations.py
+++ b/tests/test_operator_mutations.py
@@ -3,12 +3,12 @@
 import unittest
 
 from hgp_lib.mutations import (
-    RemoveIntermediateOperator,
-    ReplaceOperator,
     AddLiteral,
     MutationError,
+    RemoveIntermediateOperator,
+    ReplaceOperator,
 )
-from hgp_lib.rules import Literal, And, Or
+from hgp_lib.rules import And, Literal, Or
 
 
 class TestRemoveIntermediateOperator(unittest.TestCase):

--- a/tests/test_populations.py
+++ b/tests/test_populations.py
@@ -1,15 +1,16 @@
-import unittest
 import random
+import unittest
+
 import numpy as np
 
+from hgp_lib.mutations import MutationExecutorFactory
 from hgp_lib.populations import (
+    BestLiteralStrategy,
     PopulationGenerator,
     PopulationGeneratorFactory,
     RandomStrategy,
-    BestLiteralStrategy,
 )
-from hgp_lib.mutations import MutationExecutorFactory
-from hgp_lib.rules import And, Or, Literal
+from hgp_lib.rules import And, Literal, Or
 from hgp_lib.utils.metrics import fast_accuracy_score
 
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -3,10 +3,10 @@ import unittest
 from multiprocessing import Queue
 
 from hgp_lib.benchmarkers.progress import (
+    _SHUTDOWN_SENTINEL,
     ProgressConfig,
     ProgressListener,
     send_progress,
-    _SHUTDOWN_SENTINEL,
 )
 
 

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -46,7 +46,7 @@ class TestSendProgress(unittest.TestCase):
     def test_default_count(self):
         q = Queue()
         send_progress(q, "run")
-        msg, count = q.get(timeout=1)
+        _msg, count = q.get(timeout=1)
         self.assertEqual(count, 1)
 
     def test_multiple_messages(self):

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -33,14 +33,14 @@ class _Helpers:
             if train_score is not None:
                 g = replace(g, train_scores=[train_score])
             gens = [g]
-        defaults = dict(
-            global_best_rule=Literal(value=rule_value),
-            tp=3,
-            fp=1,
-            fn=2,
-            tn=4,
-            generations=gens,
-        )
+        defaults = {
+            "global_best_rule": Literal(value=rule_value),
+            "tp": 3,
+            "fp": 1,
+            "fn": 2,
+            "tn": 4,
+            "generations": gens,
+        }
         defaults.update(kwargs)
         return PopulationHistory(**defaults)
 
@@ -50,18 +50,18 @@ class _Helpers:
     ):
         if folds is None:
             folds = [_Helpers.make_fold()]
-        defaults = dict(
-            run_id=run_id,
-            seed=seed,
-            best_fold_idx=best_fold_idx,
-            folds=folds,
-            test_score=test_score,
-            test_tp=4,
-            test_fp=1,
-            test_fn=1,
-            test_tn=4,
-            feature_names=["col_a", "col_b"],
-        )
+        defaults = {
+            "run_id": run_id,
+            "seed": seed,
+            "best_fold_idx": best_fold_idx,
+            "folds": folds,
+            "test_score": test_score,
+            "test_tp": 4,
+            "test_fp": 1,
+            "test_fn": 1,
+            "test_tn": 4,
+            "feature_names": ["col_a", "col_b"],
+        }
         defaults.update(kwargs)
         return RunResult(**defaults)
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 
 from hgp_lib.metrics.core import GenerationMetrics
 from hgp_lib.metrics.history import PopulationHistory
-from hgp_lib.metrics.results import RunResult, ExperimentResult
+from hgp_lib.metrics.results import ExperimentResult, RunResult
 from hgp_lib.rules import Literal
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -2,11 +2,13 @@ import os
 import subprocess
 import sys
 import unittest
+
 import numpy as np
 
 from hgp_lib.rules import Literal
+from hgp_lib.rules.low_memory_operators import And as LowMemoryAnd
+from hgp_lib.rules.low_memory_operators import Or as LowMemoryOr
 from hgp_lib.rules.operators import And, Or
-from hgp_lib.rules.low_memory_operators import And as LowMemoryAnd, Or as LowMemoryOr
 
 
 class TestRules(unittest.TestCase):

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -232,6 +232,7 @@ class TestImports(unittest.TestCase):
             env=env,
             capture_output=True,
             text=True,
+            check=True,
         )
 
         self.assertEqual(

--- a/tests/test_rules_utils.py
+++ b/tests/test_rules_utils.py
@@ -3,13 +3,13 @@
 import random
 import unittest
 
-from hgp_lib.rules import Literal, And, Or
+from hgp_lib.rules import And, Literal, Or
 from hgp_lib.rules.utils import (
+    apply_feature_mapping,
+    deep_swap,
     is_operator,
     is_operator_type,
     replace_with_rule,
-    deep_swap,
-    apply_feature_mapping,
     select_crossover_point,
 )
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,12 +1,13 @@
 """Tests for sampling strategies."""
 
 import unittest
+
 import numpy as np
 
 from hgp_lib.populations.sampling import (
+    CombinedSamplingStrategy,
     FeatureSamplingStrategy,
     InstanceSamplingStrategy,
-    CombinedSamplingStrategy,
 )
 
 

--- a/tests/test_selections.py
+++ b/tests/test_selections.py
@@ -1,10 +1,10 @@
-import unittest
 import random
+import unittest
 
 import numpy as np
 
+from hgp_lib.rules import And, Literal, Or, Rule
 from hgp_lib.selections import BaseSelection, RouletteSelection, TournamentSelection
-from hgp_lib.rules import Rule, Literal, And, Or
 
 
 class TestBaseSelection(unittest.TestCase):

--- a/tests/test_utils_metrics.py
+++ b/tests/test_utils_metrics.py
@@ -128,28 +128,28 @@ class TestTransformDuplicates(unittest.TestCase):
     def test_removes_duplicates(self):
         data = np.array([[1, 0], [1, 0], [0, 1]])
         labels = np.array([1, 1, 0])
-        ud, ul, sw = transform_duplicates_to_sample_weight(data, labels)
+        ud, _ul, sw = transform_duplicates_to_sample_weight(data, labels)
         self.assertLess(len(ud), len(data))
         self.assertEqual(sw.sum(), len(data))
 
     def test_no_duplicates(self):
         data = np.array([[1, 0], [0, 1]])
         labels = np.array([1, 0])
-        ud, ul, sw = transform_duplicates_to_sample_weight(data, labels)
+        ud, _ul, sw = transform_duplicates_to_sample_weight(data, labels)
         self.assertEqual(len(ud), 2)
         np.testing.assert_array_equal(sw, [1, 1])
 
     def test_all_same(self):
         data = np.array([[1, 1], [1, 1], [1, 1]])
         labels = np.array([0, 0, 0])
-        ud, ul, sw = transform_duplicates_to_sample_weight(data, labels)
+        ud, _ul, sw = transform_duplicates_to_sample_weight(data, labels)
         self.assertEqual(len(ud), 1)
         self.assertEqual(sw[0], 3)
 
     def test_labels_preserved(self):
         data = np.array([[1, 0], [1, 0], [0, 1]])
         labels = np.array([1, 1, 0])
-        ud, ul, sw = transform_duplicates_to_sample_weight(data, labels)
+        ud, _ul, _sw = transform_duplicates_to_sample_weight(data, labels)
         # Each unique (data, label) pair should appear
         self.assertEqual(len(ud), 2)
 
@@ -164,7 +164,7 @@ class TestOptimizeScorersForData(unittest.TestCase):
     def test_optimizes_when_sw_supported(self):
         data = np.array([[1, 0], [1, 0], [0, 1]])
         labels = np.array([1, 1, 0])
-        opt_scorer, opt_data, opt_labels = optimize_scorers_for_data(
+        _opt_scorer, opt_data, _opt_labels = optimize_scorers_for_data(
             self._scorer_with_sw,
             data=data,
             labels=labels,
@@ -176,7 +176,7 @@ class TestOptimizeScorersForData(unittest.TestCase):
         labels = np.array([1, 1, 0])
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            opt_scorer, opt_data, opt_labels = optimize_scorers_for_data(
+            _opt_scorer, opt_data, _opt_labels = optimize_scorers_for_data(
                 self._scorer_without_sw,
                 data=data,
                 labels=labels,
@@ -201,7 +201,7 @@ class TestOptimizeScorersForData(unittest.TestCase):
     def test_multiple_scorers(self):
         data = np.array([[1, 0], [0, 1]])
         labels = np.array([1, 0])
-        s1, s2, opt_data, opt_labels = optimize_scorers_for_data(
+        s1, s2, _opt_data, _opt_labels = optimize_scorers_for_data(
             self._scorer_with_sw,
             self._scorer_with_sw,
             data=data,

--- a/tests/test_utils_metrics.py
+++ b/tests/test_utils_metrics.py
@@ -8,11 +8,11 @@ import numpy as np
 
 import hgp_lib.utils.metrics
 from hgp_lib.utils.metrics import (
+    accepts_sample_weight,
     confusion_matrix,
     fast_f1_score,
-    accepts_sample_weight,
-    transform_duplicates_to_sample_weight,
     optimize_scorers_for_data,
+    transform_duplicates_to_sample_weight,
 )
 
 

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -5,14 +5,14 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from hgp_lib.rules import Literal, And, Or
+from hgp_lib.rules import And, Literal, Or
 from hgp_lib.utils.validation import (
     ComplexityCheck,
-    validate_callable,
     check_isinstance,
+    check_X_y,
+    validate_callable,
     validate_num_literals,
     validate_operator_types,
-    check_X_y,
 )
 
 


### PR DESCRIPTION
* Renouncing the usage of the `typing` module.
* Sorted imports and `__all__`.
* Removed strict dependency on ruff `0.15.22`. Fixes #101.
* Ignoring the docs folder when applying ruff format and checks.
* Renouncing to make the "multiprocessing.Queue" type annotation to work.