### PR TITLE
Removed the unused index fields from `SamplingResult`

### DIFF
--- a/hgp_lib/populations/sampling.py
+++ b/hgp_lib/populations/sampling.py
@@ -16,19 +16,15 @@ from hgp_lib.utils.validation import check_isinstance
 
 @dataclass
 class SamplingResult:
-    """Result of a sampling operation containing sampled data and index mappings.
+    """Result of a sampling operation containing sampled data and the feature mapping.
 
     Attributes:
         data: Sampled training data as 2D boolean ndarray (instances x features).
         labels: Sampled labels as 1D integer ndarray.
-        feature_indices: Selected feature indices from the parent's feature space as 1D ndarray.
-            For example, if the parent has 20 features and we sample [3, 7, 12], the child's
-            feature 0 corresponds to parent's feature 3, feature 1 to parent's 7, etc.
-        instance_indices: Selected instance indices as 1D ndarray, or None for feature-only sampling.
         feature_mapping: Dictionary mapping child feature indices to parent feature indices.
             Direction: child_index -> parent_index.
 
-            For example, if feature_indices is [3, 7, 12], then feature_mapping is:
+            For example, if the sampled features are [3, 7, 12], then feature_mapping is:
                 {0: 3, 1: 7, 2: 12}
 
             This mapping is used during crossover to translate rules evolved in the child's
@@ -41,8 +37,6 @@ class SamplingResult:
 
     data: ndarray
     labels: ndarray
-    feature_indices: ndarray
-    instance_indices: ndarray | None
     feature_mapping: dict[int, int] | None
 
 
@@ -113,6 +107,18 @@ class SamplingStrategy(ABC):
     def create_sampling_result(
         data, labels, feature_indices: ndarray | None, instance_indices: ndarray | None
     ):
+        """Slice `data` and `labels` by the given indices and build the result.
+
+        Args:
+            data: Parent training data as 2D boolean array (instances x features).
+            labels: Parent training labels as 1D integer array.
+            feature_indices: Feature columns to keep, or None to keep all features.
+            instance_indices: Instance rows to keep, or None to keep all instances.
+
+        Returns:
+            SamplingResult: The sampled data and labels, with `feature_mapping` set
+                from `feature_indices` (None when no features were sampled).
+        """
         if instance_indices is not None:
             data = data[instance_indices]
             labels = labels[instance_indices]
@@ -125,9 +131,6 @@ class SamplingStrategy(ABC):
             data=data,
             labels=labels,
             feature_mapping=feature_mapping,
-            # TODO: (1) Remove feature indices and also update tests
-            feature_indices=feature_indices,
-            instance_indices=instance_indices,
         )
 
     @abstractmethod
@@ -178,8 +181,10 @@ class FeatureSamplingStrategy(SamplingStrategy):
         >>> results = strategy.sample(data, labels, num_children=3)
         >>> len(results)
         3
-        >>> len(results[0].feature_indices)
-        5
+        >>> results[0].data.shape
+        (100, 5)
+        >>> results[0].feature_mapping.keys()
+        dict_keys([0, 1, 2, 3, 4])
     """
 
     def __init__(self, feature_fraction: float = 1.0, replace: bool = False):
@@ -200,7 +205,7 @@ class FeatureSamplingStrategy(SamplingStrategy):
 
         Returns:
             List of SamplingResult, one per child, with sampled feature columns,
-            all instances preserved, and instance_indices set to None.
+            all instances preserved, and feature_mapping set.
         """
         num_features = data.shape[1]
         features_per_child = ceil(num_features * self.feature_fraction)
@@ -242,8 +247,10 @@ class InstanceSamplingStrategy(SamplingStrategy):
         >>> results = strategy.sample(data, labels, num_children=3)
         >>> len(results)
         3
-        >>> len(results[0].instance_indices)
-        80
+        >>> results[0].data.shape
+        (80, 10)
+        >>> results[0].feature_mapping is None
+        True
     """
 
     def __init__(self, sample_fraction: float = 1.0, replace: bool = False):
@@ -339,7 +346,7 @@ class CombinedSamplingStrategy(SamplingStrategy):
 
         Returns:
             List of SamplingResult, one per child, with both feature and instance
-            subsets applied, containing both feature_indices and instance_indices.
+            subsets applied and feature_mapping set.
         """
         num_instances, num_features = data.shape
         samples_per_child = ceil(num_instances * self.sample_fraction)

