### PR TITLE
Added `SchemaMismatchError` and reused sklearn's `NotFittedError`

### DIFF
--- a/docs/api/preprocessing.md
+++ b/docs/api/preprocessing.md
@@ -16,6 +16,10 @@
 
 ::: hgp_lib.preprocessing.binning.SupervisedTreeBinning
 
+## Errors
+
+::: hgp_lib.preprocessing.errors.SchemaMismatchError
+
 ## Warnings
 
 ::: hgp_lib.preprocessing.warnings.BinarizerWarning

--- a/hgp_lib/algorithms/boolean_gp.py
+++ b/hgp_lib/algorithms/boolean_gp.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 
 import numpy as np
 from numpy import ndarray
+from sklearn.exceptions import NotFittedError
 
 from hgp_lib.utils.metrics import confusion_matrix
 
@@ -593,7 +594,7 @@ class BooleanGP:
             float: Score of the global best rule on the provided data.
 
         Raises:
-            RuntimeError: If no best rule is available (run at least one step first).
+            NotFittedError: If no best rule is available (run at least one step first).
 
         Examples:
             >>> import numpy as np
@@ -613,7 +614,7 @@ class BooleanGP:
             True
         """
         if self.global_best_rule is None:
-            raise RuntimeError("No best rule available. Run at least one step first.")
+            raise NotFittedError("No best rule available. Run at least one step first.")
 
         fn = self._original_score_fn if score_fn is None else score_fn
         return float(fn(labels, self.global_best_rule.evaluate(data)))

--- a/hgp_lib/benchmarkers/gp_benchmarker.py
+++ b/hgp_lib/benchmarkers/gp_benchmarker.py
@@ -4,6 +4,7 @@ import os
 
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 from tqdm import tqdm
 
 from ..configs import BenchmarkerConfig, validate_benchmarker_config
@@ -217,8 +218,9 @@ class GPBenchmarker:
             np.ndarray: 1-D boolean array with one prediction per input row.
 
         Raises:
-            RuntimeError: If called before ``fit`` (no results are available yet), or
-                if the best run has no fitted binarizer to transform the raw data.
+            NotFittedError: If called before ``fit`` (no results are available yet).
+            RuntimeError: If the best run has no fitted binarizer to transform the
+                raw data.
 
         Examples:
             >>> from sklearn.metrics import accuracy_score
@@ -244,7 +246,7 @@ class GPBenchmarker:
             (8,)
         """
         if self._run_results is None:
-            raise RuntimeError("GPBenchmarker must be fit before calling predict")
+            raise NotFittedError("GPBenchmarker must be fit before calling predict")
 
         best_run = self._run_results.best_run
         if best_run.binarizer is None:

--- a/hgp_lib/preprocessing/__init__.py
+++ b/hgp_lib/preprocessing/__init__.py
@@ -1,6 +1,7 @@
 from .base import Binarizer
 from .binarizer import StandardBinarizer
 from .binning import BinningStrategy, QuantileBinning, SupervisedTreeBinning
