### PR TITLE
Replaced `send_progress` and `ProgressSender` with a single `ProgressReporter`

### DIFF
--- a/docs/api/benchmarkers.md
+++ b/docs/api/benchmarkers.md
@@ -6,4 +6,6 @@
 
 ::: hgp_lib.benchmarkers.progress.ProgressListener
 
-::: hgp_lib.benchmarkers.progress.send_progress
+::: hgp_lib.benchmarkers.progress.ProgressReporter
+
+::: hgp_lib.benchmarkers.progress.ProgressChannel

--- a/hgp_lib/benchmarkers/gp_benchmarker.py
+++ b/hgp_lib/benchmarkers/gp_benchmarker.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 from ..configs import BenchmarkerConfig, validate_benchmarker_config
 from ..metrics import ExperimentResult, RunResult
 from ..preprocessing import StandardBinarizer
-from .progress import ProgressConfig, ProgressListener
+from .progress import ProgressConfig, ProgressListener, ProgressReporter
 from .runner import execute_single_run, single_run_wrapper
 
 
@@ -158,16 +158,17 @@ class GPBenchmarker:
 
         # LIFO cleanup: pool first (so workers stop emitting progress), then the listener, then the manager
         with contextlib.ExitStack() as stack:
-            queue = None
+            reporter = ProgressReporter()
             if any_progress:
                 manager = stack.enter_context(multiprocessing.Manager())
                 queue = manager.Queue()
+                reporter = ProgressReporter(queue)
                 listener = ProgressListener(queue, progress_config)
                 listener.start()
                 stack.callback(listener.stop)
 
             run_args = [
-                (run_id, self.config.base_seed + run_id, self.config, queue)
+                (run_id, self.config.base_seed + run_id, self.config, reporter)
                 for run_id in range(self.config.num_runs)
             ]
 

--- a/hgp_lib/benchmarkers/progress.py
+++ b/hgp_lib/benchmarkers/progress.py
@@ -7,6 +7,7 @@ a multiprocessing queue.
 """
 
 import threading
+from enum import Enum
 from multiprocessing import Queue
 from queue import Empty
 from typing import NamedTuple
@@ -18,6 +19,23 @@ _SHUTDOWN_SENTINEL = ("__shutdown__", 0)
 
 # Timeout for queue.get() to allow periodic liveness checks
 _QUEUE_TIMEOUT_SECONDS = 5.0
+
+
+class ProgressChannel(str, Enum):
+    """
+    The nesting levels a worker can report progress on.
+
+    Each member's value is the literal that travels over the queue.
+
+    Examples:
+        >>> from hgp_lib.benchmarkers.progress import ProgressChannel
+        >>> ProgressChannel.FOLD.value
+        'fold'
+    """
+
+    EPOCH = "epoch"
+    FOLD = "fold"
+    RUN = "run"
 
 
 class ProgressConfig(NamedTuple):
@@ -100,10 +118,9 @@ class ProgressListener:
         """
         Main listener loop. Uses timeout to allow periodic stop checks.
 
-        Expected message format: (msg_type, count)
-        - ("epoch", n): Update epoch bar by n
-        - ("fold", n): Update fold bar by n
-        - ("run", n): Update run bar by n
+        Expected message format: ``(channel, count)``, where ``channel`` is a
+        :class:`ProgressChannel` value. The matching bar advances by ``count``.
+        Unknown channels are ignored.
         """
         # Initialize progress bars (position=0 is bottom, position=2 is top)
         self._pbar_exp = tqdm(
@@ -128,6 +145,12 @@ class ProgressListener:
             disable=not self.config.show_epoch_progress,
         )
 
+        bars = {
+            ProgressChannel.EPOCH.value: self._pbar_epoch,
+            ProgressChannel.FOLD.value: self._pbar_fold,
+            ProgressChannel.RUN.value: self._pbar_exp,
+        }
+
         finished_runs = 0
 
         try:
@@ -146,12 +169,12 @@ class ProgressListener:
                 if msg == _SHUTDOWN_SENTINEL[0]:
                     break
 
-                if msg == "epoch":
-                    self._pbar_epoch.update(count)
-                elif msg == "fold":
-                    self._pbar_fold.update(count)
-                elif msg == "run":
-                    self._pbar_exp.update(count)
+                pbar = bars.get(msg)
+                if pbar is None:
+                    continue  # Unknown channel
+
+                pbar.update(count)
+                if msg == ProgressChannel.RUN.value:
                     finished_runs += count
         finally:
             # Ensure bars are closed properly
@@ -163,41 +186,64 @@ class ProgressListener:
                 self._pbar_exp.close()
 
 
-# "Queue | None" because type[Queue] is <method>..
-def send_progress(
-    progress_queue: "Queue | None", msg_type: str, count: int = 1
-) -> None:
+class ProgressReporter:
     """