--- a/tests/test_hierarchical_gp.py
+++ b/tests/test_hierarchical_gp.py
@@ -31,9 +31,8 @@ class TestSamplingStrategies(unittest.TestCase):
 
         # ceil(20 * 0.25) = 5 features per child
         result = results[0]
-        self.assertEqual(len(result.feature_indices), 5)
         self.assertEqual(result.data.shape, (100, 5))
-        self.assertIsNone(result.instance_indices)
+        self.assertEqual(len(result.feature_mapping), 5)
         np.testing.assert_array_equal(result.labels, self.labels)
 
     def test_feature_sampling_with_fraction(self):
@@ -44,7 +43,8 @@ class TestSamplingStrategies(unittest.TestCase):
         self.assertEqual(len(results), 4)
 
         # ceil(20 * 0.5) = 10 features per child
-        self.assertEqual(len(results[0].feature_indices), 10)
+        self.assertEqual(results[0].data.shape, (100, 10))
+        self.assertEqual(len(results[0].feature_mapping), 10)
 
     def test_instance_sampling_basic(self):
         """Test that InstanceSamplingStrategy samples correct number of instances."""
@@ -55,8 +55,8 @@ class TestSamplingStrategies(unittest.TestCase):
 
         # ceil(100 * 0.25) = 25 instances per child
         result = results[0]
-        self.assertEqual(len(result.instance_indices), 25)
         self.assertEqual(result.data.shape, (25, 20))
+        self.assertEqual(len(result.labels), 25)
         self.assertIsNone(result.feature_mapping)
 
     def test_combined_sampling(self):
@@ -68,9 +68,9 @@ class TestSamplingStrategies(unittest.TestCase):
 
         # Features: ceil(20 * 0.25) = 5, Instances: ceil(100 * 0.25) = 25
         result = results[0]
-        self.assertEqual(len(result.feature_indices), 5)
-        self.assertEqual(len(result.instance_indices), 25)
         self.assertEqual(result.data.shape, (25, 5))
+        self.assertEqual(len(result.labels), 25)
+        self.assertEqual(len(result.feature_mapping), 5)
 
 
 class TestChildPopulationCreation(unittest.TestCase):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -11,7 +11,144 @@ from hgp_lib.populations.sampling import (
 )
 
 