+from .errors import SchemaMismatchError
 from .sklearn_binarizer import SklearnBinarizer
 from .utils import is_categorical_like, load_data
 from .warnings import (
@@ -18,6 +19,7 @@ __all__ = [
     "EmptyBinarizationWarning",
     "HighCardinalityWarning",
     "QuantileBinning",
+    "SchemaMismatchError",
     "SklearnBinarizer",
     "StandardBinarizer",
     "StringColumnWarning",

--- a/hgp_lib/preprocessing/binarizer.py
+++ b/hgp_lib/preprocessing/binarizer.py
@@ -3,6 +3,7 @@ from enum import Enum
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_bool_dtype, is_numeric_dtype
+from sklearn.exceptions import NotFittedError
 from tqdm import tqdm
 
 from hgp_lib.utils.validation import check_isinstance
@@ -10,6 +11,7 @@ from hgp_lib.utils.warnings import warn_once
 
 from .base import Binarizer
 from .binning import BinningStrategy, QuantileBinning, SupervisedTreeBinning
+from .errors import SchemaMismatchError
 from .utils import is_categorical_like
 from .warnings import (
     EmptyBinarizationWarning,
@@ -230,7 +232,7 @@ class StandardBinarizer(Binarizer):
                 columns produced by ``fit_transform`` / ``transform``.
 
         Raises:
-            ValueError: If the binarizer has not been fitted yet.
+            NotFittedError: If the binarizer has not been fitted yet.
 
         Examples:
             >>> import pandas as pd
@@ -241,7 +243,7 @@ class StandardBinarizer(Binarizer):
             ['x < 2.500', '2.500 <= x']
         """
         if not self._is_fitted:
-            raise ValueError(
+            raise NotFittedError(
                 "Binarizer must be fitted before calling get_feature_names_out"
             )
         return list(self._feature_names)
@@ -262,9 +264,9 @@ class StandardBinarizer(Binarizer):
 
         Raises:
             TypeError: If ``X`` is not a DataFrame.
-            ValueError: If the binarizer has not been fitted yet, or if a column dtype
-                differs from the one seen during fitting.
-            RuntimeError: If the columns differ from the fitting data.
+            NotFittedError: If the binarizer has not been fitted yet.
+            SchemaMismatchError: If the columns, a column dtype, or the number of
+                produced features differ from the fitting data.
 
         Examples:
             >>> import pandas as pd
@@ -276,10 +278,9 @@ class StandardBinarizer(Binarizer):
         """
         check_isinstance(X, pd.DataFrame)
         if not self._is_fitted:
-            raise ValueError("Binarizer must be fitted before calling transform")
+            raise NotFittedError("Binarizer must be fitted before calling transform")
         if not self._original_columns.equals(X.columns):
-            # TODO: (1) We should add custom Errors in the library where it makes sense.;
-            raise RuntimeError(
+            raise SchemaMismatchError(
                 f"Original columns do not match current columns. "
                 f"Original columns: {self._original_columns}. Current columns: {X.columns}."
             )
@@ -305,7 +306,7 @@ class StandardBinarizer(Binarizer):
                 values_list.extend(self._transform_column(column, series))
 
             if len(values_list) != len(names):
-                raise RuntimeError(
+                raise SchemaMismatchError(
                     f"Column '{column}' produced {len(values_list)} features at transform "
                     f"but {len(names)} were produced at fit."
                 )
@@ -394,7 +395,7 @@ class StandardBinarizer(Binarizer):
         expected = self._original_column_dtypes[column]
         actual = self._infer_kind(column, series)
         if actual != expected:
-            raise ValueError(
+            raise SchemaMismatchError(
                 f"Original column {column} was {expected.value}. "
                 f"Current column is {actual.value}. Current column must be {expected.value}."
             )

--- a/hgp_lib/preprocessing/errors.py
+++ b/hgp_lib/preprocessing/errors.py
@@ -1,0 +1,14 @@
+class SchemaMismatchError(RuntimeError):
+    """
+    Data passed to `transform` does not match the schema seen during `fit`.
+
+    Raised when the columns, their dtypes, or the number of produced features
+    differ from the fitting data. Distinguishing this from a plain `ValueError`
+    lets callers tell "this data does not fit the binarizer" apart from "these
+    arguments are invalid", and react by refitting.
+
+    Examples:
+        >>> from hgp_lib.preprocessing.errors import SchemaMismatchError
+        >>> issubclass(SchemaMismatchError, RuntimeError)
+        True
+    """

--- a/hgp_lib/preprocessing/sklearn_binarizer.py
+++ b/hgp_lib/preprocessing/sklearn_binarizer.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 
 from hgp_lib.utils.validation import check_isinstance
 
@@ -51,7 +52,7 @@ class SklearnBinarizer(Binarizer):
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         check_isinstance(X, pd.DataFrame)
         if not self._is_fitted:
-            raise ValueError("Binarizer must be fitted before calling transform")
+            raise NotFittedError("Binarizer must be fitted before calling transform")
         array = np.asarray(self.transformer.transform(X))
         return pd.DataFrame(array.astype(bool), columns=self._columns, index=X.index)
 
@@ -66,10 +67,10 @@ class SklearnBinarizer(Binarizer):
             list[str]: The boolean output column names.
 
         Raises:
-            ValueError: If the binarizer has not been fitted yet.
+            NotFittedError: If the binarizer has not been fitted yet.
         """
         if not self._is_fitted:
-            raise ValueError(
+            raise NotFittedError(
                 "Binarizer must be fitted before calling get_feature_names_out"
             )
         return list(self._columns)

--- a/hgp_lib/preprocessing/utils.py
+++ b/hgp_lib/preprocessing/utils.py
@@ -59,7 +59,7 @@ def load_data(data_path: str) -> tuple[pd.DataFrame, ndarray]:
     Raises:
         FileNotFoundError: If ``data_path`` does not exist.
         ValueError: If the file extension is not ``.csv`` or ``.hdf``.
-        RuntimeError: If no ``"target"`` column is found.
+        KeyError: If no ``"target"`` column is found.
 
     Examples:
         >>> import tempfile, os
@@ -92,7 +92,7 @@ def load_data(data_path: str) -> tuple[pd.DataFrame, ndarray]:
     if "target" in df.columns:
         target_column = "target"
     else:
-        raise RuntimeError(f"Unknown target column. Available: {df.columns.tolist()}")
+        raise KeyError(f"Unknown target column. Available: {df.columns.tolist()}")
 
     labels = df[target_column].to_numpy(dtype=bool, copy=True)
     data = df.drop([target_column], axis=1)

--- a/hgp_lib/preprocessing/utils.py
+++ b/hgp_lib/preprocessing/utils.py
@@ -80,7 +80,7 @@ def load_data(data_path: str) -> tuple[pd.DataFrame, ndarray]:
         raise FileNotFoundError(f"Data file not found: {data_path}")
 
     logging.getLogger(__name__).info(f"Loading data from {data_path}...")
-    # TODO: (1) Create a unified logging system
+    # TODO: See if any things are worth logging
 
     if path.suffix == ".hdf":
         df: pd.DataFrame = pd.read_hdf(data_path)

--- a/hgp_lib/trainers/boolean_rule_classifier.py
+++ b/hgp_lib/trainers/boolean_rule_classifier.py
@@ -2,6 +2,7 @@ from dataclasses import replace
 
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 
 from ..configs import TrainerConfig, validate_trainer_config
 from ..metrics import PopulationHistory
@@ -159,7 +160,7 @@ class BooleanRuleClassifier:
 
         Raises:
             TypeError: If ``X`` is not a ``pandas.DataFrame``.
-            RuntimeError: If called before ``fit``.
+            NotFittedError: If called before ``fit``.
         """
         check_isinstance(X, pd.DataFrame)
         self._check_fitted("predict")
@@ -190,6 +191,6 @@ class BooleanRuleClassifier:
 
     def _check_fitted(self, attr: str) -> None:
         if self._history is None:
-            raise RuntimeError(
+            raise NotFittedError(
                 f"BooleanRuleClassifier must be fit before accessing '{attr}'"
             )

--- a/hgp_lib/trainers/gp_trainer.py
+++ b/hgp_lib/trainers/gp_trainer.py
@@ -1,4 +1,5 @@
 import numpy as np
+from sklearn.exceptions import NotFittedError
 from tqdm import tqdm
 
 from ..algorithms import BooleanGP
@@ -163,7 +164,7 @@ class GPTrainer:
             np.ndarray: 1-D boolean array with one prediction per input row.
 
         Raises:
-            RuntimeError: If called before ``fit`` (no best rule is available yet).
+            NotFittedError: If called before ``fit`` (no best rule is available yet).
 
         Examples:
             >>> import numpy as np
@@ -186,5 +187,5 @@ class GPTrainer:
             (2,)
         """
         if self.gp_algo.global_best_rule is None:
-            raise RuntimeError("GPTrainer must be fit before calling predict")
+            raise NotFittedError("GPTrainer must be fit before calling predict")
         return self.gp_algo.global_best_rule.evaluate(data)

--- a/tests/test_binarizer.py
+++ b/tests/test_binarizer.py
@@ -2,8 +2,9 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 
-from hgp_lib.preprocessing import StandardBinarizer
+from hgp_lib.preprocessing import SchemaMismatchError, StandardBinarizer
 from hgp_lib.preprocessing.binning import (
     BinningStrategy,
     QuantileBinning,
@@ -73,7 +74,7 @@ class TestStandardBinarizer(unittest.TestCase):
 
     def test_transform_before_fit_raises(self):
         b = StandardBinarizer()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotFittedError):
             b.transform(pd.DataFrame({"x": [1.0]}))
 
     # ------------------------------------------------------------------ #
@@ -349,25 +350,25 @@ class TestStandardBinarizer(unittest.TestCase):
     def test_transform_dtype_change_raises(self):
         b = StandardBinarizer()
         b.fit_transform(pd.DataFrame({"x": [True, False]}))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SchemaMismatchError):
             b.transform(pd.DataFrame({"x": pd.array(["a", "b"], dtype="string")}))
 
     def test_transform_numeric_to_categorical_raises(self):
         b = StandardBinarizer(num_bins=2)
         b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
-        with self.assertRaises(ValueError):
+        with self.assertRaises(SchemaMismatchError):
             b.transform(pd.DataFrame({"x": pd.Categorical(["a", "b", "c"])}))
 
     def test_transform_different_columns_raises(self):
         b = StandardBinarizer(num_bins=2)
         b.fit_transform(pd.DataFrame({"x": [1.0, 2.0, 3.0]}))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(SchemaMismatchError):
             b.transform(pd.DataFrame({"y": [1.0, 2.0]}))
 
     def test_transform_different_column_order_raises(self):
         b = StandardBinarizer(num_bins=2)
         b.fit_transform(pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]}))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(SchemaMismatchError):
             b.transform(pd.DataFrame({"b": [3.0], "a": [1.0]}))
 
     def test_unsupported_dtype_fit_transform(self):
@@ -399,7 +400,7 @@ class TestStandardBinarizer(unittest.TestCase):
 
     def test_get_feature_names_out_before_fit_raises(self):
         b = StandardBinarizer()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotFittedError):
             b.get_feature_names_out()
 
 
@@ -412,7 +413,7 @@ class TestSklearnBinarizer(unittest.TestCase):
         b = SklearnBinarizer(
             KBinsDiscretizer(n_bins=2, encode="onehot-dense", strategy="uniform")
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotFittedError):
             b.transform(pd.DataFrame({"x": [0.0, 1.0]}))
 
     def test_feature_names_positional_fallback(self):
@@ -453,7 +454,7 @@ class TestSklearnBinarizer(unittest.TestCase):
         b = SklearnBinarizer(
             KBinsDiscretizer(n_bins=2, encode="onehot-dense", strategy="uniform")
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(NotFittedError):
             b.get_feature_names_out()
 
 

--- a/tests/test_boolean_gp.py
+++ b/tests/test_boolean_gp.py
@@ -3,6 +3,7 @@ import unittest
 from collections.abc import Sequence
 
 import numpy as np
+from sklearn.exceptions import NotFittedError
 
 from hgp_lib.algorithms import BooleanGP
 from hgp_lib.configs import BooleanGPConfig
@@ -291,7 +292,7 @@ class TestBooleanGP(unittest.TestCase):
     # ------------------------------------------------------------------ #
     def test_evaluate_best_before_step_raises(self):
         gp = BooleanGP(self._make_config())
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotFittedError):
             gp.evaluate_best(self.val_data, self.val_labels)
 
     def test_evaluate_best_returns_float(self):

--- a/tests/test_boolean_rule_classifier.py
+++ b/tests/test_boolean_rule_classifier.py
@@ -4,6 +4,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 
 from hgp_lib import BooleanRuleClassifier
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
@@ -132,17 +133,17 @@ class TestBooleanRuleClassifier(unittest.TestCase):
     # ------------------------------------------------------------------ #
     def test_predict_before_fit_raises(self):
         clf = BooleanRuleClassifier(self._make_config())
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotFittedError):
             clf.predict(self.data)
 
     def test_rule_before_fit_raises(self):
         clf = BooleanRuleClassifier(self._make_config())
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotFittedError):
             _ = clf.rule
 
     def test_feature_names_before_fit_raises(self):
         clf = BooleanRuleClassifier(self._make_config())
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotFittedError):
             _ = clf.feature_names
 
 

--- a/tests/test_gp_benchmarker.py
+++ b/tests/test_gp_benchmarker.py
@@ -7,6 +7,7 @@ from multiprocessing import Queue
 
 import numpy as np
 import pandas as pd
+from sklearn.exceptions import NotFittedError
 
 from hgp_lib.benchmarkers import GPBenchmarker
 from hgp_lib.benchmarkers.progress import ProgressReporter
@@ -587,7 +588,7 @@ class TestGPBenchmarker(unittest.TestCase):
     # ------------------------------------------------------------------ #
     def test_predict_before_fit_raises(self):
         benchmarker = GPBenchmarker(self._make_config(num_runs=1))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotFittedError):
             benchmarker.predict(self.data)
 
     def test_predict_returns_boolean_array(self):

--- a/tests/test_gp_trainer.py
+++ b/tests/test_gp_trainer.py
@@ -2,6 +2,7 @@ import random
 import unittest
 
 import numpy as np
+from sklearn.exceptions import NotFittedError
 
 from hgp_lib.configs import BooleanGPConfig, TrainerConfig
 from hgp_lib.crossover import CrossoverExecutor, CrossoverExecutorFactory
@@ -308,7 +309,7 @@ class TestGPTrainer(unittest.TestCase):
     def test_predict_before_fit_raises(self):
         config = self._make_trainer_config(num_epochs=5)
         trainer = GPTrainer(config)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NotFittedError):
             trainer.predict(self.train_data)
 
     def test_predict_returns_boolean_array(self):

--- a/tests/test_preprocessing_utils.py
+++ b/tests/test_preprocessing_utils.py
@@ -104,7 +104,7 @@ class TestLoadData(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
             path = self._write_csv(df, tmpdir)
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(KeyError):
                 load_data(path)
 
     # ------------------------------------------------------------------ #


### PR DESCRIPTION
* Every "used before fit" path now raises `sklearn.exceptions.NotFittedError`
* Added `SchemaMismatchError` in `preprocessing/errors.py` for transform-time data that does not match the fitted schema
* `load_data` raises `KeyError` for an unknown target column.
* Updated tests and docs