-    Send a progress update to the listener queue.
+    Producer-side handle for reporting progress, one method per channel.
 
-    This is a safe helper that no-ops if the queue is ``None`` (sequential mode).
+    Wraps the queue that :class:`ProgressListener` consumes. A reporter built
+    without a queue is inert and discards every update.
+
+    Every method has the shape ``Callable[[int], None]``, so a bound method such
+    as ``reporter.epoch`` can be passed as ``TrainerConfig.progress_callback``.
 
     Args:
         progress_queue (Queue | None):
-            Multiprocessing queue or ``None`` for sequential mode.
-        msg_type (str):
-            Type of progress (``"epoch"``, ``"fold"``, or ``"run"``).
-        count (int):
-            Number to increment by. Default: `1`.
+            Queue to publish updates on, or ``None`` for an inert reporter.
+            Default: `None`.
 
     Examples:
-        >>> from hgp_lib.benchmarkers.progress import send_progress
-        >>> send_progress(None, "epoch", 5)  # no-op when queue is None
         >>> from multiprocessing import Queue
-        >>> q = Queue()
-        >>> send_progress(q, "fold", 1)
-        >>> q.get()
+        >>> from hgp_lib.benchmarkers.progress import ProgressReporter
+        >>> reporter = ProgressReporter(Queue())
+        >>> reporter.enabled
+        True
+        >>> reporter.fold()
+        >>> reporter.queue.get()
         ('fold', 1)
+        >>> reporter.epoch(10)
+        >>> reporter.queue.get()
+        ('epoch', 10)
+
+        An inert reporter accepts the same calls and discards them:
+
+        >>> inert = ProgressReporter()
+        >>> inert.enabled
+        False
+        >>> inert.run(5)
     """
-    if progress_queue is not None:
-        progress_queue.put((msg_type, count))
 
+    # "Queue | None" because type[Queue] is <method>..
+    def __init__(self, progress_queue: "Queue | None" = None):
+        self.queue = progress_queue
 
-class ProgressSender:
-    # TODO: Join Progress Sender with send_progress and keep only ProgressSender
-    def __init__(self, progress_queue: "Queue | None", msg_type: str):
-        self.progress_queue = progress_queue
-        self.msg_type = msg_type
+    @property
+    def enabled(self) -> bool:
+        """bool: Whether updates are published rather than discarded."""
+        return self.queue is not None
 
-    def __call__(self, count: int) -> None:
-        send_progress(self.progress_queue, self.msg_type, count)
+    def epoch(self, count: int = 1) -> None:
+        """Report ``count`` completed epochs. Default: `1`."""
+        self._send(ProgressChannel.EPOCH, count)
+
+    def fold(self, count: int = 1) -> None:
+        """Report ``count`` completed folds. Default: `1`."""
+        self._send(ProgressChannel.FOLD, count)
+
+    def run(self, count: int = 1) -> None:
+        """Report ``count`` completed runs. Default: `1`."""
+        self._send(ProgressChannel.RUN, count)
+
+    def _send(self, channel: ProgressChannel, count: int) -> None:
+        """Publish ``(channel, count)`` unless this reporter is inert."""
+        if self.queue is not None:
+            self.queue.put((channel.value, count))

--- a/hgp_lib/benchmarkers/runner.py
+++ b/hgp_lib/benchmarkers/runner.py
@@ -1,7 +1,6 @@
 import random
 from copy import deepcopy
 from dataclasses import replace
-from multiprocessing import Queue
 
 import numpy as np
 from sklearn.model_selection import StratifiedKFold, train_test_split
@@ -11,15 +10,14 @@ from ..configs import BenchmarkerConfig
 from ..metrics import PopulationHistory, RunResult
 from ..trainers import GPTrainer
 from ..utils.metrics import confusion_matrix, optimize_scorers_for_data
-from .progress import ProgressSender, send_progress
+from .progress import ProgressReporter
 
 
-# "Queue | None" because type[Queue] is <method>..
 def execute_single_run(
     run_id: int,
     seed: int,
     config: BenchmarkerConfig,
-    progress_queue: "Queue | None" = None,
+    reporter: ProgressReporter | None = None,
 ) -> RunResult:
     """
     Execute one benchmark run: stratified train/test split, per-fold binarization,