-class TestFeatureSamplingStrategy(unittest.TestCase):
+def identifiable_data(num_instances: int, num_features: int) -> np.ndarray:
+    """Boolean data whose every row encodes its own row index in binary.
+
+    Rows are therefore unique and their original index can be recovered with
+    `recover_row_indices`, which lets tests check which instances a child
+    received without the strategies having to report indices.
+
+    Requires `2 ** num_features > num_instances`.
+    """
+    assert 2**num_features > num_instances, "not enough features to encode row indices"
+    return ((np.arange(num_instances)[:, None] >> np.arange(num_features)) & 1).astype(
+        bool
+    )
+
+
+def recover_row_indices(data: np.ndarray) -> np.ndarray:
+    """Recover the original row indices from data built by `identifiable_data`."""
+    return data.astype(int) @ (1 << np.arange(data.shape[1]))
+
+
+class TestIndexAllocation(unittest.TestCase):
+    """Tests for `SamplingStrategy.allocate_indices_to_children`.
+
+    This helper owns the overlap and uniqueness behaviour that `replace`
+    controls, so the invariants are asserted here rather than through the
+    sampled data of each strategy.
+    """
+
+    def setUp(self):
+        np.random.seed(42)
+
+    @staticmethod
+    def _allocate(k, n, num_children, replace):
+        strategy = FeatureSamplingStrategy(replace=replace)
+        return strategy.allocate_indices_to_children(k, n, num_children)
+
+    def test_returns_one_allocation_per_child(self):
+        for k, n, num_children, replace in [
+            (10, 10, 3, False),  # k >= n
+            (3, 10, 3, False),  # partitioned
+            (3, 10, 3, True),  # independent samples
+            (4, 10, 3, False),  # partition impossible, independent samples
+        ]:
+            with self.subTest(k=k, n=n, num_children=num_children, replace=replace):
+                allocation = self._allocate(k, n, num_children, replace)
+                self.assertEqual(len(allocation), num_children)
+
+    def test_all_indices_given_when_k_at_least_n(self):
+        """With k >= n every child receives all n indices."""
+        for k in (10, 15):
+            with self.subTest(k=k):
+                allocation = self._allocate(k, n=10, num_children=3, replace=False)
+                for indices in allocation:
+                    np.testing.assert_array_equal(indices, np.arange(10))
+
+    def test_partitions_without_overlap(self):
+        """With replace=False and k * num_children <= n children are disjoint."""
+        allocation = self._allocate(k=3, n=10, num_children=3, replace=False)
+
+        seen = set()
+        for indices in allocation:
+            self.assertEqual(len(indices), 3)
+            current = set(indices.tolist())
+            self.assertEqual(len(current & seen), 0, "children share an index")
+            seen |= current
+        self.assertEqual(len(seen), 9)
+
+    def test_independent_samples_when_replace_true(self):
+        """With replace=True children are sampled independently of each other."""
+        allocation = self._allocate(k=3, n=10, num_children=3, replace=True)
+        for indices in allocation:
+            self.assertEqual(len(indices), 3)
+
+    def test_independent_samples_when_partition_impossible(self):
+        """With replace=False but k * num_children > n each child is sampled on its own."""
+        allocation = self._allocate(k=4, n=10, num_children=3, replace=False)
+        for indices in allocation:
+            self.assertEqual(len(indices), 4)
+
+    def test_indices_are_unique_within_each_child_and_in_range(self):
+        for k, n, num_children, replace in [
+            (10, 10, 3, False),
+            (3, 10, 3, False),
+            (3, 10, 3, True),
+            (4, 10, 3, False),
+            (7, 20, 4, True),
+        ]:
+            with self.subTest(k=k, n=n, num_children=num_children, replace=replace):
+                allocation = self._allocate(k, n, num_children, replace)
+                for indices in allocation:
+                    self.assertEqual(len(np.unique(indices)), len(indices))
+                    self.assertTrue(((indices >= 0) & (indices < n)).all())
+
+
+class SamplingAssertions(unittest.TestCase):
+    """Shared assertions about a SamplingResult, all derived from its data."""
+
+    def assert_feature_mapping_well_formed(self, result, num_parent_features):
+        """feature_mapping keys cover the child columns and values are valid parents."""
+        self.assertIsNotNone(result.feature_mapping)
+        self.assertEqual(
+            set(result.feature_mapping.keys()), set(range(result.data.shape[1]))
+        )
+        values = list(result.feature_mapping.values())
+        self.assertEqual(len(set(values)), len(values), "duplicate parent features")
+        for value in values:
+            self.assertIsInstance(value, int)
+            self.assertGreaterEqual(value, 0)
+            self.assertLess(value, num_parent_features)
+
+    def assert_columns_match_mapping(self, result, parent_data, rows=slice(None)):
+        """Each child column holds the parent column that feature_mapping names.
+
+        This is what makes the mapping trustworthy: the columns actually kept in
+        `data` and the columns recorded in `feature_mapping` must agree, since
+        crossover relies on the mapping to translate rules back to the parent.
+        """
+        for child_col, parent_col in result.feature_mapping.items():
+            np.testing.assert_array_equal(
+                result.data[:, child_col],
+                parent_data[rows, parent_col],
+                f"child column {child_col} is not parent column {parent_col}",
+            )
+
+    def assert_rows_exist_in_parent(self, result, parent_data, parent_labels):
+        """Every (row, label) pair of the child occurs in the parent's projection."""
+        if result.feature_mapping is None:
+            projection = parent_data
+        else:
+            projection = parent_data[:, list(result.feature_mapping.values())]
+
+        for row, label in zip(result.data, result.labels):
+            candidates = np.flatnonzero((projection == row).all(axis=1))
+            self.assertGreater(candidates.size, 0, "child row is not a parent row")
+            self.assertIn(label, parent_labels[candidates])
+
+
+class TestFeatureSamplingStrategy(SamplingAssertions):
     """Tests for FeatureSamplingStrategy."""
 
     def setUp(self):
@@ -25,50 +162,52 @@ class TestFeatureSamplingStrategy(unittest.TestCase):
         results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
-    def test_each_result_has_unique_features(self):
-        """Each child has unique feature indices (no duplicates within a child)."""
-        strategy = FeatureSamplingStrategy(feature_fraction=1.0, replace=True)
+    def test_data_dimensions_correct(self):
+        """Sampled data keeps every instance and ceil(features * fraction) columns."""
+        strategy = FeatureSamplingStrategy(feature_fraction=0.3)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            unique_count = len(np.unique(result.feature_indices))
-            self.assertEqual(unique_count, len(result.feature_indices))
+            # ceil(20 * 0.3) = 6
+            self.assertEqual(result.data.shape, (100, 6))
+            np.testing.assert_array_equal(result.labels, self.labels)
 
-    def test_no_overlap_when_replace_false(self):
-        """When replace=False, features don't overlap between children."""
+    def test_feature_mapping_matches_sampled_columns(self):
+        """feature_mapping names exactly the parent columns present in the data."""
+        strategy = FeatureSamplingStrategy(feature_fraction=0.3)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            self.assert_feature_mapping_well_formed(result, self.data.shape[1])
+            self.assert_columns_match_mapping(result, self.data)
+
+    def test_full_fraction_keeps_all_features_in_order(self):
+        """With feature_fraction=1.0 children get the identity mapping."""
+        strategy = FeatureSamplingStrategy(feature_fraction=1.0)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            np.testing.assert_array_equal(result.data, self.data)
+            self.assertEqual(result.feature_mapping, {i: i for i in range(20)})
+
+    def test_features_do_not_overlap_when_replace_false(self):
+        """With replace=False no parent feature reaches two children."""
         strategy = FeatureSamplingStrategy(feature_fraction=0.3, replace=False)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
-        for i in range(len(results)):
-            for j in range(i + 1, len(results)):
-                set_i = set(results[i].feature_indices)
-                set_j = set(results[j].feature_indices)
-                intersection = set_i & set_j
-                self.assertEqual(
-                    len(intersection),
-                    0,
-                    f"Children {i} and {j} have overlapping features: {intersection}",
-                )
-
-    def test_feature_mapping_correct(self):
-        """feature_mapping correctly maps child indices to parent indices."""
-        strategy = FeatureSamplingStrategy(feature_fraction=1.0)
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
+        seen = set()
         for result in results:
-            self.assertIsNotNone(result.feature_mapping)
-            for i, idx in enumerate(result.feature_indices):
-                self.assertEqual(result.feature_mapping[i], int(idx))
+            current = set(result.feature_mapping.values())
+            self.assertEqual(
+                len(current & seen), 0, f"features reused across children: {current}"
+            )
+            seen |= current
 
-    def test_data_dimensions_correct(self):
-        """Sampled data has correct dimensions."""
-        strategy = FeatureSamplingStrategy(feature_fraction=1.0)
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
-        for result in results:
-            self.assertEqual(result.data.shape[0], len(self.labels))
-            self.assertEqual(result.data.shape[1], len(result.feature_indices))
-            self.assertIsNone(result.instance_indices)
+    def test_too_few_features_raises(self):
+        """A fraction that yields fewer than MIN_FEATURES columns raises ValueError."""
+        strategy = FeatureSamplingStrategy(feature_fraction=0.1)
+        with self.assertRaises(ValueError):
+            strategy.sample(self.data[:, :5], self.labels, num_children=2)
 
     def test_invalid_feature_fraction_raises(self):
         """feature_fraction <= 0 raises ValueError."""
@@ -78,12 +217,13 @@ class TestFeatureSamplingStrategy(unittest.TestCase):
             FeatureSamplingStrategy(feature_fraction=-1.0)
 
 
-class TestInstanceSamplingStrategy(unittest.TestCase):
+class TestInstanceSamplingStrategy(SamplingAssertions):
     """Tests for InstanceSamplingStrategy."""
 
     def setUp(self):
         np.random.seed(42)