@@ -37,7 +35,8 @@ def execute_single_run(
         run_id (int): Index of the run (0-based).
         seed (int): Random seed for stratified split and k-fold.
         config (BenchmarkerConfig): Configuration for the benchmark run.
-        progress_queue (Queue | None): Optional queue for sending progress updates.
+        reporter (ProgressReporter | None): Where to report epoch/fold/run
+            progress. Default: an inert reporter that discards updates.
 
     Returns:
         RunResult: Contains run_id, seed, folds, test_score, best_rule, feature_names.
@@ -48,13 +47,13 @@ def execute_single_run(
     trainer_template = config.trainer_config
     gp_template = trainer_template.gp_config
 
-    use_queue = progress_queue is not None
-    show_folds = (
-        config.show_fold_progress and trainer_template.progress_bar and not use_queue
-    )
-    show_epochs = (
-        config.show_epoch_progress and trainer_template.progress_bar and not use_queue
-    )
+    if reporter is None:
+        reporter = ProgressReporter()
+
+    # Local bars would collide with the centralized ones the listener draws.
+    show_local_bars = trainer_template.progress_bar and not reporter.enabled
+    show_folds = config.show_fold_progress and show_local_bars
+    show_epochs = config.show_epoch_progress and show_local_bars
     config.binarizer.progress_bar = show_epochs
 
     np.random.seed(seed)
@@ -78,7 +77,7 @@ def execute_single_run(
     if show_folds:
         fold_splits = tqdm(fold_splits, total=config.n_folds, desc="Folds", leave=False)
 
-    epoch_callback = ProgressSender(progress_queue, "epoch") if use_queue else None
+    epoch_callback = reporter.epoch if reporter.enabled else None
 
     best_fold_idx = 0
     best_fold_score = -float("inf")
@@ -124,7 +123,7 @@ def execute_single_run(
 
         folds.append(history)
 
-        send_progress(progress_queue, "fold", 1)
+        reporter.fold()
 
     del train_data, train_labels
 
@@ -149,7 +148,7 @@ def execute_single_run(
 
     tp, fp, fn, tn = test_cm(test_labels, test_pred)
 
-    send_progress(progress_queue, "run", 1)
+    reporter.run()
 
     return RunResult(
         run_id=run_id,
@@ -167,16 +166,16 @@ def execute_single_run(
 
 
 def single_run_wrapper(
-    args: tuple[int, int, BenchmarkerConfig, "Queue | None"],
+    args: tuple[int, int, BenchmarkerConfig, ProgressReporter | None],
 ) -> RunResult:
     """
     Picklable wrapper for multiprocessing Pool.
 
     Args:
-        args (tuple): Tuple of (run_id, seed, config, progress_queue).
+        args (tuple): Tuple of (run_id, seed, config, reporter).
 
     Returns:
         RunResult: Result for the run.
     """
-    run_id, seed, config, progress_queue = args
-    return execute_single_run(run_id, seed, config, progress_queue)
+    run_id, seed, config, reporter = args
+    return execute_single_run(run_id, seed, config, reporter)

--- a/hgp_lib/populations/sampling.py
+++ b/hgp_lib/populations/sampling.py
@@ -125,7 +125,7 @@ class SamplingStrategy(ABC):
             data=data,
             labels=labels,
             feature_mapping=feature_mapping,
-            # TODO: Remove feature indices and also update tests
+            # TODO: (1) Remove feature indices and also update tests
             feature_indices=feature_indices,
             instance_indices=instance_indices,
         )

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -262,7 +262,7 @@ class StandardBinarizer(Binarizer):
         if not self._is_fitted:
             raise ValueError("Binarizer must be fitted before calling transform")
         if not self._original_columns.equals(X.columns):
-            # TODO: We should add custom Errors in the library where it makes sense.;
+            # TODO: (1) We should add custom Errors in the library where it makes sense.;
             raise RuntimeError(
                 f"Original columns do not match current columns. "
                 f"Original columns: {self._original_columns}. Current columns: {X.columns}."
@@ -310,7 +310,7 @@ class StandardBinarizer(Binarizer):
         nan_mask: np.ndarray,
     ):
         """Dispatch a single column to the matching dtype hook and record its dtype."""
-        # TODO: Instead of string values, we should have an enum. And an enum-like dispatch.
+        # TODO: (1) Instead of string values, we should have an enum. And an enum-like dispatch.
         if is_bool_dtype(series):
             self._original_column_dtypes[column] = "bool"
             return self._fit_boolean(column, series)

--- a/hgp_lib/preprocessing/utils.py
+++ b/hgp_lib/preprocessing/utils.py
@@ -80,7 +80,7 @@ def load_data(data_path: str) -> tuple[pd.DataFrame, ndarray]:
         raise FileNotFoundError(f"Data file not found: {data_path}")
 
     logging.getLogger(__name__).info(f"Loading data from {data_path}...")
-    # TODO: Create a unified logging system
+    # TODO: (1) Create a unified logging system
 
     if path.suffix == ".hdf":
         df: pd.DataFrame = pd.read_hdf(data_path)

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 from hgp_lib.benchmarkers import GPBenchmarker
+from hgp_lib.benchmarkers.progress import ProgressReporter
 from hgp_lib.benchmarkers.runner import execute_single_run, single_run_wrapper
 from hgp_lib.configs import BenchmarkerConfig, BooleanGPConfig, TrainerConfig
 from hgp_lib.crossover import CrossoverExecutorFactory
@@ -483,15 +484,17 @@ class TestGPBenchmarker(unittest.TestCase):
         self.assertEqual(len(run.folds), 2)
         self.assertIsInstance(run.best_rule, Rule)
 
-    def test_execute_single_run_with_progress_queue(self):
-        """execute_single_run should send epoch/fold/run messages to the queue."""
+    def test_execute_single_run_with_reporter(self):
+        """execute_single_run should report epoch/fold/run progress to the queue."""
         config = self._make_config(
             num_runs=1,
             trainer_config=self._make_trainer_config(num_epochs=2, progress_bar=True),
         )
         config.binarizer = StandardBinarizer()
         q = Queue()
-        run = execute_single_run(run_id=0, seed=42, config=config, progress_queue=q)
+        run = execute_single_run(
+            run_id=0, seed=42, config=config, reporter=ProgressReporter(q)
+        )
         self.assertIsInstance(run, RunResult)
 
         # Drain the queue using get(timeout) to avoid the race where the

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -4,9 +4,10 @@ from multiprocessing import Queue
 
 from hgp_lib.benchmarkers.progress import (
     _SHUTDOWN_SENTINEL,
+    ProgressChannel,
     ProgressConfig,
     ProgressListener,
-    send_progress,
+    ProgressReporter,
 )
 
 
@@ -31,31 +32,59 @@ class TestProgressConfig(unittest.TestCase):
         self.assertFalse(cfg.show_epoch_progress)
 
 
-class TestSendProgress(unittest.TestCase):
-    def test_none_queue_is_noop(self):
+class TestProgressChannel(unittest.TestCase):
+    def test_values_are_the_wire_literals(self):
+        self.assertEqual(ProgressChannel.EPOCH.value, "epoch")
+        self.assertEqual(ProgressChannel.FOLD.value, "fold")
+        self.assertEqual(ProgressChannel.RUN.value, "run")
+
+
+class TestProgressReporter(unittest.TestCase):
+    def test_without_queue_is_inert(self):
+        reporter = ProgressReporter()
+        self.assertFalse(reporter.enabled)
         # Should not raise
-        send_progress(None, "epoch", 5)
+        reporter.epoch(5)
+        reporter.fold()
+        reporter.run()
+
+    def test_with_queue_is_enabled(self):
+        self.assertTrue(ProgressReporter(Queue()).enabled)
 
     def test_sends_to_queue(self):
-        q = Queue()
-        send_progress(q, "fold", 3)
-        msg, count = q.get(timeout=1)
+        reporter = ProgressReporter(Queue())
+        reporter.fold(3)
+        msg, count = reporter.queue.get(timeout=1)
         self.assertEqual(msg, "fold")
         self.assertEqual(count, 3)
 
     def test_default_count(self):
-        q = Queue()
-        send_progress(q, "run")
-        _msg, count = q.get(timeout=1)
+        reporter = ProgressReporter(Queue())
+        reporter.run()
+        _msg, count = reporter.queue.get(timeout=1)
         self.assertEqual(count, 1)
 
+    def test_channels_travel_as_plain_strings(self):
+        """The listener matches on str, so messages must not carry enum members."""
+        reporter = ProgressReporter(Queue())
+        reporter.epoch()
+        msg, _count = reporter.queue.get(timeout=1)
+        self.assertIs(type(msg), str)
+
     def test_multiple_messages(self):
-        q = Queue()
-        send_progress(q, "epoch", 10)
-        send_progress(q, "fold", 1)
-        send_progress(q, "run", 1)
-        msgs = [q.get(timeout=1) for _ in range(3)]
+        reporter = ProgressReporter(Queue())
+        reporter.epoch(10)
+        reporter.fold()
+        reporter.run()
+        msgs = [reporter.queue.get(timeout=1) for _ in range(3)]
         self.assertEqual(msgs, [("epoch", 10), ("fold", 1), ("run", 1)])
+
+    def test_methods_are_usable_as_callbacks(self):
+        """Bound methods match the Callable[[int], None] progress_callback shape."""
+        reporter = ProgressReporter(Queue())
+        callback = reporter.epoch
+        callback(7)
+        self.assertEqual(reporter.queue.get(timeout=1), ("epoch", 7))
 
 
 class TestProgressListener(unittest.TestCase):
@@ -98,6 +127,18 @@ class TestProgressListener(unittest.TestCase):
         q.put(("fold", 1))
         q.put(("fold", 1))
         q.put(("run", 1))
+        listener.join()
+        self.assertFalse(listener._thread.is_alive())
+
+    def test_reporter_drives_listener(self):
+        """Messages produced by a reporter are understood by the listener."""
+        q = Queue()
+        listener = ProgressListener(q, self._make_config(runs=1, folds=1, epochs=1))
+        listener.start()
+        reporter = ProgressReporter(q)
+        reporter.epoch()
+        reporter.fold()
+        reporter.run()
         listener.join()
         self.assertFalse(listener._thread.is_alive())
 


### PR DESCRIPTION
* Added a `ProgressChannel` enum so the queue message literals are defined once and shared between the producer and the listener.
* `ProgressReporter` exposes one method per channel and is inert when built without a queue, removing the `None` checks from every call site. Its bound methods are passed directly as `progress_callback`.
* `execute_single_run` and `single_run_wrapper` now take a reporter instead of a raw queue, decoupling the runner from the transport.
* Simplified the local `tqdm` bar flags in `execute_single_run` and replaced the listener's `if/elif` dispatch with a channel lookup.
* Updated tests and API docs.