-        self.data = np.random.rand(100, 20) > 0.5
+        # Self-identifying rows, so tests can tell which instances a child received.
+        self.data = identifiable_data(100, 20)
         self.labels = np.random.randint(0, 2, 100)
 
     def test_returns_correct_number_of_results(self):
@@ -92,41 +232,62 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
         results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
-    def test_each_result_has_unique_instances(self):
-        """Each child has unique instance indices (no duplicates within a child)."""
-        strategy = InstanceSamplingStrategy(sample_fraction=1.0, replace=True)
+    def test_data_dimensions_correct(self):
+        """Sampled data keeps every feature and ceil(instances * fraction) rows."""
+        strategy = InstanceSamplingStrategy(sample_fraction=0.3)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            unique_count = len(np.unique(result.instance_indices))
-            self.assertEqual(unique_count, len(result.instance_indices))
+            # ceil(100 * 0.3) = 30
+            self.assertEqual(result.data.shape, (30, 20))
+            self.assertEqual(len(result.labels), 30)
+            self.assertIsNone(result.feature_mapping)
 
-    def test_no_overlap_when_replace_false(self):
-        """When replace=False, instances don't overlap between children."""
+    def test_rows_and_labels_are_sliced_together(self):
+        """Each child label belongs to the instance sitting in the same row."""
+        strategy = InstanceSamplingStrategy(sample_fraction=0.3)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            instances = recover_row_indices(result.data)
+            np.testing.assert_array_equal(result.labels, self.labels[instances])
+
+    def test_instances_are_unique_within_a_child(self):
+        """No instance is handed to the same child twice."""
+        strategy = InstanceSamplingStrategy(sample_fraction=0.3, replace=True)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            instances = recover_row_indices(result.data)
+            self.assertEqual(len(np.unique(instances)), len(instances))
+
+    def test_instances_do_not_overlap_when_replace_false(self):
+        """With replace=False no instance reaches two children."""
         strategy = InstanceSamplingStrategy(sample_fraction=0.3, replace=False)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
-        for i in range(len(results)):
-            for j in range(i + 1, len(results)):
-                set_i = set(results[i].instance_indices)
-                set_j = set(results[j].instance_indices)
-                intersection = set_i & set_j
-                self.assertEqual(
-                    len(intersection),
-                    0,
-                    f"Children {i} and {j} have overlapping instances: {intersection}",
-                )
+        seen = set()
+        for result in results:
+            current = set(recover_row_indices(result.data).tolist())
+            self.assertEqual(
+                len(current & seen), 0, f"instances reused across children: {current}"
+            )
+            seen |= current
 
-    def test_data_dimensions_correct(self):
-        """Sampled data has correct dimensions."""
+    def test_full_fraction_keeps_all_instances(self):
+        """With sample_fraction=1.0 children get the whole dataset."""
         strategy = InstanceSamplingStrategy(sample_fraction=1.0)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            self.assertEqual(result.data.shape[0], len(result.instance_indices))
-            self.assertEqual(result.data.shape[1], 20)
-            self.assertEqual(len(result.labels), len(result.instance_indices))
-            self.assertIsNone(result.feature_mapping)
+            np.testing.assert_array_equal(result.data, self.data)
+            np.testing.assert_array_equal(result.labels, self.labels)
+
+    def test_too_few_instances_raises(self):
+        """A fraction that yields fewer than MIN_INSTANCES rows raises ValueError."""
+        strategy = InstanceSamplingStrategy(sample_fraction=0.1)
+        with self.assertRaises(ValueError):
+            strategy.sample(self.data[:5], self.labels[:5], num_children=2)
 
     def test_invalid_sample_fraction_raises(self):
         """sample_fraction <= 0 raises ValueError."""
@@ -136,7 +297,7 @@ class TestInstanceSamplingStrategy(unittest.TestCase):
             InstanceSamplingStrategy(sample_fraction=-1.0)
 
 
-class TestCombinedSamplingStrategy(unittest.TestCase):
+class TestCombinedSamplingStrategy(SamplingAssertions):
     """Tests for CombinedSamplingStrategy."""
 
     def setUp(self):
@@ -150,83 +311,70 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
         results = strategy.sample(self.data, self.labels, num_children=5)
         self.assertEqual(len(results), 5)
 
-    def test_each_result_has_unique_features(self):
-        """Each child has unique feature indices (no duplicates within a child)."""
-        strategy = CombinedSamplingStrategy(
-            feature_fraction=1.0, sample_fraction=1.0, replace=True
-        )
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
-        for result in results:
-            unique_count = len(np.unique(result.feature_indices))
-            self.assertEqual(unique_count, len(result.feature_indices))
-
-    def test_each_result_has_unique_instances(self):
-        """Each child has unique instance indices (no duplicates within a child)."""
-        strategy = CombinedSamplingStrategy(
-            feature_fraction=1.0, sample_fraction=1.0, replace=True
-        )
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
-        for result in results:
-            unique_count = len(np.unique(result.instance_indices))
-            self.assertEqual(unique_count, len(result.instance_indices))
-
-    def test_no_feature_overlap_when_replace_false(self):
-        """When replace=False, features don't overlap between children."""
-        strategy = CombinedSamplingStrategy(
-            feature_fraction=0.3, sample_fraction=0.3, replace=False
-        )
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
-        for i in range(len(results)):
-            for j in range(i + 1, len(results)):
-                set_i = set(results[i].feature_indices)
-                set_j = set(results[j].feature_indices)
-                intersection = set_i & set_j
-                self.assertEqual(
-                    len(intersection),
-                    0,
-                    f"Children {i} and {j} have overlapping features: {intersection}",
-                )
-
-    def test_no_instance_overlap_when_replace_false(self):
-        """When replace=False, instances don't overlap between children."""
-        strategy = CombinedSamplingStrategy(
-            feature_fraction=0.3, sample_fraction=0.3, replace=False
-        )
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
-        for i in range(len(results)):
-            for j in range(i + 1, len(results)):
-                set_i = set(results[i].instance_indices)
-                set_j = set(results[j].instance_indices)
-                intersection = set_i & set_j
-                self.assertEqual(
-                    len(intersection),
-                    0,
-                    f"Children {i} and {j} have overlapping instances: {intersection}",
-                )
-
-    def test_feature_mapping_correct(self):
-        """feature_mapping correctly maps child indices to parent indices."""
-        strategy = CombinedSamplingStrategy(feature_fraction=1.0, sample_fraction=1.0)
-        results = strategy.sample(self.data, self.labels, num_children=3)
-
-        for result in results:
-            self.assertIsNotNone(result.feature_mapping)
-            for i, idx in enumerate(result.feature_indices):
-                self.assertEqual(result.feature_mapping[i], int(idx))
-
     def test_data_dimensions_correct(self):
-        """Sampled data has correct dimensions."""
-        strategy = CombinedSamplingStrategy(feature_fraction=1.0, sample_fraction=1.0)
+        """Both fractions are applied to the sampled data."""
+        strategy = CombinedSamplingStrategy(feature_fraction=0.3, sample_fraction=0.3)
         results = strategy.sample(self.data, self.labels, num_children=3)
 
         for result in results:
-            self.assertEqual(result.data.shape[0], len(result.instance_indices))
-            self.assertEqual(result.data.shape[1], len(result.feature_indices))
-            self.assertEqual(len(result.labels), len(result.instance_indices))
+            # ceil(100 * 0.3) = 30 rows, ceil(20 * 0.3) = 6 columns
+            self.assertEqual(result.data.shape, (30, 6))
+            self.assertEqual(len(result.labels), 30)
+
+    def test_feature_mapping_well_formed(self):
+        """feature_mapping covers the child columns and names distinct parents."""
+        strategy = CombinedSamplingStrategy(feature_fraction=0.3, sample_fraction=0.3)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            self.assert_feature_mapping_well_formed(result, self.data.shape[1])
+
+    def test_rows_come_from_the_parent(self):
+        """Sampled rows and labels are consistent with the parent's projection."""
+        strategy = CombinedSamplingStrategy(feature_fraction=0.3, sample_fraction=0.3)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            self.assert_rows_exist_in_parent(result, self.data, self.labels)
+
+    def test_columns_match_mapping_when_all_instances_kept(self):
+        """With sample_fraction=1.0 the columns can be compared to the parent directly."""
+        strategy = CombinedSamplingStrategy(feature_fraction=0.3, sample_fraction=1.0)
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        for result in results:
+            self.assert_columns_match_mapping(result, self.data)
+
+    def test_features_do_not_overlap_when_replace_false(self):
+        """With replace=False no parent feature reaches two children."""
+        strategy = CombinedSamplingStrategy(
+            feature_fraction=0.3, sample_fraction=0.3, replace=False
+        )
+        results = strategy.sample(self.data, self.labels, num_children=3)
+
+        seen = set()
+        for result in results:
+            current = set(result.feature_mapping.values())
+            self.assertEqual(
+                len(current & seen), 0, f"features reused across children: {current}"
+            )
+            seen |= current
+
+    def test_instances_do_not_overlap_when_replace_false(self):
+        """With replace=False no instance reaches two children."""
+        data = identifiable_data(100, 20)
+        strategy = CombinedSamplingStrategy(
+            feature_fraction=1.0, sample_fraction=0.3, replace=False
+        )
+        results = strategy.sample(data, self.labels, num_children=3)
+
+        seen = set()
+        for result in results:
+            current = set(recover_row_indices(result.data).tolist())
+            self.assertEqual(
+                len(current & seen), 0, f"instances reused across children: {current}"
+            )
+            seen |= current
 
     def test_invalid_fractions_raise(self):
         """Invalid fractions raise ValueError."""
@@ -236,7 +384,7 @@ class TestCombinedSamplingStrategy(unittest.TestCase):
             CombinedSamplingStrategy(sample_fraction=-1.0)
 
 
-class TestSamplingRandomized(unittest.TestCase):
+class TestSamplingRandomized(SamplingAssertions):
     """Randomized tests for sampling strategies.
 
     These tests verify behavior across multiple random configurations.
@@ -316,8 +464,8 @@ class TestSamplingRandomized(unittest.TestCase):
 
         self._run_randomized_test(check)
 
-    def test_feature_sampling_feature_mapping_correct(self):
-        """FeatureSamplingStrategy feature_mapping correctly maps child to parent indices."""
+    def test_feature_sampling_mapping_matches_sampled_columns(self):
+        """FeatureSamplingStrategy keeps exactly the columns feature_mapping names."""
 
         def check():
             num_features = np.random.randint(4, 51)
@@ -335,16 +483,14 @@ class TestSamplingRandomized(unittest.TestCase):
             results = strategy.sample(data, labels, num_children=int(num_children))
 
             for result in results:
-                self.assertIsNotNone(result.feature_mapping)
-                expected_keys = set(range(len(result.feature_indices)))
-                self.assertEqual(set(result.feature_mapping.keys()), expected_keys)
-                for i, idx in enumerate(result.feature_indices):
-                    self.assertEqual(result.feature_mapping[i], int(idx))
+                self.assert_feature_mapping_well_formed(result, num_features)
+                self.assert_columns_match_mapping(result, data)
+                np.testing.assert_array_equal(result.labels, labels)
 
         self._run_randomized_test(check)
 
-    def test_combined_sampling_feature_mapping_correct(self):
-        """CombinedSamplingStrategy feature_mapping correctly maps child to parent indices."""
+    def test_combined_sampling_mapping_and_rows_consistent(self):
+        """CombinedSamplingStrategy rows and labels stay consistent with the parent."""
 
         def check():
             num_features = np.random.randint(4, 51)
@@ -365,11 +511,8 @@ class TestSamplingRandomized(unittest.TestCase):
             results = strategy.sample(data, labels, num_children=int(num_children))
 
             for result in results:
-                self.assertIsNotNone(result.feature_mapping)
-                expected_keys = set(range(len(result.feature_indices)))
-                self.assertEqual(set(result.feature_mapping.keys()), expected_keys)
-                for i, idx in enumerate(result.feature_indices):
-                    self.assertEqual(result.feature_mapping[i], int(idx))
+                self.assert_feature_mapping_well_formed(result, num_features)
+                self.assert_rows_exist_in_parent(result, data, labels)
 
         self._run_randomized_test(check)
 


### PR DESCRIPTION
* `SamplingResult` now holds only `data`, `labels` and `feature_mapping`.
* Documented `create_sampling_result` and updated the doctests.